### PR TITLE
Adding missing `source-map` and `private` to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   "dependencies": {
     "ast-types": "git+https://github.com/jlongster/ast-types.git",
     "babylon": "git+https://github.com/jlongster/babylon.git#published",
+    "flow-parser": "^0.37.0",
     "minimist": "^1.2.0",
+    "private": "^0.1.6",
     "recast": "^0.11.18",
-    "flow-parser": "^0.37.0"
+    "source-map": "^0.5.6"
   },
   "devDependencies": {
     "jest": "^18.0.0"


### PR DESCRIPTION
Installed via npm (not yarn). Also stuck on npm 2 at work.  In ran `npm install -g prettier`. Install worked fine.

Then I went to run:
```
prettier -h
```

And found that 2 packages were missing until I installed them: `source-map` and `private`