### PR TITLE
Print Flow types with no name (fixes #38)

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1329,7 +1329,7 @@ function genericPrintNoParens(path, options, print) {
     return concat([
       path.call(print, "name"),
       n.optional ? "?" : "",
-      ": ",
+      n.name ? ": " : "",
       path.call(print, "typeAnnotation")
     ]);
   case "GenericTypeAnnotation":
@@ -1399,7 +1399,7 @@ function genericPrintNoParens(path, options, print) {
       variance,
       "[",
       path.call(print, "id"),
-      ": ",
+      n.id ? ": " : "",
       path.call(print, "key"),
       "]: ",
       path.call(print, "value")

--- a/tests/prettier/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/prettier/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,9 @@
+exports[`test optional-type-name.js 1`] = `
+"type Foo = (any) => string
+
+type Bar = { [string]: number }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type Foo = (any) => string;
+
+type Bar = { [string]: number };"
+`;

--- a/tests/prettier/jsfmt.spec.js
+++ b/tests/prettier/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/prettier/optional-type-name.js
+++ b/tests/prettier/optional-type-name.js
@@ -1,0 +1,3 @@
+type Foo = (any) => string
+
+type Bar = { [string]: number }


### PR DESCRIPTION
Fixes #38.

The `name` on `FunctionTypeParam`, and the `id` on `ObjectTypeIndexer`, can be skipped as of Flow 34.

I wasn't exactly sure where to put the tests, I added them into `abnormal`? Let me know if there's a better place for them.