### PR TITLE
Enforce trailing commas by default

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -9,7 +9,7 @@ var defaults = {
   singleQuote: false,
 
   // Controls the printing of trailing commas wherever possible
-  trailingComma: false,
+  trailingComma: true,
 
   // Controls the printing of spaces inside array and objects
   bracketSpacing: true


### PR DESCRIPTION
Enforcing trailing commas by default leads to better diff'ing. A tool like this should aim to make dev lives easier, enforcing trailing commas does that.

https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8#.sapaz7y3e