### PR TITLE
Do not fatal when formatting throws

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -39,14 +39,21 @@ filenames.forEach(filename => {
       return;
     }
 
-    const output = jscodefmt.format(input, {
-      printWidth: argv["print-width"],
-      tabWidth: argv["tab-width"],
-      bracketSpacing: argv["bracket-spacing"],
-      useFlowParser: argv["flow-parser"],
-      singleQuote: argv["single-quote"],
-      trailingComma: argv["trailing-comma"]
-    });
+    let output;
+    try {
+      output = jscodefmt.format(input, {
+        printWidth: argv["print-width"],
+        tabWidth: argv["tab-width"],
+        bracketSpacing: argv["bracket-spacing"],
+        useFlowParser: argv["flow-parser"],
+        singleQuote: argv["single-quote"],
+        trailingComma: argv["trailing-comma"]
+      });
+    } catch (e) {
+      process.exitCode = 2;
+      console.error(e);
+      return;
+    }
 
     if (write) {
       fs.writeFile(filename, output, "utf8", err => {


### PR DESCRIPTION
When you are formatting an entire codebase and a single file throw, it shouldn't stop the entire process.

Example with #84 added:
<img width="611" alt="screen shot 2017-01-10 at 10 08 06 pm" src="https://cloud.githubusercontent.com/assets/197597/21837562/beedfb34-d781-11e6-9e9d-e0b80ed00077.png">

