### PR TITLE
Fix #79: omit unnecessary quotes in property names

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "ast-types": "git+https://github.com/jlongster/ast-types.git",
     "babylon": "^6.15.0",
+    "esutils": "^2.0.2",
     "flow-parser": "^0.37.0",
     "minimist": "^1.2.0",
     "private": "^0.1.6",

--- a/src/printer.js
+++ b/src/printer.js
@@ -25,6 +25,7 @@ var isString = types.builtInTypes.string;
 var isObject = types.builtInTypes.object;
 var FastPath = require("./fast-path");
 var util = require("./util");
+var isIdentifierName = require("esutils").keyword.isIdentifierNameES6;
 
 function PrintResult(code, sourceMap) {
   assert.ok(this instanceof PrintResult);
@@ -641,13 +642,14 @@ function genericPrintNoParens(path, options, print) {
       return printMethod(path, options, print);
     }
 
-    if (n.computed) {
-      parts.push("[", path.call(print, "key"), "]");
+    if (n.shorthand) {
+      parts.push(path.call(print, "value"));
     } else {
-      parts.push(path.call(print, n.shorthand ? "value" : "key"));
-    }
-
-    if (!n.shorthand) {
+      if (n.computed) {
+        parts.push("[", path.call(print, "key"), "]");
+      } else {
+        parts.push(printPropertyKey(path, print));
+      }
       parts.push(": ", path.call(print, "value"));
     }
 
@@ -1155,15 +1157,18 @@ function genericPrintNoParens(path, options, print) {
     if (n.static)
       parts.push("static ");
 
-    var key = path.call(print, "key");
+    var key;
 
     if (n.computed) {
-      key = concat([ "[", key, "]" ]);
-    } else if (n.variance === "plus") {
-      key = concat([ "+", key ]);
-    } else if (n.variance === "minus") {
-      key = concat([ "-", key ]);
-    }
+      key = concat([ "[", path.call(print, "key"), "]" ]);
+    } else {
+      key = printPropertyKey(path, print);
+      if (n.variance === "plus") {
+        key = concat([ "+", key ]);
+      } else if (n.variance === "minus") {
+        key = concat([ "-", key ]);
+      }
+    } 
 
     parts.push(key);
 
@@ -1608,6 +1613,21 @@ function printStatementSequence(path, options, print) {
   return join(hardline, printed);
 }
 
+function printPropertyKey(path, print) {
+  var node = path.getNode().key;
+  if (node.type === "StringLiteral") {
+    if (isIdentifierName(node.value)) { // 'a' -> a
+      return node.value;
+    }
+    let val = parseFloat(node.value);
+    let strVal = fromString(val);
+    if (val >= 0 && strVal === node.value) { // '0' -> 0
+      return strVal;
+    }
+  }
+  return path.call(print, "key");
+}
+
 function printMethod(path, options, print) {
   var node = path.getNode();
   var kind = node.kind;
@@ -1633,7 +1653,7 @@ function printMethod(path, options, print) {
     parts.push(kind, " ");
   }
 
-  var key = path.call(print, "key");
+  var key = printPropertyKey(path, print);
 
   if (node.computed) {
     key = concat([ "[", key, "]" ]);
@@ -1773,7 +1793,7 @@ function printObjectMethod(path, options, print) {
     return printMethod(path, options, print);
   }
 
-  var key = path.call(print, "key");
+  var key = printPropertyKey(path, print);
 
   if (objMethod.computed) {
     parts.push("[", key, "]");

--- a/src/printer.js
+++ b/src/printer.js
@@ -1615,15 +1615,9 @@ function printStatementSequence(path, options, print) {
 
 function printPropertyKey(path, print) {
   var node = path.getNode().key;
-  if (node.type === "StringLiteral") {
-    if (isIdentifierName(node.value)) { // 'a' -> a
-      return node.value;
-    }
-    let val = parseFloat(node.value);
-    let strVal = fromString(val);
-    if (val >= 0 && strVal === node.value) { // '0' -> 0
-      return strVal;
-    }
+  if (node.type === "StringLiteral" && isIdentifierName(node.value)) {
+    // 'a' -> a
+    return node.value;
   }
   return path.call(print, "key");
 }


### PR DESCRIPTION
This omits quotes for property names which don't need them, fixing #79. It doesn't touch property names in flow type annotations, since I'm not sure which quotes are semantic there.

There's currently no tests, and no effect on the snapshots. As an example of its effect, currently the below passes through prettier without change:

```js
function f({ "a": b = c }) {}
({ "0": null });
class A {
  ["d"];
  "e";
  "f"() {}
  get "g"() {}
  +"0";
}
```

~~With this PR, it becomes~~
```js
function f({ a: b = c }) {}
({ 0: null });
class A {
  ["d"];
  e;
  f() {}
  get g() {}
  +0;
}
```

Please take an especially careful look `printPropertyKey`, since I'm not entirely sure how it ought to be implemented.

Edit: per review, updated to not apply to numbers. Now it outputs

```js
function f({ a: b = c }) {}
({ "0": null });
class A {
  ["d"];
  e;
  f() {}
  get g() {}
  +"0";
}
```