### PR TITLE
Add missing comma in API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ prettier.format(source, {
   printWidth: 80,
 
   // Number of spaces it should use per tab
-  tabWidth: 2
+  tabWidth: 2,
 
   // Use the flow parser instead of babylon
   useFlowParser: false,


### PR DESCRIPTION
I got an error the first time I tried to use the API, because I copied-and-pasted the example, and there is a missing comma in the API example.

This PR could help save some time for the users. 😄 