### PR TITLE
Break long `exports` into multiple lines.

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1832,9 +1832,25 @@ function printExportDeclaration(path, options, print) {
     } else {
       parts.push(
         decl.exportKind === "type" ? "type " : "",
-        shouldPrintSpaces ? "{ " : "{",
-        join(", ", path.map(print, "specifiers")),
-        shouldPrintSpaces ? " }" : "}"
+        conditionalGroup([
+          concat([
+            shouldPrintSpaces ? "{ " : "{",
+            join(", ", path.map(print, "specifiers")),
+            shouldPrintSpaces ? " }" : "}"
+          ]),
+          concat([
+            "{",
+            indent(
+              options.tabWidth,
+              concat([
+                hardline,
+                join(concat([",", hardline]), path.map(print, "specifiers"))
+              ])
+            ),
+            hardline,
+            "}"
+          ])
+        ])
       );
     }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -443,7 +443,7 @@ function genericPrintNoParens(path, options, print) {
       parts.push(" as ", path.call(print, "exported"));
     }
 
-    parts.push(" from ", path.call(print, "source"));
+    parts.push(" from ", path.call(print, "source"), ";");
 
     return concat(parts);
   case "ExportNamespaceSpecifier":
@@ -1819,6 +1819,10 @@ function printExportDeclaration(path, options, print) {
 
   if (decl.declaration) {
     parts.push(path.call(print, "declaration"));
+
+    if (decl.type === "ExportDefaultDeclaration" && decl.declaration.type == "Identifier") {
+      parts.push(";");
+    }
   } else if (decl.specifiers && decl.specifiers.length > 0) {
     if (
       decl.specifiers.length === 1 &&
@@ -1837,6 +1841,8 @@ function printExportDeclaration(path, options, print) {
     if (decl.source) {
       parts.push(" from ", path.call(print, "source"));
     }
+
+    parts.push(';');
   }
 
   return concat(parts);

--- a/tests/declare_export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/declare_export/__snapshots__/jsfmt.spec.js.snap
@@ -335,7 +335,10 @@ declare export {
  * @flow
  */
 
-declare export { numberValue1, numberValue2 as numberValue2_renamed } from \"ES6_ExportFrom_Source1\";"
+declare export {
+  numberValue1,
+  numberValue2 as numberValue2_renamed
+} from \"ES6_ExportFrom_Source1\";"
 `;
 
 exports[`test ES6_ExportFrom_Intermediary2.js 1`] = `
@@ -354,7 +357,10 @@ declare export {
  * @flow
  */
 
-declare export { numberValue1, numberValue2 as numberValue2_renamed2 } from \"ES6_ExportFrom_Source2\";"
+declare export {
+  numberValue1,
+  numberValue2 as numberValue2_renamed2
+} from \"ES6_ExportFrom_Source2\";"
 `;
 
 exports[`test ES6_ExportFrom_Source1.js 1`] = `

--- a/tests/declare_export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/declare_export/__snapshots__/jsfmt.spec.js.snap
@@ -178,7 +178,7 @@ declare export default class FooImpl { givesANum(): number }
 // Regression test for https://github.com/facebook/flow/issues/511
 //
 // Default-exported class should also be available in local scope
-declare export { FooImpl as Foo }
+declare export { FooImpl as Foo };
 declare export function getAFoo(): FooImpl;"
 `;
 
@@ -335,7 +335,7 @@ declare export {
  * @flow
  */
 
-declare export { numberValue1, numberValue2 as numberValue2_renamed } from \"ES6_ExportFrom_Source1\""
+declare export { numberValue1, numberValue2 as numberValue2_renamed } from \"ES6_ExportFrom_Source1\";"
 `;
 
 exports[`test ES6_ExportFrom_Intermediary2.js 1`] = `
@@ -354,7 +354,7 @@ declare export {
  * @flow
  */
 
-declare export { numberValue1, numberValue2 as numberValue2_renamed2 } from \"ES6_ExportFrom_Source2\""
+declare export { numberValue1, numberValue2 as numberValue2_renamed2 } from \"ES6_ExportFrom_Source2\";"
 `;
 
 exports[`test ES6_ExportFrom_Source1.js 1`] = `
@@ -427,10 +427,10 @@ var specifierNumber3 = 3;
 var groupedSpecifierNumber1 = 1;
 var groupedSpecifierNumber2 = 2;
 
-declare export { specifierNumber1 }
-declare export { specifierNumber2 as specifierNumber2Renamed }
-declare export { specifierNumber3 }
-declare export { groupedSpecifierNumber1, groupedSpecifierNumber2 }
+declare export { specifierNumber1 };
+declare export { specifierNumber2 as specifierNumber2Renamed };
+declare export { specifierNumber3 };
+declare export { groupedSpecifierNumber1, groupedSpecifierNumber2 };
 
 declare export function givesANumber(): number;
 declare export class NumberGenerator { givesANumber(): number }
@@ -470,9 +470,9 @@ var specifierNumber5 = 2;
 var groupedSpecifierNumber3 = 1;
 var groupedSpecifierNumber4 = 2;
 
-declare export { specifierNumber4 }
-declare export { specifierNumber5 as specifierNumber5Renamed }
-declare export { groupedSpecifierNumber3, groupedSpecifierNumber4 }
+declare export { specifierNumber4 };
+declare export { specifierNumber5 as specifierNumber5Renamed };
+declare export { groupedSpecifierNumber3, groupedSpecifierNumber4 };
 
 declare export function givesANumber2(): number;
 declare export class NumberGenerator2 { givesANumber(): number }

--- a/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -330,7 +330,7 @@ export * from \"ES6_ExportAllFrom_Source1\";
  * @flow
  */
 
-export * from \"ES6_ExportAllFrom_Source1\""
+export * from \"ES6_ExportAllFrom_Source1\";"
 `;
 
 exports[`test ES6_ExportAllFrom_Intermediary2.js 1`] = `
@@ -346,7 +346,7 @@ export * from \"ES6_ExportAllFrom_Source2\";
  * @flow
  */
 
-export * from \"ES6_ExportAllFrom_Source2\""
+export * from \"ES6_ExportAllFrom_Source2\";"
 `;
 
 exports[`test ES6_ExportAllFrom_Source1.js 1`] = `
@@ -389,8 +389,8 @@ export * from \"./ES6_ExportAllFrom_Source2\";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // @flow
 
-export * from \"./ES6_ExportAllFrom_Source1\"
-export * from \"./ES6_ExportAllFrom_Source2\""
+export * from \"./ES6_ExportAllFrom_Source1\";
+export * from \"./ES6_ExportAllFrom_Source2\";"
 `;
 
 exports[`test ES6_ExportFrom_Intermediary1.js 1`] = `
@@ -409,7 +409,7 @@ export {
  * @flow
  */
 
-export { numberValue1, numberValue2 as numberValue2_renamed } from \"ES6_ExportFrom_Source1\""
+export { numberValue1, numberValue2 as numberValue2_renamed } from \"ES6_ExportFrom_Source1\";"
 `;
 
 exports[`test ES6_ExportFrom_Intermediary2.js 1`] = `
@@ -428,7 +428,7 @@ export {
  * @flow
  */
 
-export { numberValue1, numberValue2 as numberValue2_renamed2 } from \"ES6_ExportFrom_Source2\""
+export { numberValue1, numberValue2 as numberValue2_renamed2 } from \"ES6_ExportFrom_Source2\";"
 `;
 
 exports[`test ES6_ExportFrom_Source1.js 1`] = `
@@ -498,10 +498,10 @@ var specifierNumber3 = 3;
 var groupedSpecifierNumber1 = 1;
 var groupedSpecifierNumber2 = 2;
 
-export { specifierNumber1 }
-export { specifierNumber2 as specifierNumber2Renamed }
-export { specifierNumber3 }
-export { groupedSpecifierNumber1, groupedSpecifierNumber2 }
+export { specifierNumber1 };
+export { specifierNumber2 as specifierNumber2Renamed };
+export { specifierNumber3 };
+export { groupedSpecifierNumber1, groupedSpecifierNumber2 };
 
 export function givesANumber(): number {
   return 42;
@@ -550,9 +550,9 @@ var specifierNumber5 = 2;
 var groupedSpecifierNumber3 = 1;
 var groupedSpecifierNumber4 = 2;
 
-export { specifierNumber4 }
-export { specifierNumber5 as specifierNumber5Renamed }
-export { groupedSpecifierNumber3, groupedSpecifierNumber4 }
+export { specifierNumber4 };
+export { specifierNumber5 as specifierNumber5Renamed };
+export { groupedSpecifierNumber3, groupedSpecifierNumber4 };
 
 export function givesANumber2(): number {
   return 42;

--- a/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -409,7 +409,10 @@ export {
  * @flow
  */
 
-export { numberValue1, numberValue2 as numberValue2_renamed } from \"ES6_ExportFrom_Source1\";"
+export {
+  numberValue1,
+  numberValue2 as numberValue2_renamed
+} from \"ES6_ExportFrom_Source1\";"
 `;
 
 exports[`test ES6_ExportFrom_Intermediary2.js 1`] = `
@@ -428,7 +431,10 @@ export {
  * @flow
  */
 
-export { numberValue1, numberValue2 as numberValue2_renamed2 } from \"ES6_ExportFrom_Source2\";"
+export {
+  numberValue1,
+  numberValue2 as numberValue2_renamed2
+} from \"ES6_ExportFrom_Source2\";"
 `;
 
 exports[`test ES6_ExportFrom_Source1.js 1`] = `

--- a/tests/es_declare_module/flow-typed/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/es_declare_module/flow-typed/__snapshots__/jsfmt.spec.js.snap
@@ -32,7 +32,7 @@ declare module \"CJS_Clobbered\" {
 }
 declare module \"ES\" {
   declare var strHidden: string;
-  declare export { strHidden as str3 }
+  declare export { strHidden as str3 };
   declare export var num3: number;
   declare export class C {}
   declare export type T = number;

--- a/tests/export_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/export_type/__snapshots__/jsfmt.spec.js.snap
@@ -101,12 +101,12 @@ var a: inlinedType1 = 42;
 var b: inlinedType1 = \"asdf\";
 // Error: string ~> number
 type standaloneType1 = number;
-export type { standaloneType1 }
+export type { standaloneType1 };
 
 type standaloneType2 = number;
-export { standaloneType2 }
+export { standaloneType2 };
 // Error: Missing \`type\` keyword
-export type { talias1, talias2 as talias3, IFoo2 } from \"./types_only2\"
+export type { talias1, talias2 as talias3, IFoo2 } from \"./types_only2\";
 
 export interface IFoo  { prop: number }
 "

--- a/tests/get-def/helpers/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/get-def/helpers/__snapshots__/jsfmt.spec.js.snap
@@ -9,7 +9,7 @@ export default x;
 
 const x = \"foo\";
 
-export default x"
+export default x;"
 `;
 
 exports[`test exports_named.js 1`] = `

--- a/tests/import_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import_type/__snapshots__/jsfmt.spec.js.snap
@@ -100,7 +100,7 @@ class ClassFoo1 {
   }
 }
 
-export default ClassFoo1
+export default ClassFoo1;
 export var foo1Inst = new ClassFoo1();"
 `;
 
@@ -155,7 +155,7 @@ class ClassFoo2 {
   }
 }
 
-export { ClassFoo2 }
+export { ClassFoo2 };
 export var foo2Inst = new ClassFoo2();"
 `;
 
@@ -345,5 +345,5 @@ export default ClassFoo6;
 
 class ClassFoo6 {}
 
-export default ClassFoo6"
+export default ClassFoo6;"
 `;

--- a/tests/import_typeof/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import_typeof/__snapshots__/jsfmt.spec.js.snap
@@ -87,7 +87,7 @@ class ClassFoo1 {
   }
 }
 
-export default ClassFoo1"
+export default ClassFoo1;"
 `;
 
 exports[`test ExportDefault_Number.js 1`] = `
@@ -150,7 +150,7 @@ class ClassFoo2 {
   }
 }
 
-export { ClassFoo2 }"
+export { ClassFoo2 };"
 `;
 
 exports[`test ExportNamed_Multi.js 1`] = `

--- a/tests/method_properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method_properties/__snapshots__/jsfmt.spec.js.snap
@@ -11,7 +11,7 @@ export {Foo};
 
 declare class Foo { bar?: () => string }
 
-export { Foo }"
+export { Foo };"
 `;
 
 exports[`test test.js 1`] = `

--- a/tests/prettier/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/prettier/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,15 @@
+exports[`test exports.js 1`] = `
+"export { value1, value2 as value2_renamed, value3, value4 as value4_renamed, value5 } from \"exports\";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export {
+  value1,
+  value2 as value2_renamed,
+  value3,
+  value4 as value4_renamed,
+  value5
+} from \"exports\";"
+`;
+
 exports[`test optional-type-name.js 1`] = `
 "type Foo = (any) => string
 

--- a/tests/prettier/exports.js
+++ b/tests/prettier/exports.js
@@ -1,0 +1,1 @@
+export { value1, value2 as value2_renamed, value3, value4 as value4_renamed, value5 } from "exports";


### PR DESCRIPTION
Ref #19.

Currently this PR (https://github.com/jlongster/prettier/pull/104/commits/244c810bd0ef7a41fb76624fb9352652fcfae32c) is based on #101, so you might have to merge that in first, otherwise there has to be a lot of rebasing :|