### PR TITLE
Remove trailing whitespace in broken arrow function expressions.

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -336,10 +336,10 @@ function genericPrintNoParens(path, options, print) {
       ])));
     }
 
-    parts.push(" => ");
+    parts.push(" =>");
 
     return conditionalGroup([
-      concat([ concat(parts), path.call(print, "body") ]),
+      concat([ concat(parts), " ", path.call(print, "body") ]),
       concat([ concat(parts),
                indent(options.tabWidth,
                       concat([line, path.call(print, "body")]))])

--- a/tests/predicates-parsing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/predicates-parsing/__snapshots__/jsfmt.spec.js.snap
@@ -113,7 +113,7 @@ var a1 = (x: mixed): %checks => x !== null;
 
 (x): %checks => x !== null;
 
-const insert_a_really_big_predicated_arrow_function_name_here = (x): %checks => 
+const insert_a_really_big_predicated_arrow_function_name_here = (x): %checks =>
   x !== null;
 
 declare var x;


### PR DESCRIPTION
Closes #103.