### PR TITLE
chore: link prettier package to its github project

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "bin": {
     "prettier": "./bin/prettier.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jlongster/prettier.git"
+  },
+  "author": "James Long",
+  "bugs": {
+    "url": "https://github.com/jlongster/prettier/issues"
+  },
   "main": "./index.js",
   "dependencies": {
     "ast-types": "git+https://github.com/jlongster/ast-types.git",


### PR DESCRIPTION
Add repository field to package.json, allowing the [package page](https://www.npmjs.com/package/prettier) at npm to link to [jlongster/prettier](https://github.com/jlongster/prettier).