### PR TITLE
docs: add globbing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,18 @@ Run prettier through the CLI with this script. Run it without any
 arguments to see the options.
 
 To format a file in-place, use `--write`. While this is in beta you
-should probably commit your code before doing that. In the future we
-will have better support for formatting whole projects.
+should probably commit your code before doing that.
 
 ```js
-prettier <opts> <filename>
+prettier [opts] [filename ...]
 ```
+
+For example, you could format your source using bash filename expansion:
+```bash
+prettier --write src/**/*.js bin/*.js
+```
+
+In the future we will have better support for formatting whole projects.
 
 ### API
 

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -17,7 +17,7 @@ const write = argv["write"];
 
 if (!filenames.length) {
   console.log(
-    "Usage: prettier [opts] [filename]\n\n" +
+    "Usage: prettier [opts] [filename ...]\n\n" +
     "Available options:\n" +
     "  --write              Edit the file in-place (beware!)\n" +
     "  --print-width <int>  Specify the length of line that the printer will wrap on. Defaults to 80.\n" +


### PR DESCRIPTION
Although prettier lacks options to filter project files to format by itself, most shells allow to submit multiple files with a filename expansion. Add an example using bash.