### PR TITLE
v0.0.5 -- Accidentally didn't push this commit out before others land…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "bin": {
     "prettier": "./bin/prettier.js"
   },


### PR DESCRIPTION
…ed; 0.0.5 is actually based on commit faed09ceea32fcdd58b525aa09b880afb9fa55b7

I accidentally published 0.0.5 without pushing the 0.0.5 commit to master which updated package.json. We landed a bunch of stuff since and I'm not going to rewrite history. This bumps the package.json.

I'm opening a PR to see if tests run. I'm not sure why they're failing in another PR.