### PR TITLE
Always use double quotes for JSX and properly escape

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1038,8 +1038,18 @@ function genericPrintNoParens(path, options, print) {
   case "JSXAttribute":
     parts.push(path.call(print, "name"));
 
-    if (n.value)
-      parts.push("=", path.call(print, "value"));
+    if (n.value) {
+      let res;
+      if (
+        (n.value.type === 'StringLiteral' || n.value.type === 'Literal') &&
+        typeof n.value.value === 'string'
+      ) {
+        res = '"' + util.htmlEscapeInsideDoubleQuote(n.value.value) + '"';
+      } else {
+        res = path.call(print, "value");
+      }
+      parts.push("=", res);
+    }
 
     return concat(parts);
   case "JSXIdentifier":

--- a/src/util.js
+++ b/src/util.js
@@ -311,3 +311,16 @@ function setLocEnd(node, index) {
   }
 }
 util.setLocEnd = setLocEnd;
+
+// http://stackoverflow.com/a/7124052
+function htmlEscapeInsideDoubleQuote(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;');
+// Intentionally disable the following since it is safe inside of a
+// double quote context
+//    .replace(/'/g, '&#39;')
+//    .replace(/</g, '&lt;')
+//    .replace(/>/g, '&gt;');
+}
+util.htmlEscapeInsideDoubleQuote = htmlEscapeInsideDoubleQuote;

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+exports[`test quotes.js 1`] = `
+"<div id=\"&quot;\'<>&amp;quot;\" />;
+<div id=\'\"&#39;<>&amp;quot;\' />;
+<div id={\'\\\'\"&quot;<>&amp;quot;\'} />;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div id=\"&quot;\'<>&amp;quot;\" />;
+<div id=\"&quot;\'<>&amp;quot;\" />;
+<div id={\"\'\\\"&quot;<>&amp;quot;\"} />;
+"
+`;

--- a/tests/jsx/jsfmt.spec.js
+++ b/tests/jsx/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/jsx/quotes.js
+++ b/tests/jsx/quotes.js
@@ -1,0 +1,3 @@
+<div id="&quot;'<>&amp;quot;" />;
+<div id='"&#39;<>&amp;quot;' />;
+<div id={'\'"&quot;<>&amp;quot;'} />;


### PR DESCRIPTION
JSX quotes are unfortunately using html escaping. Also, we should disregard the single-quote option for JSX quotes as we always want double quotes.