### PR TITLE
Support type annotation for rest argument on babylon parser

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -287,7 +287,11 @@ function genericPrintNoParens(path, options, print) {
   case "SpreadProperty":
   case "SpreadPropertyPattern":
   case "RestElement":
-    return concat([ "...", path.call(print, "argument") ]);
+    return concat([
+      "...",
+      path.call(print, "argument"),
+      path.call(print, "typeAnnotation")
+    ]);
   case "FunctionDeclaration":
   case "FunctionExpression":
     if (n.async)


### PR DESCRIPTION
This is working on the flow parser but not babylon

```js
echo 'function f(...flags: Array<boolean>) {}' | ./bin/prettier.js --stdin
function f(...flags: Array<boolean>) {}
```