### PR TITLE
Support method generics on babylon parser

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1811,6 +1811,10 @@ function printObjectMethod(path, options, print) {
     parts.push(key);
   }
 
+  if (objMethod.typeParameters) {
+    parts.push(path.call(print, "typeParameters"));
+  }
+
   parts.push(
     multilineGroup(concat([
       printFunctionParams(path, print, options),


### PR DESCRIPTION
This is working on the flow parser but not babylon

```js
echo 'class C<T> { submit<T>() { } }' | ./bin/prettier.js --stdin
class C<T> {
  submit<T>() {}
}
```