### PR TITLE
Numeric literal callees should keep parens

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -330,8 +330,7 @@ FPp.needsParens = function(assumeExpressionContext) {
         && parent.object === node;
 
     case "NumericLiteral":
-      return parent.type === "MemberExpression"
-        && isNumber.check(node.value);
+      return parent.type === "MemberExpression";
 
     case "AssignmentExpression":
     case "ConditionalExpression":

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -329,6 +329,10 @@ FPp.needsParens = function(assumeExpressionContext) {
         && name === "object"
         && parent.object === node;
 
+    case "NumericLiteral":
+      return parent.type === "MemberExpression"
+        && isNumber.check(node.value);
+
     case "AssignmentExpression":
     case "ConditionalExpression":
       switch (parent.type) {

--- a/tests/literal/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/literal/__snapshots__/jsfmt.spec.js.snap
@@ -84,6 +84,11 @@ function test4(flip_times: number): number {
   }
   return x;
 }
+
+// parentheses around numeric literal should be preserved
+function test5(): string {
+  return (100).toString();
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function test1(x: number): number {
   return -x;
@@ -107,6 +112,11 @@ function test4(flip_times: number): number {
     x = -x;
   }
   return x;
+}
+
+// parentheses around numeric literal should be preserved
+function test5(): string {
+  return (100).toString();
 }
 "
 `;

--- a/tests/literal/number.js
+++ b/tests/literal/number.js
@@ -21,3 +21,8 @@ function test4(flip_times: number): number {
   }
   return x;
 }
+
+// parentheses around numeric literal should be preserved
+function test5(): string {
+  return (100).toString();
+}


### PR DESCRIPTION
Here's a shot at fixing #96. It's pretty much a shot in the dark, but it was fun rooting around and getting to know the codebase a little.