### PR TITLE
Fix misprinting of computed properties in method chains.

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1968,7 +1968,7 @@ function printMemberChain(node, options, print) {
   // easily analyze.
   while (curr.type === "CallExpression" &&
     curr.callee.type === "MemberExpression") {
-    nodes.push({property: curr.callee.property, call: curr});
+    nodes.push({member: curr.callee, call: curr});
     curr = curr.callee.object;
   }
   nodes.reverse();
@@ -1995,7 +1995,7 @@ function printMemberChain(node, options, print) {
   if (hasMultipleLookups) {
     const currPrinted = print(FastPath.from(curr));
     const nodesPrinted = nodes.map(node => ({
-      property: print(FastPath.from(node.property)),
+      property: printMemberLookup(FastPath.from(node.member), print),
       args: printArgumentsList(FastPath.from(node.call), options, print)
     }));
     const fullyExpanded = concat([
@@ -2004,7 +2004,7 @@ function printMemberChain(node, options, print) {
         nodesPrinted.map(node => {
           return indent(
             options.tabWidth,
-            concat([ hardline, ".", node.property, node.args ])
+            concat([ hardline, node.property, node.args ])
           );
         })
       )
@@ -2026,7 +2026,7 @@ function printMemberChain(node, options, print) {
           currPrinted,
           concat(
             nodesPrinted.map(node => {
-              return concat([ ".", node.property, node.args ]);
+              return concat([ node.property, node.args ]);
             })
           )
         ]),

--- a/tests/prettier/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/prettier/__snapshots__/jsfmt.spec.js.snap
@@ -11,8 +11,6 @@ function fn() {
   \"use strict\";
 }
 "
-<<<<<<< bbe2524dab164d43febc1a8d549a76e26eb9d483
-=======
 `;
 
 exports[`test method-chain.js 1`] = `
@@ -25,7 +23,6 @@ method()
   [\"abc\"](x => x)
   [abc](x => x);
 "
->>>>>>> Fix misprinting of computed properties in method chains.
 `;
 
 exports[`test exports.js 1`] = `

--- a/tests/prettier/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/prettier/__snapshots__/jsfmt.spec.js.snap
@@ -11,6 +11,21 @@ function fn() {
   \"use strict\";
 }
 "
+<<<<<<< bbe2524dab164d43febc1a8d549a76e26eb9d483
+=======
+`;
+
+exports[`test method-chain.js 1`] = `
+"method().then(x => x)
+  [\"abc\"](x => x)
+  [abc](x => x);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+method()
+  .then(x => x)
+  [\"abc\"](x => x)
+  [abc](x => x);
+"
+>>>>>>> Fix misprinting of computed properties in method chains.
 `;
 
 exports[`test exports.js 1`] = `

--- a/tests/prettier/method-chain.js
+++ b/tests/prettier/method-chain.js
@@ -1,0 +1,3 @@
+method().then(x => x)
+  ["abc"](x => x)
+  [abc](x => x);


### PR DESCRIPTION
Supersedes https://github.com/jlongster/prettier/pull/108 with fixes to get it in.