### PR TITLE
Break multiline imports

### DIFF
--- a/tests/config_module_name_mapper_filetype/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/config_module_name_mapper_filetype/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,8 @@ import {doesntExist} from \"./SomeCSSFile.css\"; // Error: \`doestExist\` isn\'t
 // @flow
 
 import { className } from \"./SomeCSSFile.css\";
-import { doesntExist } from \"./SomeCSSFile.css\"; // Error: \`doestExist\` isn\'t an export
+import {
+  doesntExist
+} from \"./SomeCSSFile.css\"; // Error: \`doestExist\` isn\'t an export
 "
 `;

--- a/tests/declare_export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/declare_export/__snapshots__/jsfmt.spec.js.snap
@@ -1144,7 +1144,10 @@ import { specifierNumber } from \"ES6_Named1\";
 ///////////////////////////////////////////////////
 // == Multi \`export *\` should combine exports == //
 ///////////////////////////////////////////////////
-import { numberValue1 as numberValue8, numberValue2 as numberValue9 } from \"./ES6_ExportAllFromMulti\";
+import {
+  numberValue1 as numberValue8,
+  numberValue2 as numberValue9
+} from \"./ES6_ExportAllFromMulti\";
 
 var at1: number = numberValue8;
 var at2: string = numberValue8;

--- a/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -1275,7 +1275,10 @@ import { specifierNumber } from \"ES6_Named1\";
 ///////////////////////////////////////////////////
 // == Multi \`export *\` should combine exports == //
 ///////////////////////////////////////////////////
-import { numberValue1 as numberValue8, numberValue2 as numberValue9 } from \"./ES6_ExportAllFromMulti\";
+import {
+  numberValue1 as numberValue8,
+  numberValue2 as numberValue9
+} from \"./ES6_ExportAllFromMulti\";
 
 var at1: number = numberValue8;
 var at2: string = numberValue8;
@@ -1286,7 +1289,9 @@ var at4: string = numberValue9;
 /////////////////////////////////////////////////////////////
 // == Vanilla \`import\` cannot import a type-only export == //
 /////////////////////////////////////////////////////////////
-import { typeAlias } from \"./ExportType\"; // Error: Cannot vanilla-import a type alias!
+import {
+  typeAlias
+} from \"./ExportType\"; // Error: Cannot vanilla-import a type alias!
 "
 `;
 

--- a/tests/export_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/export_type/__snapshots__/jsfmt.spec.js.snap
@@ -51,7 +51,12 @@ var n: IFoo2 = {prop: 42}; // Error: {prop:number} ~> {prop:string}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
 
-import type { inlinedType1, standaloneType1, talias1, talias3 } from \"./types_only\";
+import type {
+  inlinedType1,
+  standaloneType1,
+  talias1,
+  talias3
+} from \"./types_only\";
 
 var a: inlinedType1 = 42;
 var b: inlinedType1 = \"asdf\";


### PR DESCRIPTION
Follows the same pattern as https://github.com/jlongster/prettier/pull/156/files

```js
echo "import { aaaaaaaa, bbbbbb, cccccc, dddddddd, eeeeeee, fffffffff, ggggggggg } from 'vjeux';" | ./bin/prettier.js --stdin
import {
  aaaaaaaa,
  bbbbbb,
  cccccc,
  dddddddd,
  eeeeeee,
  fffffffff,
  ggggggggg
} from "vjeux";
```