### PR TITLE
Add trailing comma support for multiline exports

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1876,6 +1876,7 @@ function printExportDeclaration(path, options, print) {
                    path.map(print, "specifiers"))
             ])
           ),
+          ifBreak(options.trailingComma ? "," : ""),
           options.bracketSpacing ? line : softline,
           "}"
         ]))


### PR DESCRIPTION
```js
echo "export { aaaaaaaa, bbbbbb, cccccc, dddddddd, eeeeeee, fffffffff, ggggggggg } from 'vjeux';" | ./bin/prettier.js --stdin --trailing-comma
export {
  aaaaaaaa,
  bbbbbb,
  cccccc,
  dddddddd,
  eeeeeee,
  fffffffff,
  ggggggggg,
} from "vjeux";
```