### PR TITLE
Remove leftover `arrowParensAlways` option

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -327,11 +327,11 @@ function genericPrintNoParens(path, options, print) {
     }
 
     if (
-      !options.arrowParensAlways && n.params.length === 1 && !n.rest &&
-        n.params[0].type === "Identifier" &&
-        !n.params[0].typeAnnotation &&
-        !n.predicate &&
-        !n.returnType
+      n.params.length === 1 && !n.rest &&
+      n.params[0].type === "Identifier" &&
+      !n.params[0].typeAnnotation &&
+      !n.predicate &&
+      !n.returnType
     ) {
       parts.push(path.call(print, "params", 0));
     } else {


### PR DESCRIPTION
This option was leftover from recast's printer. There's no need for an option for such a tiny syntax tweak.