### PR TITLE
Adds various prettier-browser changes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
 <script src="prettier.min.js"></script>
 
 <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
+<link rel="stylesheet" href="https://codemirror.net/theme/base16-dark.css">
 <script src="https://codemirror.net/lib/codemirror.js"></script>
 <script src="https://codemirror.net/mode/javascript/javascript.js"></script>
 <script src="https://codemirror.net/addon/display/rulers.js"></script>
@@ -55,9 +56,6 @@
     font-family: Menlo, monospace;
     font-size: 11.05px;
     line-height: 17.68px;
-  }
-  .editor.output .CodeMirror {
-    background-color: #fdfcfc;
   }
   .editor.input {
     margin-right: 5px;
@@ -149,11 +147,12 @@ var editorOptions = {
   autoCloseBrackets: true,
   matchBrackets: true,
   showCursorWhenSelecting: true,
+  theme: 'base16-dark',
   tabWidth: 2
 };
 var inputEditor = CodeMirror.fromTextArea(input, editorOptions);
 inputEditor.on('change', format);
-var outputEditor = CodeMirror.fromTextArea(output, {readOnly: true, lineNumbers: true });
+var outputEditor = CodeMirror.fromTextArea(output, {readOnly: true, lineNumbers: true, theme: 'base16-dark' });
 </script>
 
 <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,12 @@
 <script src="https://codemirror.net/lib/codemirror.js"></script>
 <script src="https://codemirror.net/mode/javascript/javascript.js"></script>
 <script src="https://codemirror.net/addon/display/rulers.js"></script>
+<script src="https://codemirror.net/addon/search/searchcursor.js"></script>
+<script src="https://codemirror.net/addon/edit/matchbrackets.js"></script>
+<script src="https://codemirror.net/addon/edit/closebrackets.js"></script>
+<script src="https://codemirror.net/addon/comment/comment.js"></script>
+<script src="https://codemirror.net/addon/wrap/hardwrap.js"></script>
+<script src="https://codemirror.net/keymap/sublime.js"></script>
 
 <style type="text/css">
   html, body {
@@ -112,7 +118,7 @@ function getOptions() {
   var options = {};
   OPTIONS.forEach(function(option) {
     var elem = document.getElementById(option);
-    options[option] = elem.type === 'number' ? +elem.value : elem.checked;
+    options[option] = elem.type === 'number' ? Number(elem.value) : elem.checked;
   });
   return options;
 }
@@ -137,9 +143,17 @@ function format() {
 
 document.getElementsByClassName('options')[0].onchange = format;
 
-var inputEditor = CodeMirror.fromTextArea(input);
+var editorOptions = {
+  lineNumbers: true,
+  keyMap: "sublime",
+  autoCloseBrackets: true,
+  matchBrackets: true,
+  showCursorWhenSelecting: true,
+  tabWidth: 2
+};
+var inputEditor = CodeMirror.fromTextArea(input, editorOptions);
 inputEditor.on('change', format);
-var outputEditor = CodeMirror.fromTextArea(output, {readOnly: true});
+var outputEditor = CodeMirror.fromTextArea(output, {readOnly: true, lineNumbers: true });
 </script>
 
 <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,6 +61,12 @@
     margin: 5px;
     margin-bottom: 0;
   }
+  .title a {
+    color: #e2e1e1;
+  }
+  .title a:hover {
+    color: #fdfcfc;
+  }
   label {
     margin-right: 5px;
   }
@@ -71,7 +77,7 @@
 
 <div class="container">
   <div class="options">
-    <label class="title">prettier v0.0.6</label>
+    <label class="title"><a href="https://github.com/jlongster/prettier">prettier v0.0.6</a></label>
     <label><input type="number" value="80" id="printWidth"></input> printWidth</label>
     <label><input type="number" value="2" id="tabWidth"></input> tabWidth</label>
     <label><input type="checkbox" id="singleQuote"></input> singleQuote</label>
@@ -142,6 +148,6 @@ try {
   setOptions(json.options);
   inputEditor.setValue(json.content);
 } catch (e) {
-  inputEditor.setValue(code.innerText.trim());  
+  inputEditor.setValue(code.innerText.trim());
 }
 </script>


### PR DESCRIPTION
Hi! Cool project and concept. Love auto formatting in languages like OCaml, so I'm excited for this.

I did some various changes (subjectively improvements) to prettier-browser that I think would make for more comfortable usage.

- Added link to project repo on header for easier navigation to code.
- Added Sublime key-mapping, which I think is one of the more popular/widely used mappings. Helps for better tabbing, duplicate lines, multi cursors etc.
- Added line numbers.
- Changed theme to be more soothing I think (highly subjective of course). See image below

I get that this is subjective and might not be what all want, but let me know if there is anything I should remove or of course close the PR if not interested.

Thanks again.

## Preview
![Preview](https://cloud.githubusercontent.com/assets/606374/21946583/58c4cd26-d9e1-11e6-9bf1-9d6beb042912.png)

