### PR TITLE
Do not advance for forward skipSpaces

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -262,7 +262,7 @@ util.newlineExistsAfter = function(text, index) {
 
 function skipSpaces(text, index, backwards) {
   const length = text.length;
-  let cursor = backwards ? index - 1 : index + 1;
+  let cursor = backwards ? index - 1 : index;
   // Look forward and see if there is a newline after/before this code
   // by scanning up/back to the next non-indentation character.
   while (cursor > 0 && cursor < length) {


### PR DESCRIPTION
For backward, we should go one step back, but for forward we are already in the correct place. It doesn't change any tests.