### PR TITLE
Fix windows line-endings

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -234,9 +234,20 @@ util.getLast = function(arr) {
   return null;
 };
 
+function skipNewLineForward(text, index) {
+  if (text.charAt(index) === "\n") {
+    return index + 1;
+  }
+  if (text.charAt(index) === "\r" && text.charAt(index + 1) === "\n") {
+    return index + 2;
+  }
+  // Note: this is incorrect, but makes the current tests pass for now.
+  return index + 1;
+}
+
 function _findNewline(text, index, backwards) {
   const length = text.length;
-  let cursor = backwards ? index - 1 : index + 1;
+  let cursor = backwards ? index - 1 : skipNewLineForward(text, index);
   // Look forward and see if there is a newline after/before this code
   // by scanning up/back to the next non-indentation character.
   while (cursor > 0 && cursor < length) {

--- a/tests/line-endings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/line-endings/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,14 @@
+exports[`test windows.js 1`] = `
+"const vscode = require(\"vscode\");
+const {getDir, getActiveFile, uint8arrayToString} = require(\"./utils\");
+
+let outChannel;
+let _commands;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const vscode = require(\"vscode\");
+const { getDir, getActiveFile, uint8arrayToString } = require(\"./utils\");
+
+let outChannel;
+let _commands;
+"
+`;

--- a/tests/line-endings/jsfmt.spec.js
+++ b/tests/line-endings/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/line-endings/windows.js
+++ b/tests/line-endings/windows.js
@@ -1,0 +1,5 @@
+const vscode = require("vscode");
+const {getDir, getActiveFile, uint8arrayToString} = require("./utils");
+
+let outChannel;
+let _commands;


### PR DESCRIPTION
The search for an empty line incorrectly does +1 which happens to be skipping a `\n`, but in case of windows line endings it skips the `\r` but sees a `\n` afterwards and incorrectly assumes that it is a empty line.

This doesn't change the behavior of doing +1 when there's not a line ending. Making it correct actually triggers a bunch of changes, where half of them are better and half of them regressions. So I'm going to send another pull request to fix that case.

Fixes #151