### PR TITLE
add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git+https://github.com/jlongster/prettier.git"
   },
   "author": "James Long",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/jlongster/prettier/issues"
   },


### PR DESCRIPTION
Because right now it doesn't show any license on [the npm page](https://www.npmjs.com/package/prettier).

Also, it's causing my [DependencyCI](https://dependencyci.com/github/kentcdodds/prettier-eslint/builds/5) build to fail 😅