### PR TITLE
Fix `[(0)]`

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -322,13 +322,11 @@ FPp.needsParens = function(assumeExpressionContext) {
       return parent.type === "UnionTypeAnnotation" ||
         parent.type === "IntersectionTypeAnnotation";
 
+    case "NumericLiteral":
     case "Literal":
       return parent.type === "MemberExpression" && isNumber.check(node.value) &&
         name === "object" &&
         parent.object === node;
-
-    case "NumericLiteral":
-      return parent.type === "MemberExpression";
 
     case "AssignmentExpression":
     case "ConditionalExpression":


### PR DESCRIPTION
Another issue where babylon and flow ast are different. In babylon, it is NumericLiteral but flow is Literal. All the tests are running on flow so were working correctly, but the default in the command line is to use babylon, so people report bugs with it.