### PR TITLE
Fix DeclareInterface

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1370,9 +1370,12 @@ function genericPrintNoParens(path, options, print) {
         path.call(print, "typeParameters")
       ]);
     case "DeclareInterface":
-      parts.push("declare ");
+    case "InterfaceDeclaration": {
+      const parent = path.getParentNode(1);
+      if (parent && parent.type === "DeclareModule") {
+        parts.push("declare ");
+      }
 
-    case "InterfaceDeclaration":
       parts.push(
         fromString("interface ", options),
         path.call(print, "id"),
@@ -1381,12 +1384,17 @@ function genericPrintNoParens(path, options, print) {
       );
 
       if (n["extends"].length > 0) {
-        parts.push("extends ", join(", ", path.map(print, "extends")));
+        parts.push(
+          "extends ",
+          join(", ", path.map(print, "extends")),
+          " "
+        );
       }
 
-      parts.push(" ", path.call(print, "body"));
+      parts.push(path.call(print, "body"));
 
       return concat(parts);
+    }
     case "ClassImplements":
     case "InterfaceExtends":
       return concat([

--- a/tests/async_iteration/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/async_iteration/__snapshots__/jsfmt.spec.js.snap
@@ -82,7 +82,7 @@ async function f() {
   }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface File  { readLine(): Promise<string>, close(): void, EOF: boolean }
+interface File { readLine(): Promise<string>, close(): void, EOF: boolean }
 
 declare function fileOpen(path: string): Promise<File>;
 

--- a/tests/callable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/callable/__snapshots__/jsfmt.spec.js.snap
@@ -50,7 +50,7 @@ foo(Boolean);
 var dict: { [k: string]: any } = {};
 dict();
 // error, callable signature not found
-interface ICall  { (x: string): void }
+interface ICall { (x: string): void }
 declare var icall: ICall;
 icall(0);
 // error, number ~> string

--- a/tests/constructor_annots/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/constructor_annots/__snapshots__/jsfmt.spec.js.snap
@@ -38,7 +38,7 @@ Foo.prototype = {
 exports.Foo = Foo;
 
 // so you want to type Foo, by declaring it as a class
-interface IFooPrototype  { m(): number }
+interface IFooPrototype { m(): number }
 interface IFoo extends IFooPrototype {
   /* error, should have declared x: number instead*/
   static (): void,

--- a/tests/export_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/export_type/__snapshots__/jsfmt.spec.js.snap
@@ -9,7 +9,7 @@ module.exports = {}
 /* @flow */
 
 export type talias4 = number;
-export interface IFoo  { prop: number }
+export interface IFoo { prop: number }
 
 module.exports = {};
 "
@@ -115,7 +115,7 @@ export { standaloneType2 };
 // Error: Missing \`type\` keyword
 export type { talias1, talias2 as talias3, IFoo2 } from \"./types_only2\";
 
-export interface IFoo  { prop: number }
+export interface IFoo { prop: number }
 
 "
 `;
@@ -131,7 +131,7 @@ export interface IFoo2 { prop: string };
 
 export type talias1 = number;
 export type talias2 = number;
-export interface IFoo2  { prop: string }
+export interface IFoo2 { prop: string }
 
 "
 `;

--- a/tests/interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/interface/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@ exports[`test import.js 1`] = `
 "interface I { x: number }
 export type J = I; // workaround for export interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface I  { x: number }
+interface I { x: number }
 export type J = I; // workaround for export interface
 "
 `;
@@ -21,9 +21,9 @@ interface Bad {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // @flow
 
-interface Ok  { [key: string]: string }
+interface Ok { [key: string]: string }
 
-interface Bad  {
+interface Bad {
   [k1: string]: string,
   [k2: number]: number /* error: not supported (yet)*/
 }
@@ -43,12 +43,15 @@ function testInterfaceName(o: I) {
   (o.name: string); // error, name is static
   (o.constructor.name: string); // ok
 }
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+declare module X {
+  declare interface Y { x: number; }
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class C { x: number }
 
 var x: string = new C().x;
 
-interface I  { x: number }
+interface I { x: number }
 
 var i = new I();
 // error
@@ -56,6 +59,10 @@ function testInterfaceName(o: I) {
   (o.name: string);
   // error, name is static
   (o.constructor.name: string); // ok
+}
+
+declare module X {
+  declare interface Y { x: number }
 }
 "
 `;
@@ -84,8 +91,8 @@ var e: E<number> = { x: \"\", y: \"\", z: \"\" }; // error: x and z should be nu
 (e.y: string);
 (e.z: string); // error: z is number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface I  { y: string }
-interface I_  { x: number }
+interface I { y: string }
+interface I_ { x: number }
 interface J extends I, I_ {}
 interface K extends J {}
 
@@ -99,8 +106,8 @@ declare class C { x: number }
 declare class D extends C, Other {}
 // error: multiple extends
 //declare class E implements I { } // parse error
-interface A<Y>  { y: Y }
-interface A_<X>  { x: X }
+interface A<Y> { y: Y }
+interface A_<X> { x: X }
 interface B<Z> extends A<string>, A_<Z> { z: Z }
 interface E<Z> extends B<Z> {}
 
@@ -126,7 +133,7 @@ type M = { y: string } & J & { z: boolean }
 function bar(m: M) { m.x; m.y; m.z; } // OK
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import type { J } from \"./import\";
-interface K  {}
+interface K {}
 interface L extends J, K { y: string }
 
 function foo(l: L) {
@@ -155,8 +162,8 @@ function foo(k: K) {
   (k.y: number); // error: y is string in I
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface I  { x: number, y: string }
-interface J  { y: number }
+interface I { x: number, y: string }
+interface J { y: number }
 interface K extends I, J { x: string }
 // error: x is number in I
 function foo(k: K) {
@@ -178,7 +185,7 @@ declare class C {
 
 new C().bar((x: string) => { }); // error, number ~/~> string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface I  { foo(x: number): void }
+interface I { foo(x: number): void }
 (function foo(x: number) {}: I);
 // error, property \`foo\` not found function
 declare class C { bar(i: I): void, bar(f: (x: number) => void): void }

--- a/tests/interface/interface.js
+++ b/tests/interface/interface.js
@@ -10,3 +10,7 @@ function testInterfaceName(o: I) {
   (o.name: string); // error, name is static
   (o.constructor.name: string); // ok
 }
+
+declare module X {
+  declare interface Y { x: number; }
+}

--- a/tests/lib_interfaces/declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/lib_interfaces/declarations/__snapshots__/jsfmt.spec.js.snap
@@ -7,7 +7,7 @@ interface CArrays<T> extends C<Array<T>> {
   bar(): C<any>;
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface C<T>  { foo(): CArrays<T>, bar(): C<any> }
+interface C<T> { foo(): CArrays<T>, bar(): C<any> }
 interface CArrays<T> extends C<Array<T>> { bar(): C<any> }
 "
 `;

--- a/tests/object-method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object-method/__snapshots__/jsfmt.spec.js.snap
@@ -17,7 +17,7 @@ import type { ObjectType } from \'./test\';
 
 function subtypeCheck(x: Interface): ObjectType { return x; }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface Interface  { m(): void }
+interface Interface { m(): void }
 import type { ObjectType } from \"./test\";
 
 function subtypeCheck(x: Interface): ObjectType {

--- a/tests/poly_overload/decls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/poly_overload/decls/__snapshots__/jsfmt.spec.js.snap
@@ -16,11 +16,11 @@ interface B<X> extends A<X> {
   foo<Y>(s: Other<X>, e: Nada<Y>): B<Y>;
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface Some<X>  {}
-interface Other<X>  { x: X }
-interface None<Y>  {}
-interface Nada<Y>  { y: Y }
-interface A<X>  {
+interface Some<X> {}
+interface Other<X> { x: X }
+interface None<Y> {}
+interface Nada<Y> { y: Y }
+interface A<X> {
   foo<Y>(s: Some<X>, e: None<Y>): A<Y>,
   foo<Y>(s: Some<X>, e: Nada<Y>): A<Y>,
   foo<Y>(s: Other<X>, e: None<Y>): A<Y>,

--- a/tests/structural_subtyping/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/structural_subtyping/__snapshots__/jsfmt.spec.js.snap
@@ -16,7 +16,7 @@ var lengthTest4: IHasLength = true; // bool doesn\'t have length
  * @flow
  */
 
-interface IHasLength  { length: number }
+interface IHasLength { length: number }
 
 var lengthTest1: IHasLength = [];
 var lengthTest2: IHasLength = \"hello\";
@@ -59,11 +59,11 @@ class ClassWithXString {
   x: string;
 }
 
-interface IHasXString  { x: string }
+interface IHasXString { x: string }
 
-interface IHasXNumber  { x: number }
+interface IHasXNumber { x: number }
 
-interface IHasYString  { y: string }
+interface IHasYString { y: string }
 
 var testInstance1: IHasXString = new ClassWithXString();
 var testInstance2: IHasXNumber = new ClassWithXString();
@@ -98,7 +98,7 @@ function propTest6(y: {[key: string]: number}) {
  * @flow
  */
 
-interface IHasXString  { x: string }
+interface IHasXString { x: string }
 
 var propTest1: IHasXString = { x: \"hello\" };
 var propTest2: IHasXString = { x: 123 };
@@ -133,7 +133,7 @@ var test3: HasOptional = { a: \"hello\", b: true }; // Error: boolean ~> number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
 
-interface HasOptional  { a: string, b?: number }
+interface HasOptional { a: string, b?: number }
 
 var test1: HasOptional = { a: \"hello\" };
 

--- a/tests/tagged-unions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/tagged-unions/__snapshots__/jsfmt.spec.js.snap
@@ -95,7 +95,7 @@ if (data.kind === \"user\") {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
 
-interface IDataBase  { id: string, name: string }
+interface IDataBase { id: string, name: string }
 
 interface IUserData extends IDataBase { kind: \"user\" }
 
@@ -141,7 +141,7 @@ if (data.kind === \"system\") {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
 
-interface IDataBase  { id: string, name: string }
+interface IDataBase { id: string, name: string }
 
 interface IUserData extends IDataBase { kind: \"user\" }
 

--- a/tests/this_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/this_type/__snapshots__/jsfmt.spec.js.snap
@@ -271,8 +271,8 @@ class C {
 function foo(c: C): I { return c; }
 function bar(c: C): J { return c; }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface I  { xs: Array<this> }
-interface J  { f(): J }
+interface I { xs: Array<this> }
+interface J { f(): J }
 class C {
   xs: Array<C>;
   f(): C {

--- a/tests/traits/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/traits/__snapshots__/jsfmt.spec.js.snap
@@ -47,7 +47,7 @@ exports[`test test2.js 1`] = `
 "declare interface I { }
 declare class C mixins I { }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface I  {}
+interface I {}
 declare class C {}
 "
 `;

--- a/tests/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
@@ -116,7 +116,7 @@ var o: MyObject = { x: 0 };
 type MySubobject = { y: number } & MyObject;
 // no error
 // arity error in interface extends
-interface MyInterface<T>  { x: T }
+interface MyInterface<T> { x: T }
 
 interface MySubinterface extends MyInterface {
   // no error

--- a/tests/type_args_strict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/type_args_strict/__snapshots__/jsfmt.spec.js.snap
@@ -114,7 +114,7 @@ var o: MyObject = { x: 0 };
 type MySubobject = { y: number } & MyObject;
 // error, missing argument list
 // arity error in interface extends
-interface MyInterface<T>  { x: T }
+interface MyInterface<T> { x: T }
 
 interface MySubinterface extends MyInterface {
   // error, missing argument list

--- a/tests/type_param_scope/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/type_param_scope/__snapshots__/jsfmt.spec.js.snap
@@ -128,7 +128,7 @@ class B<T> extends A<T> {
   }
 }
 
-interface C<T>  { m<T>(x: T): C<T> }
+interface C<T> { m<T>(x: T): C<T> }
 
 interface D<T> extends C<T> { m<T>(x: T): D<T> }
 

--- a/tests/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -1986,9 +1986,9 @@ function foo(): ImmutableMap<string, boolean> {
 // make sure tuples are type arguments (as used e.g. when viewing maps as
 // key/value iterables) work
 
-interface SomeIterator<T>  {}
+interface SomeIterator<T> {}
 
-interface SomeIterable<T>  { it(): SomeIterator<T> }
+interface SomeIterable<T> { it(): SomeIterator<T> }
 
 declare class SomeMap<K, V> {
   it(): SomeIterator<[K, V]>,


### PR DESCRIPTION
DeclareInterface (flow) and InterfaceDeclaration (babylon) are the same type so should behave the same way. I am using the same `declare` trick where I only add it if you are inside of a `declare module` block.