### PR TITLE
Make `declare type` consistent between babylon and flow

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1487,11 +1487,7 @@ function genericPrintNoParens(path, options, print) {
     case "DeclareTypeAlias":
     case "TypeAlias": {
       const parent = path.getParentNode(1);
-
-      if (
-        n.type === "DeclareTypeAlias" ||
-          parent && parent.type === "DeclareModule"
-      ) {
+      if (parent && parent.type === "DeclareModule") {
         parts.push("declare ");
       }
 


### PR DESCRIPTION
Flow doesn't have a different ast node for `type` and `declare type`. Let's always use the heuristic to be inside of a `declare module` for both ast. This way more snapshot tests are passing between the two parsers.

```js
echo 'declare type Dinosaur = "T-Rex" | "Apatosaurus";' | ./bin/prettier.js --stdin
type Dinosaur = "T-Rex" | "Apatosaurus";
```

```js
echo 'declare type Dinosaur = "T-Rex" | "Apatosaurus";' | ./bin/prettier.js --stdin --flow-parser
type Dinosaur = "T-Rex" | "Apatosaurus";
```

```js
echo 'declare module X {declare type Dinosaur = "T-Rex" | "Apatosaurus";}' | ./bin/prettier.js --stdin
declare module X {
  declare type Dinosaur = "T-Rex" | "Apatosaurus";
}
```

```js
echo 'declare module X {declare type Dinosaur = "T-Rex" | "Apatosaurus";}' | ./bin/prettier.js --stdin --flow-parser
declare module X {
  declare type Dinosaur = "T-Rex" | "Apatosaurus";
}
```
