### PR TITLE
Remove legacy Recast code and simplify API.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function format(text, opts) {
   opts.originalText = text;
 
   const printer = new Printer(opts);
-  return printer.printGenerically(ast).code;
+  return printer.print(ast);
 }
 
 function formatWithShebang(text, opts) {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "flow-parser": "^0.37.0",
     "get-stdin": "^5.0.1",
     "minimist": "^1.2.0",
-    "private": "^0.1.6",
-    "source-map": "^0.5.6"
+    "private": "^0.1.6"
   },
   "devDependencies": {
     "jest": "^18.0.0",

--- a/src/util.js
+++ b/src/util.js
@@ -3,9 +3,6 @@ var assert = require("assert");
 var types = require("ast-types");
 var getFieldValue = types.getFieldValue;
 var n = types.namedTypes;
-var sourceMap = require("source-map");
-var SourceMapConsumer = sourceMap.SourceMapConsumer;
-var SourceMapGenerator = sourceMap.SourceMapGenerator;
 var hasOwn = Object.prototype.hasOwnProperty;
 var util = exports;
 
@@ -32,55 +29,6 @@ function copyPos(pos) {
   return { line: pos.line, column: pos.column };
 }
 util.copyPos = copyPos;
-
-util.composeSourceMaps = function(formerMap, latterMap) {
-  if (formerMap) {
-    if (!latterMap) {
-      return formerMap;
-    }
-  } else {
-    return latterMap || null;
-  }
-
-  var smcFormer = new SourceMapConsumer(formerMap);
-  var smcLatter = new SourceMapConsumer(latterMap);
-  var smg = new SourceMapGenerator({
-    file: latterMap.file,
-    sourceRoot: latterMap.sourceRoot
-  });
-
-  var sourcesToContents = {};
-
-  smcLatter.eachMapping(function(mapping) {
-    var origPos = smcFormer.originalPositionFor({
-      line: mapping.originalLine,
-      column: mapping.originalColumn
-    });
-
-    var sourceName = origPos.source;
-    if (sourceName === null) {
-      return;
-    }
-
-    smg.addMapping({
-      source: sourceName,
-      original: copyPos(origPos),
-      generated: {
-        line: mapping.generatedLine,
-        column: mapping.generatedColumn
-      },
-      name: mapping.name
-    });
-
-    var sourceContent = smcFormer.sourceContentFor(sourceName);
-    if (sourceContent && !hasOwn.call(sourcesToContents, sourceName)) {
-      sourcesToContents[sourceName] = sourceContent;
-      smg.setSourceContent(sourceName, sourceContent);
-    }
-  });
-
-  return smg.toJSON();
-};
 
 function expandLoc(parentNode, childNode) {
   if (locStart(childNode) - locStart(parentNode) < 0) {


### PR DESCRIPTION
Source maps are no longer really relevant to this project, so I completely removed code dealing with them, as Prettier reprints everything anyway and it would be nearly impossible to remap from the old source to the new one. This also allows us to remove some legacy Recast options and API.