### PR TITLE
Fix directives printing for empty functions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -548,21 +548,24 @@ function genericPrintNoParens(path, options, print) {
         "body"
       );
 
+      const hasContent = getFirstString(naked);
+      const hasDirectives = n.directives && n.directives.length > 0;
+
       // If there are no contents, return a simple block
-      if (!getFirstString(naked)) {
+      if (!hasContent && !hasDirectives) {
         return "{}";
       }
 
       parts.push("{");
 
       // Babel 6
-      if (n.directives) {
+      if (hasDirectives) {
         path.each(
           function(childPath) {
             parts.push(
               indent(
                 options.tabWidth,
-                concat([ hardline, print(childPath), ";", hardline ])
+                concat([ hardline, print(childPath), ";" ])
               )
             );
           },
@@ -570,7 +573,11 @@ function genericPrintNoParens(path, options, print) {
         );
       }
 
-      parts.push(indent(options.tabWidth, concat([ hardline, naked ])));
+      if (hasContent) {
+        parts.push(
+          indent(options.tabWidth, concat([ hardline, naked ]))
+        );
+      }
 
       parts.push(hardline, "}");
 


### PR DESCRIPTION
We were not printing the directives if the body of the function was empty in babylon. Also, we were printing way too many \n

```js
echo "function fn() { 'use strict'; }" | ./bin/prettier.js --stdin
function fn() {
  "use strict";
}
```

```js
echo "function fn() { 'use strict'; }" | ./bin/prettier.js --stdin --flow-parser
function fn() {
  "use strict";
}
```