### PR TITLE
Fix key quotes omission for flow parser

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1644,7 +1644,11 @@ function printStatementSequence(path, options, print) {
 
 function printPropertyKey(path, print) {
   var node = path.getNode().key;
-  if (node.type === "StringLiteral" && isIdentifierName(node.value)) {
+  if (
+    (node.type === "StringLiteral" ||
+      node.type === "Literal" && typeof node.value === "string") &&
+    isIdentifierName(node.value)
+  ) {
     // 'a' -> a
     return node.value;
   }

--- a/tests/destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -555,7 +555,7 @@ exports[`test string_lit.js 1`] = `
 var { \"with-dash\": with_dash } = { \"with-dash\": \"motivating example\" };
 (with_dash: \"motivating example\"); // ok
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var { \"key\": val } = { key: \"val\" };
+var { key: val } = { key: \"val\" };
 (val: void);
 // error: string ~> void
 var { \"with-dash\": with_dash } = { \"with-dash\": \"motivating example\" };

--- a/tests/typeof/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typeof/__snapshots__/jsfmt.spec.js.snap
@@ -161,7 +161,7 @@ var f: typeof numberAlias = 42;
  * These provoke a specific error, not just the generic
  * \"type is incompatible\"
  */
-var Map = { \"A\": \"this is A\", \"B\": \"this is B\", \"C\": \"this is C\" };
+var Map = { A: \"this is A\", B: \"this is B\", C: \"this is C\" };
 var keys: $Keys<Map> = \"A\"; // Error: ineligible value used in type anno
 "
 `;


### PR DESCRIPTION
#90 fixed it using the Babylon AST nodes, this makes it work for Flow ones as well.

```js
echo 'var { "key": val } = 1;' | ./bin/prettier.js --stdin --flow-parser
var { key: val } = 1;
```