### PR TITLE
Preserve comments in empty blocks on babylon

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -548,21 +548,36 @@ function genericPrintNoParens(path, options, print) {
         "body"
       );
 
-      // If there are no contents, return a simple block
-      if (!getFirstString(naked)) {
+      const hasDirectives = n.directives && n.directives.length > 0;
+      const hasContent = getFirstString(naked);
+      const hasInnerComments = n.innerComments && n.innerComments.length > 0;
+
+      if (!hasInnerComments && !hasDirectives && !hasContent) {
         return "{}";
       }
 
       parts.push("{");
 
-      // Babel 6
-      if (n.directives) {
+      // Babylon 6
+      if (hasInnerComments) {
+        path.each(function(innerComment) {
+          parts.push(
+            indent(
+              options.tabWidth,
+              concat([ hardline, print(innerComment) ])
+            )
+          );
+        }, "innerComments");
+      }
+
+      // Babylon 6
+      if (hasDirectives) {
         path.each(
           function(childPath) {
             parts.push(
               indent(
                 options.tabWidth,
-                concat([ hardline, print(childPath), ";", hardline ])
+                concat([ hardline, print(childPath), ";" ])
               )
             );
           },
@@ -570,7 +585,9 @@ function genericPrintNoParens(path, options, print) {
         );
       }
 
-      parts.push(indent(options.tabWidth, concat([ hardline, naked ])));
+      if (hasContent) {
+        parts.push(indent(options.tabWidth, concat([ hardline, naked ])));
+      }
 
       parts.push(hardline, "}");
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,43 @@
+exports[`test blocks.js 1`] = `
+"if (1) { /* test */ } else if (1) { /* test */ /* test */ }
+if (1) {
+  // test
+} else if (1) { /* test */ /* test */ } else {
+  // test
+  /* test */
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+if (1) {}
+else if (1) {}
+if (1) {}
+else if (1) {}
+else {}
+"
+`;
+
+exports[`test blocks.js 2`] = `
+"if (1) { /* test */ } else if (1) { /* test */ /* test */ }
+if (1) {
+  // test
+} else if (1) { /* test */ /* test */ } else {
+  // test
+  /* test */
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+if (1) {
+  /* test */
+} else if (1) {
+  /* test */
+  /* test */
+}
+if (1) {
+  // test
+} else if (1) {
+  /* test */
+  /* test */
+} else {
+  // test
+  /* test */
+}
+"
+`;

--- a/tests/comments/blocks.js
+++ b/tests/comments/blocks.js
@@ -1,0 +1,7 @@
+if (1) { /* test */ } else if (1) { /* test */ /* test */ }
+if (1) {
+  // test
+} else if (1) { /* test */ /* test */ } else {
+  // test
+  /* test */
+}

--- a/tests/comments/jsfmt.spec.js
+++ b/tests/comments/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname);
+run_spec(__dirname, {useFlowParser: false});


### PR DESCRIPTION
They are written as `innerComments` when they are in empty blocks.

Fixes #87