### PR TITLE
Remove faulty location check on template literals that throws in Nuclide

### DIFF
--- a/tests/template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,32 @@
+exports[`test faulty-locations.js 1`] = `
+"var o = {
+  [\`key\`]: () => {
+    // Comment
+  }
+};
+
+var x = {
+  y: () => Relay.QL\`
+    query {
+      \${foo},
+      field,
+    }
+  \`
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var o = { [\`key\`]: () => {} };
+
+var x = {
+  y: () => Relay.QL\`
+    query {
+      \${foo},
+      field,
+    }
+  \`
+};
+"
+`;
+
 exports[`test template.js 1`] = `
 "/* @flow */
 

--- a/tests/template/faulty-locations.js
+++ b/tests/template/faulty-locations.js
@@ -1,0 +1,14 @@
+var o = {
+  [`key`]: () => {
+    // Comment
+  }
+};
+
+var x = {
+  y: () => Relay.QL`
+    query {
+      ${foo},
+      field,
+    }
+  `
+};


### PR DESCRIPTION
There's a handful of files inside of Nuclide that throw exceptions because an assertion is raised.

```
{ AssertionError: ']' === '`'
    at fixTemplateLiteral (/Users/vjeux/random/prettier/src/util.js:105:10)
    at Object.util.fixFaultyLocations (/Users/vjeux/random/prettier/src/util.js:45:5)
    at getSortedChildNodes (/Users/vjeux/random/prettier/src/comments.js:25:8)
    at getSortedChildNodes (/Users/vjeux/random/prettier/src/comments.js:61:5)
    at decorateComment (/Users/vjeux/random/prettier/src/comments.js:71:20)
    at decorateComment (/Users/vjeux/random/prettier/src/comments.js:85:7)
    at decorateComment (/Users/vjeux/random/prettier/src/comments.js:85:7)
    at decorateComment (/Users/vjeux/random/prettier/src/comments.js:85:7)
    at decorateComment (/Users/vjeux/random/prettier/src/comments.js:85:7)
    at /Users/vjeux/random/prettier/src/comments.js:129:5
```

When trying https://github.com/facebook/nuclide/blob/master/pkg/nuclide-task-runner/lib/main.js#L174

It throws in the fixTemplateLiteral method.

That method was added to fix https://github.com/benjamn/recast/issues/216 more than a year ago to fix the following code:

```js
var x = {
  y: () => Relay.QL`
    query {
      ${foo},
      field,
    }
  `
};
```

I've checked (and added a test) and it now parses and prints correctly without that method. So it should be safe to remove.