### PR TITLE
Add flow parser experimental options

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,11 @@ function format(text, opts) {
   let ast;
 
   if (opts.useFlowParser) {
-    ast = flowParser.parse(text);
+    ast = flowParser.parse(text, {
+      esproposal_class_instance_fields: true,
+      esproposal_class_static_fields: true,
+      esproposal_export_star_as: true,
+    });
     if (ast.errors.length > 0) {
       let msg = ast.errors[(0)].message + " on line " +
         ast.errors[(0)].loc.start.line;

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -76,7 +76,11 @@ function stripLocation(ast) {
 
 function parse(string) {
   const flowParser = require('flow-parser');
-  return stripLocation(flowParser.parse(string));
+  return stripLocation(flowParser.parse(string, {
+    esproposal_class_instance_fields: true,
+    esproposal_class_static_fields: true,
+    esproposal_export_star_as: true,
+  }));
 }
 
 function prettyprint(src, filename, options) {


### PR DESCRIPTION
The Nuclide codebase uses features that are still proposals which require a flag to be enabled. Babylon parses them fine without any flags.

Let's enable them by default as it doesn't cost much, you either are using those features and you don't want the parser to break, or you are not and you don't care.

After this and #218, none of the nuclide files are throwing exceptions anymore! (yay!)