### PR TITLE
Make sure empty for loops generate valid code

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -790,8 +790,8 @@ function genericPrintNoParens(path, options, print) {
       return concat([
         "with (",
         path.call(print, "object"),
-        ") ",
-        path.call(print, "body")
+        ")",
+        adjustClause(path.call(print, "body"), options)
       ]);
     case "IfStatement":
       const con = adjustClause(path.call(print, "consequent"), options);
@@ -2098,6 +2098,10 @@ function printJSXElement(path, options, print) {
 }
 
 function adjustClause(clause, options, forceSpace) {
+  if (clause === "") {
+    return ";";
+  }
+
   if (isCurlyBracket(clause) || forceSpace) {
     return concat([ " ", clause ]);
   }

--- a/tests/empty_statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/empty_statement/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,21 @@
+exports[`test body.js 1`] = `
+"with (a);
+if (1); else if (2); else;
+for (;;);
+while (1);
+for (var i in o);
+for (var i of o);
+do; while(1);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+with (a);
+if (1);
+else if (2);
+else;
+for (;;);
+while (1);
+for (var i in o);
+for (var i of o);
+do;
+while (1);
+"
+`;

--- a/tests/empty_statement/body.js
+++ b/tests/empty_statement/body.js
@@ -1,0 +1,7 @@
+with (a);
+if (1); else if (2); else;
+for (;;);
+while (1);
+for (var i in o);
+for (var i of o);
+do; while(1);

--- a/tests/empty_statement/jsfmt.spec.js
+++ b/tests/empty_statement/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
```js
for (;;);
function f() {}
```

The `;` was dropped meaning that the line right after was executed within the for loop which is not correct.

I tried to return `;` but it looks like

```js
for (;;)
  ;
```

which looks super weird so I ended up printing `{}` which looks like

```js
for (;;) {}
```

This fixes and issue found by #223