### PR TITLE
Print binary and logical expressions in a nicer format

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 var types = require("ast-types");
+var util = require("./util");
 var n = types.namedTypes;
 var Node = n.Node;
 var isArray = types.builtInTypes.array;
@@ -262,9 +263,9 @@ FPp.needsParens = function(assumeExpressionContext) {
         case "BinaryExpression":
         case "LogicalExpression":
           var po = parent.operator;
-          var pp = PRECEDENCE[po];
+          var pp = util.getPrecedence(po);
           var no = node.operator;
-          var np = PRECEDENCE[no];
+          var np = util.getPrecedence(no);
 
           if (pp > np) {
             return true;
@@ -423,24 +424,6 @@ function isUnaryLike(node) {
     node
   ) || n.SpreadElement && n.SpreadElement.check(node) || n.SpreadProperty && n.SpreadProperty.check(node);
 }
-
-var PRECEDENCE = {};
-[
-  [ "||" ],
-  [ "&&" ],
-  [ "|" ],
-  [ "^" ],
-  [ "&" ],
-  [ "==", "===", "!=", "!==" ],
-  [ "<", ">", "<=", ">=", "in", "instanceof" ],
-  [ ">>", "<<", ">>>" ],
-  [ "+", "-" ],
-  [ "*", "/", "%", "**" ]
-].forEach(function(tier, i) {
-  tier.forEach(function(op) {
-    PRECEDENCE[op] = i;
-  });
-});
 
 function containsCallExpression(node) {
   if (n.CallExpression.check(node)) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -180,7 +180,7 @@ function genericPrintNoParens(path, options, print) {
       );
     case "BinaryExpression":
     case "LogicalExpression": {
-      return group(printBinaryishExpressions(path, print, options));
+      return printBinaryishExpressions(path, print, options);
     }
     case "AssignmentPattern":
       return concat([
@@ -2298,11 +2298,11 @@ function printBinaryishExpressions(path, print, options) {
 
     const allowBreak = ["*", "/", "+", "-", "&&", "||"].indexOf(node.operator) !== -1;
     if(allowBreak) {
-      return concat([ left, indent(options.tabWidth,
-                                 concat([" ", node.operator, line, right ]))]);
+      return group(concat([ left, indent(options.tabWidth,
+                                         concat([" ", node.operator, line, right ]))]))
 
     }
-    return concat([ left, " ", node.operator, " ", right ]);
+    return group(concat([ left, " ", node.operator, " ", right ]));
   }
   else {
     // Our stopping case. Simply print the node normally.

--- a/src/util.js
+++ b/src/util.js
@@ -222,3 +222,25 @@ function htmlEscapeInsideDoubleQuote(str) {
   //    .replace(/>/g, '&gt;');
 }
 util.htmlEscapeInsideDoubleQuote = htmlEscapeInsideDoubleQuote;
+
+var PRECEDENCE = {};
+[
+  [ "||" ],
+  [ "&&" ],
+  [ "|" ],
+  [ "^" ],
+  [ "&" ],
+  [ "==", "===", "!=", "!==" ],
+  [ "<", ">", "<=", ">=", "in", "instanceof" ],
+  [ ">>", "<<", ">>>" ],
+  [ "+", "-" ],
+  [ "*", "/", "%", "**" ]
+].forEach(function(tier, i) {
+  tier.forEach(function(op) {
+    PRECEDENCE[op] = i;
+  });
+});
+
+util.getPrecedence = function(op) {
+  return PRECEDENCE[op];
+}

--- a/tests/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -87,12 +87,14 @@ type DuplexStreamOptions =
   };
 
 function hasObjectMode_bad(options: DuplexStreamOptions): boolean {
-  return options.objectMode || options.readableObjectMode ||
+  return options.objectMode ||
+    options.readableObjectMode ||
     options.writableObjectMode; // error, undefined ~> boolean
 }
 
 function hasObjectMode_ok(options: DuplexStreamOptions): boolean {
-  return !!(options.objectMode || options.readableObjectMode ||
+  return !!(options.objectMode ||
+    options.readableObjectMode ||
     options.writableObjectMode);
 }
 "

--- a/tests/logical/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/logical/__snapshots__/jsfmt.spec.js.snap
@@ -758,7 +758,7 @@ function logical7e(x: number): string {
  */
 function logical8a(): number {
   var x = false;
-  return (x || 0) && \"foo\";
+  return x || 0 && \"foo\";
 }
 
 /**
@@ -768,7 +768,7 @@ function logical8a(): number {
  */
 function logical8b(): string {
   var x = false;
-  return (x || 1) && \"foo\";
+  return x || 1 && \"foo\";
 }
 
 /**
@@ -778,7 +778,7 @@ function logical8b(): string {
  */
 function logical8c(): string {
   var x = true;
-  return (x || 1) && \"foo\";
+  return x || 1 && \"foo\";
 }
 
 /**
@@ -939,7 +939,7 @@ function logical15a(x: number): number {
  * || in an addition
  */
 function logical15b(x: number): number {
-  return (x || 7) + 5;
+  return x || 7 + 5;
 }
 
 /**
@@ -953,7 +953,7 @@ function logical15c(x: number): number {
  * && in an addition
  */
 function logical15d(x: number): number {
-  return (x && 7) + 5;
+  return x && 7 + 5;
 }
 
 /**
@@ -967,7 +967,7 @@ function logical16a(x: number): boolean {
  * || in a comparison
  */
 function logical16b(x: number): boolean {
-  return (x || 7) < 5;
+  return x || 7 < 5;
 }
 
 /**
@@ -981,7 +981,7 @@ function logical16c(x: number): boolean {
  * && in a comparison
  */
 function logical16d(x: number): boolean {
-  return (x && 7) < 5;
+  return x && 7 < 5;
 }
 
 /**
@@ -995,7 +995,7 @@ function logical17a(x: number): boolean {
  * || in an equality
  */
 function logical17b(x: number): boolean {
-  return (x || 7) == 5;
+  return x || 7 == 5;
 }
 
 /**
@@ -1009,7 +1009,7 @@ function logical17c(x: number): boolean {
  * && in an equality
  */
 function logical17d(x: number): boolean {
-  return (x && 7) == 5;
+  return x && 7 == 5;
 }
 
 /**

--- a/tests/logical/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/logical/__snapshots__/jsfmt.spec.js.snap
@@ -758,7 +758,7 @@ function logical7e(x: number): string {
  */
 function logical8a(): number {
   var x = false;
-  return x || 0 && \"foo\";
+  return (x || 0) && \"foo\";
 }
 
 /**
@@ -768,7 +768,7 @@ function logical8a(): number {
  */
 function logical8b(): string {
   var x = false;
-  return x || 1 && \"foo\";
+  return (x || 1) && \"foo\";
 }
 
 /**
@@ -778,7 +778,7 @@ function logical8b(): string {
  */
 function logical8c(): string {
   var x = true;
-  return x || 1 && \"foo\";
+  return (x || 1) && \"foo\";
 }
 
 /**
@@ -939,7 +939,7 @@ function logical15a(x: number): number {
  * || in an addition
  */
 function logical15b(x: number): number {
-  return x || 7 + 5;
+  return (x || 7) + 5;
 }
 
 /**
@@ -953,7 +953,7 @@ function logical15c(x: number): number {
  * && in an addition
  */
 function logical15d(x: number): number {
-  return x && 7 + 5;
+  return (x && 7) + 5;
 }
 
 /**
@@ -967,7 +967,7 @@ function logical16a(x: number): boolean {
  * || in a comparison
  */
 function logical16b(x: number): boolean {
-  return x || 7 < 5;
+  return (x || 7) < 5;
 }
 
 /**
@@ -981,7 +981,7 @@ function logical16c(x: number): boolean {
  * && in a comparison
  */
 function logical16d(x: number): boolean {
-  return x && 7 < 5;
+  return (x && 7) < 5;
 }
 
 /**
@@ -995,7 +995,7 @@ function logical17a(x: number): boolean {
  * || in an equality
  */
 function logical17b(x: number): boolean {
-  return x || 7 == 5;
+  return (x || 7) == 5;
 }
 
 /**
@@ -1009,7 +1009,7 @@ function logical17c(x: number): boolean {
  * && in an equality
  */
 function logical17d(x: number): boolean {
-  return x && 7 == 5;
+  return (x && 7) == 5;
 }
 
 /**

--- a/tests/prettier/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/prettier/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,65 @@
+exports[`test binary-expressions.js 1`] = `
+"// It should always break the highest precedence operators first, and
+// break them all at the same time.
+
+const x = longVariable + longVariable + longVariable;
+const x = longVariable + longVariable + longVariable + longVariable - longVariable + longVariable;
+const x = longVariable + longVariable * longVariable + longVariable - longVariable + longVariable;
+const x = longVariable + longVariable * longVariable * longVariable / longVariable + longVariable;
+
+const x = longVariable && longVariable && longVariable && longVariable && longVariable && longVariable;
+const x = longVariable && longVariable || longVariable && longVariable || longVariable && longVariable;
+
+const x = longVariable * longint && longVariable >> 0 && longVariable + longVariable;
+
+const x = longVariable > longint && longVariable === 0 + longVariable * longVariable;
+
+foo(obj.property * new Class() && obj instanceof Class && longVariable ? number + 5 : false);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// It should always break the highest precedence operators first, and
+// break them all at the same time.
+
+const x = longVariable + longVariable + longVariable;
+const x = longVariable +
+  longVariable +
+  longVariable +
+  longVariable -
+  longVariable +
+  longVariable;
+const x = longVariable +
+  longVariable * longVariable +
+  longVariable -
+  longVariable +
+  longVariable;
+const x = longVariable +
+  longVariable * longVariable * longVariable / longVariable +
+  longVariable;
+
+const x = longVariable &&
+  longVariable &&
+  longVariable &&
+  longVariable &&
+  longVariable &&
+  longVariable;
+const x = longVariable && longVariable ||
+  longVariable && longVariable ||
+  longVariable && longVariable;
+
+const x = longVariable * longint &&
+  longVariable >> 0 &&
+  longVariable + longVariable;
+
+const x = longVariable > longint &&
+  longVariable === 0 + longVariable * longVariable;
+
+foo(
+  obj.property * new Class() && obj instanceof Class && longVariable
+    ? number + 5
+    : false
+);
+"
+`;
+
 exports[`test directives.js 1`] = `
 "\"use strict\";
 

--- a/tests/prettier/binary-expressions.js
+++ b/tests/prettier/binary-expressions.js
@@ -1,0 +1,16 @@
+// It should always break the highest precedence operators first, and
+// break them all at the same time.
+
+const x = longVariable + longVariable + longVariable;
+const x = longVariable + longVariable + longVariable + longVariable - longVariable + longVariable;
+const x = longVariable + longVariable * longVariable + longVariable - longVariable + longVariable;
+const x = longVariable + longVariable * longVariable * longVariable / longVariable + longVariable;
+
+const x = longVariable && longVariable && longVariable && longVariable && longVariable && longVariable;
+const x = longVariable && longVariable || longVariable && longVariable || longVariable && longVariable;
+
+const x = longVariable * longint && longVariable >> 0 && longVariable + longVariable;
+
+const x = longVariable > longint && longVariable === 0 + longVariable * longVariable;
+
+foo(obj.property * new Class() && obj instanceof Class && longVariable ? number + 5 : false);


### PR DESCRIPTION
This is a complete rewrite of binary and logical expressions that, if anything, is at least a whole lot more consistent. There may be tweaks to actual output for certain patterns, but before it was somewhat arbitrary what was broken across lines.

Now, if an expression is broken up, it's all or nothing:

```js
var x = reallyLongArg() + reallyLongArg() * reallyLongArg() % reallyLongArg() + reallyLongArg() + reallyLongArg() + reallyLongArg();
```

Turns into:

```js
  var x = reallyLongArg() +
    reallyLongArg() *
    reallyLongArg() %
    reallyLongArg() +
    reallyLongArg() +
    reallyLongArg() +
    reallyLongArg();
```

The idea is that we shouldn't touch anything that you could write out by hand without adding parens. The AST makes this a little difficult, but I think the solution ended up elegant. I spent a lot of hours writing 50 lines of code, and it's mostly comments!

If there is an expression that has a difference precedence than the default, that becomes a new sub-group. For example:

```js
var z = 1 + 2 + 3 * (4 * 5 + 3) / (100000000000000000 * 328233872942374 + 3423942394239) + 2343242342342343 + 10000;
```

This turns into:

```
var z = 1 +
  2 +
  3 *
  (4 * 5 + 3) /
  (100000000000000000 * 328233872942374 + 3423942394239) +
  2343242342342343 +
  10000;
```

Notice how there are 2 expressions in there that aren't broken; this is because that have difference precedence and become sub-groups. I think this feels natural and looks good. Also parens are always properly kept.

[Here's a gist](https://gist.github.com/jlongster/dc68eef51952b0520287291072de1e85) with more examples. This was my test file.

I'm aware that there is a bug with removing parens where it shouldn't which you can see in the tests. I'll fix this tomorrow.