### PR TITLE
Fix space missing before `,` on export with bracket spacing off

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1857,7 +1857,7 @@ function printExportDeclaration(path, options, print) {
       } else {
         parts.push(
           decl.exportKind === "type" ? "type " : "",
-          group(
+          multilineGroup(
             concat([
               "{",
               indent(
@@ -1865,7 +1865,7 @@ function printExportDeclaration(path, options, print) {
                 concat([
                   options.bracketSpacing ? line : softline,
                   join(
-                    concat([ ",", options.bracketSpacing ? line : softline ]),
+                    concat([ ",", line ]),
                     path.map(print, "specifiers")
                   )
                 ])

--- a/tests/export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/export/__snapshots__/jsfmt.spec.js.snap
@@ -1,4 +1,67 @@
+exports[`test bracket.js 1`] = `
+"export {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+};
+export {fitsIn, oneLine};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+};
+export { fitsIn, oneLine };
+"
+`;
+
+exports[`test bracket.js 2`] = `
+"export {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+};
+export {fitsIn, oneLine};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+};
+export { fitsIn, oneLine };
+"
+`;
+
 exports[`test empty.js 1`] = `
+"export {};
+export {} from \".\";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export {};
+export {} from \".\";
+"
+`;
+
+exports[`test empty.js 2`] = `
 "export {};
 export {} from \".\";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/export/bracket.js
+++ b/tests/export/bracket.js
@@ -1,0 +1,11 @@
+export {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+};
+export {fitsIn, oneLine};

--- a/tests/export/jsfmt.spec.js
+++ b/tests/export/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname);
+run_spec(__dirname, {bracketsSpacing: false});


### PR DESCRIPTION
I copy and pasted the code for arrays which doesn't have this problem. Would be nice to come up with an abstraction for a list of stuff separated by commas. It happens a lot of time and right now it's duplicated everywhere.

Fixes #255