### PR TITLE
Fix space missing before `,` on import with bracket spacing off

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -454,7 +454,7 @@ function genericPrintNoParens(path, options, print) {
 
         if (grouped.length > 0) {
           parts.push(
-            group(
+            multilineGroup(
               concat([
                 "{",
                 indent(
@@ -462,7 +462,7 @@ function genericPrintNoParens(path, options, print) {
                   concat([
                     options.bracketSpacing ? line : softline,
                     join(
-                      concat([ ",", options.bracketSpacing ? line : softline ]),
+                      concat([ ",", line ]),
                       grouped
                     )
                   ])

--- a/tests/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,53 @@
+exports[`test brackets.js 1`] = `
+"import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from \'.\';
+import {fitsIn, oneLine} from \'.\';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from \".\";
+import { fitsIn, oneLine } from \".\";
+"
+`;
+
+exports[`test brackets.js 2`] = `
+"import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from \'.\';
+import {fitsIn, oneLine} from \'.\';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from \".\";
+import { fitsIn, oneLine } from \".\";
+"
+`;

--- a/tests/import/brackets.js
+++ b/tests/import/brackets.js
@@ -1,0 +1,11 @@
+import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from '.';
+import {fitsIn, oneLine} from '.';

--- a/tests/import/jsfmt.spec.js
+++ b/tests/import/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname);
+run_spec(__dirname, {bracketsSpacing: false});


### PR DESCRIPTION
Same fix as #278. We use the same (wrong) pattern in both places