### PR TITLE
Do not output trailing commas with rest arguments

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1760,13 +1760,16 @@ function printFunctionParams(path, print, options) {
     return "()";
   }
 
+  const lastParam = util.getLast(path.getValue().params);
+  const canHaveTrailingComma = lastParam.type !== "RestElement" && !fun.rest;
+
   return concat([
     "(",
     indent(
       options.tabWidth,
       concat([ softline, join(concat([ ",", line ]), printed) ])
     ),
-    ifBreak(options.trailingComma ? "," : ""),
+    ifBreak(canHaveTrailingComma && options.trailingComma ? "," : ""),
     softline,
     ")"
   ]);

--- a/tests/rest/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/rest/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,27 @@
+exports[`test trailing-commas.js 1`] = `
+"declare class C {
+  f(
+    superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
+    ...args
+  ): void,
+}
+
+function f(
+  superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
+  ...args
+) {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare class C {
+  f(
+    superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
+    ...args
+  ): void,
+}
+
+function f(
+  superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
+  ...args
+) {
+}
+"
+`;

--- a/tests/rest/jsfmt.spec.js
+++ b/tests/rest/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, {trailingComma: true});

--- a/tests/rest/trailing-commas.js
+++ b/tests/rest/trailing-commas.js
@@ -1,0 +1,11 @@
+declare class C {
+  f(
+    superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
+    ...args
+  ): void,
+}
+
+function f(
+  superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
+  ...args
+) {}


### PR DESCRIPTION
It turns out that this is not valid by the spec!