### PR TITLE
Allow customizing args sent to prettier-command

### DIFF
--- a/editors/emacs/prettier-js.el
+++ b/editors/emacs/prettier-js.el
@@ -39,6 +39,11 @@
   :type 'string
   :group 'prettier)
 
+(defcustom prettier-args '()
+  "List of args to send to prettier command"
+  :type 'list
+  :group 'prettier)
+
 (defcustom prettier-target-mode
   "js-mode"
   "Name of the major mode to be used by 'prettier-before-save'."
@@ -198,12 +203,12 @@ function."
              (erase-buffer))
            (if (zerop (apply 'call-process
                              prettier-command nil (list (list :file outputfile) errorfile)
-                             nil (append width-args (list bufferfile))))
+                             nil (append (append prettier-args width-args) (list bufferfile))))
                (progn
                  (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-"
                                       outputfile)
                  (prettier--apply-rcs-patch patchbuf)
-                 (message "Applied prettier")
+                 (message "Applied prettier with args `%s'" prettier-args)
                  (if errbuf (prettier--kill-error-buffer errbuf)))
              (message "Could not apply prettier")
              (if errbuf
@@ -215,4 +220,3 @@ function."
      (delete-file outputfile)))
 
 (provide 'prettier-js)
-


### PR DESCRIPTION
We require single quotes in our eslint config, which conflicts with prettier's default rules. Now the `prettier-args` custom variable allows anyone to set the arguments passed to the prettier command when it runs.

Might be nice to eventually build this up out of individual customization options (ie. `(setq prettier-single-quote t)`), but this is a pretty simple approach that works for now.