### PR TITLE
[WIP] Fix trailing whitespace

### DIFF
--- a/src/pp.js
+++ b/src/pp.js
@@ -55,6 +55,10 @@ function ifBreak(contents) {
   return { type: "if-break", contents };
 }
 
+function ifNoBreak(contents) {
+  return { type: "if-no-break", contents };
+}
+
 function iterDoc(topDoc, func) {
   const docs = [ topDoc ];
   while (docs.length !== 0) {
@@ -189,6 +193,12 @@ function fits(next, restCommands, width) {
           }
 
           break;
+        case "if-no-break":
+          if (mode !== MODE_BREAK) {
+            cmds.push([ ind, mode, doc.contents ]);
+          }
+
+          break;
         case "line":
           switch (mode) {
             // fallthrough
@@ -307,7 +317,13 @@ function print(w, doc) {
           break;
         case "if-break":
           if (mode === MODE_BREAK) {
-            cmds.push([ ind, MODE_BREAK, doc.contents ]);
+            cmds.push([ ind, mode, doc.contents ]);
+          }
+
+          break;
+        case "if-no-break":
+          if (mode !== MODE_BREAK) {
+            cmds.push([ ind, mode, doc.contents ]);
           }
 
           break;
@@ -375,6 +391,7 @@ module.exports = {
   multilineGroup,
   conditionalGroup,
   ifBreak,
+  ifNoBreak,
   hasHardLine,
   indent,
   print,

--- a/src/printer.js
+++ b/src/printer.js
@@ -17,6 +17,7 @@ var getFirstString = pp.getFirstString;
 var hasHardLine = pp.hasHardLine;
 var conditionalGroup = pp.conditionalGroup;
 var ifBreak = pp.ifBreak;
+var ifNoBreak = pp.ifNoBreak;
 var normalizeOptions = require("./options").normalize;
 var types = require("ast-types");
 var namedTypes = types.namedTypes;
@@ -1462,7 +1463,8 @@ function genericPrintNoParens(path, options, print) {
         "type ",
         path.call(print, "id"),
         path.call(print, "typeParameters"),
-        " = ",
+        " =",
+        ifNoBreak(" "),
         path.call(print, "right"),
         ";"
       );


### PR DESCRIPTION
Note: this is not working, putting this pull request to figure out why.

```js
echo 'export type Result<T, V> = | { kind: "not-test-editor1" } | { kind: "not-test-editor2" }; export type Result2<T, V> = { kind: "not-test-editor"};' | ./bin/prettier.js --stdin | cat -e
export type Result<T, V> =$
  | { kind: "not-test-editor1" }$
  | { kind: "not-test-editor2" };$
export type Result2<T, V> ={ kind: "not-test-editor" };$
$
```

As you can see, the space is not showing up when it fits in one line.

Fixed #222