### PR TITLE
Fix bracketSpacing typo in tests

### DIFF
--- a/tests/export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/export/__snapshots__/jsfmt.spec.js.snap
@@ -48,7 +48,7 @@ export {
   andMore,
   soWeCanGetItTo80Columns
 };
-export { fitsIn, oneLine };
+export {fitsIn, oneLine};
 "
 `;
 

--- a/tests/export/jsfmt.spec.js
+++ b/tests/export/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(__dirname);
-run_spec(__dirname, {bracketsSpacing: false});
+run_spec(__dirname, {bracketSpacing: false});

--- a/tests/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import/__snapshots__/jsfmt.spec.js.snap
@@ -48,6 +48,6 @@ import {
   andMore,
   soWeCanGetItTo80Columns
 } from \".\";
-import { fitsIn, oneLine } from \".\";
+import {fitsIn, oneLine} from \".\";
 "
 `;

--- a/tests/import/jsfmt.spec.js
+++ b/tests/import/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(__dirname);
-run_spec(__dirname, {bracketsSpacing: false});
+run_spec(__dirname, {bracketSpacing: false});


### PR DESCRIPTION
Basically `bracketsSpacing` -> `bracketSpacing`.

Do you think it's worth to validate config options, so such typos could be easily caught?

I actually was testing [`jest-validate`](https://github.com/facebook/jest/tree/master/packages/jest-validate) here because I thought it may come in handy and this showed up:
 
<img width="662" alt="screen shot 2017-01-18 at 20 02 20" src="https://cloud.githubusercontent.com/assets/5106466/22078679/1f4021a0-ddb9-11e6-9db9-23151db3db8d.png">

From some very rough (measured Jest total time) tests the impact on performance is ~1-2% 