### PR TITLE
Validate user-provided config with jest-validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "jest": "18.0.0",
+    "jest-validate": "18.1.0",
     "rollup": "0.41.1",
     "rollup-plugin-commonjs": "7.0.0",
     "rollup-plugin-json": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "jest": "18.0.0",
-    "jest-validate": "18.1.0",
+    "jest-validate": "18.2.0",
     "rollup": "0.41.1",
     "rollup-plugin-commonjs": "7.0.0",
     "rollup-plugin-json": "2.1.0",

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const chalk = require('chalk'); // "chalk" comes with jest-validate
+const bold = chalk
+  ? chalk.bold
+  : value => value; // fallback when chalk is not available (e.g. for npm 2)
+
+const deprecated = {
+  useFlowParser: config =>
+`  The ${bold("\"useFlowParser\"")} option is deprecated. Use ${bold("\"parser\"")} instead.
+
+  Prettier now treats your configuration as:
+  {
+    ${bold("\"parser\"")}: ${bold(config.seFlowParser ? "\"flow\"" : "\"babylon\"")}
+  }`
+};
+
+module.exports = deprecated;

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,17 +1,12 @@
 "use strict";
 
-const chalk = require('chalk'); // "chalk" comes with jest-validate
-const bold = chalk
-  ? chalk.bold
-  : value => value; // fallback when chalk is not available (e.g. for npm 2)
-
 const deprecated = {
   useFlowParser: config =>
-`  The ${bold("\"useFlowParser\"")} option is deprecated. Use ${bold("\"parser\"")} instead.
+`  The ${"\"useFlowParser\""} option is deprecated. Use ${"\"parser\""} instead.
 
   Prettier now treats your configuration as:
   {
-    ${bold("\"parser\"")}: ${bold(config.seFlowParser ? "\"flow\"" : "\"babylon\"")}
+    ${"\"parser\""}: ${config.seFlowParser ? "\"flow\"" : "\"babylon\""}
   }`
 };
 

--- a/src/options.js
+++ b/src/options.js
@@ -25,7 +25,7 @@ var exampleConfig = Object.assign({}, defaults, {
 
 // Copy options and fill in default values.
 function normalize(options) {
-  validate(options, { exampleConfig });
+  validate(options, { exampleConfig: exampleConfig });
   const normalized = Object.assign({}, options || {});
 
   // For backward compatibility. Deprecated in 0.0.10

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var validate = require("jest-validate").validate;
+var deprecatedConfig = require("./deprecated");
 
 var defaults = {
   // Number of spaces the pretty-printer should use per tab
@@ -25,14 +26,11 @@ var exampleConfig = Object.assign({}, defaults, {
 
 // Copy options and fill in default values.
 function normalize(options) {
-  validate(options, { exampleConfig });
+  validate(options, { exampleConfig, deprecatedConfig });
   const normalized = Object.assign({}, options || {});
 
   // For backward compatibility. Deprecated in 0.0.10
   if ("useFlowParser" in normalized) {
-    console.warn(
-      'The `"useFlowParser": true/false` option is deprecated. Use `parser: "flow"` instead.'
-    );
     normalized.parser = normalized.useFlowParser ? "flow" : "babylon";
     delete normalized.useFlowParser;
   }

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { validate } = require("jest-validate");
+var validate = require("jest-validate").validate;
 
 var defaults = {
   // Number of spaces the pretty-printer should use per tab
@@ -25,7 +25,7 @@ var exampleConfig = Object.assign({}, defaults, {
 
 // Copy options and fill in default values.
 function normalize(options) {
-  validate(options, { exampleConfig: exampleConfig });
+  validate(options, { exampleConfig });
   const normalized = Object.assign({}, options || {});
 
   // For backward compatibility. Deprecated in 0.0.10

--- a/src/options.js
+++ b/src/options.js
@@ -1,4 +1,7 @@
 "use strict";
+
+const { validate } = require("jest-validate");
+
 var defaults = {
   // Number of spaces the pretty-printer should use per tab
   tabWidth: 2,
@@ -14,8 +17,15 @@ var defaults = {
   parser: "babylon"
 };
 
+var exampleConfig = Object.assign({}, defaults, {
+  filename: "testFilename",
+  printWidth: 80,
+  originalText: "text"
+});
+
 // Copy options and fill in default values.
 function normalize(options) {
+  validate(options, { exampleConfig });
   const normalized = Object.assign({}, options || {});
 
   // For backward compatibility. Deprecated in 0.0.10

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,6 +1441,14 @@ jest-util@^18.1.0:
     jest-mock "^18.0.0"
     mkdirp "^0.5.1"
 
+jest-validate@18.1.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-18.1.0.tgz#014792ccdb97801db475da0ad42076d94fba301a"
+  dependencies:
+    chalk "^1.1.1"
+    jest-matcher-utils "^18.1.0"
+    pretty-format "^18.1.0"
+
 jest@18.0.0:
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-18.0.0.tgz#ef12f70befe0fcb30f1c61c0ae58748706267d4b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,12 +1441,13 @@ jest-util@^18.1.0:
     jest-mock "^18.0.0"
     mkdirp "^0.5.1"
 
-jest-validate@18.1.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-18.1.0.tgz#014792ccdb97801db475da0ad42076d94fba301a"
+jest-validate@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-18.2.0.tgz#01f93ac78f23901cf9889808e2bbb931ffc58d86"
   dependencies:
     chalk "^1.1.1"
     jest-matcher-utils "^18.1.0"
+    leven "^2.0.0"
     pretty-format "^18.1.0"
 
 jest@18.0.0:
@@ -1558,6 +1559,10 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+leven@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.0.0.tgz#74c45744439550da185801912829f61d22071bc1"
 
 levn@~0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Example usage of `jest-validate` for pretty errors and warnings