### PR TITLE
Fix docs generation process

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <title>Prettier</title>
 
 <script>global = window;</script>
+<script>Buffer = {isBuffer: function() { return false; }};</script>
 <script src="prettier.min.js"></script>
 
 <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
@@ -81,7 +82,7 @@
 
 <div class="container">
   <div class="options">
-    <label class="title"><a href="https://github.com/jlongster/prettier">prettier v0.0.8</a></label>
+    <label class="title"><a href="https://github.com/jlongster/prettier">prettier v<span class="version"></span></a></label>
     <label><input type="number" value="80" id="printWidth"></input> printWidth</label>
     <label><input type="number" value="2" id="tabWidth"></input> tabWidth</label>
     <label><input type="checkbox" id="singleQuote"></input> singleQuote</label>
@@ -153,6 +154,8 @@ var editorOptions = {
 var inputEditor = CodeMirror.fromTextArea(input, editorOptions);
 inputEditor.on('change', format);
 var outputEditor = CodeMirror.fromTextArea(output, {readOnly: true, lineNumbers: true, theme: 'base16-dark' });
+
+document.getElementsByClassName('version')[0].innerText = prettier.version;
 </script>
 
 <script>

--- a/docs/rollup.config.js
+++ b/docs/rollup.config.js
@@ -2,12 +2,14 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import builtins from 'rollup-plugin-node-builtins';
 import babili from 'rollup-plugin-real-babili';
+import json from 'rollup-plugin-json';
 
 export default {
   entry: 'index.js',
   dest: 'docs/prettier.min.js',
   format: 'iife',
   plugins: [
+    json(),
     resolve(),
     commonjs(),
     builtins(),

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jest": "18.0.0",
     "rollup": "0.41.1",
     "rollup-plugin-commonjs": "7.0.0",
+    "rollup-plugin-json": "^2.1.0",
     "rollup-plugin-node-builtins": "2.0.0",
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-real-babili": "1.0.0-alpha3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,6 +2087,12 @@ rollup-plugin-commonjs@7.0.0:
     resolve "^1.1.7"
     rollup-pluginutils "^1.5.1"
 
+rollup-plugin-json@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-2.1.0.tgz#7f8e1b2b156932dd934b938dc5547e4118d4121f"
+  dependencies:
+    rollup-pluginutils "^1.5.2"
+
 rollup-plugin-node-builtins@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.0.0.tgz#c6f291e167e9560ebea87fbfdc1abb44b0a7c1e6"
@@ -2111,7 +2117,7 @@ rollup-plugin-real-babili@1.0.0-alpha3:
     babel-core "^6.21.0"
     babel-preset-babili "0.0.9"
 
-rollup-pluginutils@^1.5.1:
+rollup-pluginutils@^1.5.1, rollup-pluginutils@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:


### PR DESCRIPTION
It doesn't compile cleanly anymore:
- esutils checks for Buffer.isBuffer without ensuring that Buffer exists.
- for version, we require a json file, need a rollup extension for that.

I no longer hardcode the version number.

Note: we need to merge this pull request after we have done the release so that the version number is correct and need to rebuild the minified version in a subsequent commit.