### PR TITLE
Fix crash for single rest on class declaration

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1766,7 +1766,7 @@ function printFunctionParams(path, print, options) {
   }
 
   const lastParam = util.getLast(path.getValue().params);
-  const canHaveTrailingComma = lastParam.type !== "RestElement" && !fun.rest;
+  const canHaveTrailingComma = !(lastParam && lastParam.type === "RestElement") && !fun.rest;
 
   return concat([
     "(",

--- a/tests/rest/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/rest/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,8 @@ function f(
   superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
   ...args
 ) {}
+
+declare class C { f(...superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong): void; }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class C {
   f(
@@ -22,6 +24,12 @@ function f(
   superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
   ...args
 ) {
+}
+
+declare class C {
+  f(
+    ...superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong
+  ): void,
 }
 "
 `;

--- a/tests/rest/trailing-commas.js
+++ b/tests/rest/trailing-commas.js
@@ -9,3 +9,5 @@ function f(
   superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
   ...args
 ) {}
+
+declare class C { f(...superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong): void; }


### PR DESCRIPTION
I thought I didn't need to check the length but forgot that the rest argument is not in the list for class declaration. Now it doesn't crash anymore and there's a test...