### PR TITLE
Add Canonical Sublime Text Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ Can also be installed using `ext install prettier-vscode`
 
 ### Sublime Text
 
-Please see [this issue](https://github.com/jlongster/prettier/issues/17) for those interested in working on Sublime Text integration.
+Sublime Text support is available through Package Control and 
+the [JsPrettier](https://packagecontrol.io/packages/JsPrettier) plug-in.
 
 More editors are coming soon.
 


### PR DESCRIPTION
Hey guys... this would be the [canonical link](https://packagecontrol.io/packages/JsPrettier) ([discussion here](https://github.com/jlongster/prettier/pull/190#issuecomment-272619266)) for Sublime Text Prettier support, approved by [Package Control](https://packagecontrol.io).