### PR TITLE
[WIP] Disallow moving literals to their own line in binary expressions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2265,7 +2265,8 @@ function printBinaryishExpressions(path, parts, print) {
       parts.push(path.call(print, "left"));
     }
 
-    parts.push(" ", node.operator, line, path.call(print, "right"));
+    const allowLine = !namedTypes.Literal.check(node.right);
+    parts.push(" ", node.operator, allowLine ? line : " ", path.call(print, "right"));
   } else {
     // Our stopping case. Simply print the node normally.
     parts.push(path.call(print));

--- a/tests/prettier/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/prettier/__snapshots__/jsfmt.spec.js.snap
@@ -15,6 +15,8 @@ const x = longVariable * longint && longVariable >> 0 && longVariable + longVari
 const x = longVariable > longint && longVariable === 0 + longVariable * longVariable;
 
 foo(obj.property * new Class() && obj instanceof Class && longVariable ? number + 5 : false);
+
+const x = 100000 + 200000 + 300000 + 100000 + 200000 + 300000 + 100000 + 200000 + 300000 + 100000 + 200000;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // It should always break the highest precedence operators first, and
 // break them all at the same time.
@@ -57,6 +59,8 @@ foo(
     ? number + 5
     : false
 );
+
+const x = 100000 + 200000 + 300000 + 100000 + 200000 + 300000 + 100000 + 200000 + 300000 + 100000 + 200000;
 "
 `;
 

--- a/tests/prettier/binary-expressions.js
+++ b/tests/prettier/binary-expressions.js
@@ -14,3 +14,5 @@ const x = longVariable * longint && longVariable >> 0 && longVariable + longVari
 const x = longVariable > longint && longVariable === 0 + longVariable * longVariable;
 
 foo(obj.property * new Class() && obj instanceof Class && longVariable ? number + 5 : false);
+
+const x = 100000 + 200000 + 300000 + 100000 + 200000 + 300000 + 100000 + 200000 + 300000 + 100000 + 200000;


### PR DESCRIPTION
This is another proposed solution to #314, see the discussion there.

This also solves @llimllib case in #46 (see comment https://github.com/jlongster/prettier/issues/46#issuecomment-271696399). Currently we output his/her worst solution. Now we would output:

```js
lots +
  of +
  additions +
  are +
  put +
  into +
  some +
  weird +
  format +
  thats +
  ugly > 0;
```

While that might look a little weird with that example code, I think this will solve a lot of real-world problems where we'd move a simple literal to its own line.