### PR TITLE
[WIP] Add an option to print the intermediate representation

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -14,7 +14,8 @@ const argv = minimist(process.argv.slice(2), {
     "bracket-spacing",
     "single-quote",
     "trailing-comma",
-    "version"
+    "version",
+    "debug-print-docs"
   ],
   default: { "bracket-spacing": true }
 });
@@ -44,21 +45,32 @@ if (!filenames.length && !stdin) {
   process.exit(1);
 }
 
+const options = {
+  printWidth: argv["print-width"],
+  tabWidth: argv["tab-width"],
+  bracketSpacing: argv["bracket-spacing"],
+  useFlowParser: argv["flow-parser"],
+  singleQuote: argv["single-quote"],
+  trailingComma: argv["trailing-comma"]
+};
+
 function format(input) {
-  return jscodefmt.format(input, {
-    printWidth: argv["print-width"],
-    tabWidth: argv["tab-width"],
-    bracketSpacing: argv["bracket-spacing"],
-    useFlowParser: argv["flow-parser"],
-    singleQuote: argv["single-quote"],
-    trailingComma: argv["trailing-comma"]
-  });
+  return jscodefmt.format(input, options);
+}
+
+function formatInput(input) {
+  if (argv["debug-print-docs"]) {
+    const docs = jscodefmt.getDocs(input, options);
+    const printDoc = require("../src/printDoc");
+    return format(printDoc(docs), options);
+  }
+  return format(input);
 }
 
 if (stdin) {
   getStdin().then(input => {
     try {
-      console.log(format(input));
+      console.log(formatInput(input));
     } catch (e) {
       process.exitCode = 2;
       console.error(e);
@@ -81,7 +93,7 @@ if (stdin) {
 
       let output;
       try {
-        output = format(input);
+        output = formatInput(input);
       } catch (e) {
         process.exitCode = 2;
         console.error(e);

--- a/index.js
+++ b/index.js
@@ -24,7 +24,13 @@ var babylonOptions = {
   ]
 };
 
-function format(text, opts) {
+function getPrinter(text, opts) {
+  opts = opts || {};
+  opts.originalText = text;
+  return new Printer(opts);
+}
+
+function getAst(text, opts) {
   opts = opts || {};
   let ast;
 
@@ -53,10 +59,15 @@ function format(text, opts) {
     ast.comments = [];
   }
   ast.tokens = [];
-  opts.originalText = text;
+  return ast;
+}
 
-  const printer = new Printer(opts);
-  return printer.print(ast);
+function getDocs(text, opts) {
+  return getPrinter(text, opts).getDocs(getAst(text, opts));
+}
+
+function format(text, opts) {
+  return getPrinter(text, opts).print(getAst(text, opts));
 }
 
 function formatWithShebang(text, opts) {
@@ -77,5 +88,6 @@ module.exports = {
   format: function(text, opts) {
     return formatWithShebang(text, opts);
   },
+  getDocs: getDocs,
   version: version
 };

--- a/src/pp.js
+++ b/src/pp.js
@@ -1,5 +1,6 @@
 "use strict";
 const assert = require("assert");
+const printDoc = require("./printDoc");
 
 function assertDoc(val) {
   assert(

--- a/src/printDoc.js
+++ b/src/printDoc.js
@@ -1,0 +1,93 @@
+"use strict";
+
+var jsesc = require("jsesc");
+
+function flattenDoc(doc) {
+  if (!doc || 
+      typeof doc === 'string' ||
+      doc.type === 'line') {
+    return doc;
+  }
+
+  if (doc.type === 'concat') {
+    var res = [];
+    for (var i = 0; i < doc.parts.length; ++i) {
+      const doc2 = doc.parts[i];
+      if (typeof doc2 !== 'string' && doc2.type === 'concat') {
+        res.push(...doc2.parts.map(flattenDoc));
+      } else {
+        res.push(flattenDoc(doc2));
+      }
+    }
+    return Object.assign({}, doc, {
+      parts: res
+    });
+  }
+
+  if (doc.type === 'indent') {
+    return Object.assign({}, doc, {
+      contents: flattenDoc(doc.contents)
+    });
+  }
+
+  if (doc.type === 'if-break') {
+    return Object.assign({}, doc, {
+      breakContents: flattenDoc(doc.breakContents),
+      flatContents: flattenDoc(doc.flatContents),
+    });
+  }
+
+  if (doc.type === 'group') {
+    return Object.assign({}, doc, {
+      contents: flattenDoc(doc.contents),
+      expandedStates: doc.expandedStates ? doc.expandedStates.map(flattenDoc) : doc.expandedStates,
+    });
+  }
+}
+
+function printDoc(doc) {
+  if (typeof doc === 'string') {
+    return jsesc(doc, {wrap: true});
+  }
+
+  if (doc.type === 'line') {
+    if (doc.literalline) {
+      return 'literalline()';
+    }
+    if (doc.hard) {
+      return 'hardline()';
+    }
+    if (doc.soft) {
+      return 'softline()';
+    }
+    return 'line()';
+  }
+
+  if (doc.type === 'concat') {
+    return "[" + doc.parts.map(printDoc).join(", ") + "]";
+  }
+
+  if (doc.type === 'indent') {
+    return "indent(" + doc.n + ", " + printDoc(doc.contents) + ")";
+  }
+
+  if (doc.type === 'if-break') {
+    if (doc.flatContents) {
+      return 'break() ? ' + printDoc(doc.breakContents) + ' : ' + printDoc(doc.flatContents);
+    }    
+    return 'break() && ' + printDoc(doc.breakContents);
+  }
+
+  if (doc.type === 'group') {
+    return "group" + (doc.break ? "Break" : "") +
+      "(" + printDoc(doc.contents) +
+      (doc.expandedStates ?
+        ", [" + doc.expandedStates.map(printDoc).join(",") + "]" :
+        "") +
+      ")";
+  }
+}
+
+module.exports = function(doc) {
+  return printDoc(flattenDoc(doc));
+};

--- a/src/printer.js
+++ b/src/printer.js
@@ -53,6 +53,15 @@ function Printer(originalOptions) {
 
     return pp.print(options.printWidth, res);
   };
+
+  this.getDocs = function(ast) {
+    if (!ast) {
+      return "";
+    }
+
+    var path = FastPath.from(ast);
+    return printGenerically(path);
+  }
 }
 
 exports.Printer = Printer;


### PR DESCRIPTION
It's very useful to figure out what IR is generated to find out why things are not behaving the way they should.

The way this PR works is by going through the IR and flatten all the extra concat. Then, it prints them as a valid JavaScript string and uses prettier to actually properly indent it (which is extremely cool!).

Note: the integration with the command line is super hacky. I just wanted to put this out there so we can discuss before starting a refactor.

```js
echo "<div>&lt;</div>" | ./bin/prettier.js --stdin --debug-print-docs --single-quote
[
  [
    [
      [
        group(
          group([
            group([ '<', 'div', group([ indent(2, []), softline() ]), '>' ]),
            '&lt;',
            [ '</', 'div', '>' ]
          ]),
          [
            group([
              group([ '<', 'div', group([ indent(2, []), softline() ]), '>' ]),
              '&lt;',
              [ '</', 'div', '>' ]
            ]),
            group([
              group([ '<', 'div', group([ indent(2, []), softline() ]), '>' ]),
              indent(2, groupBreak([ hardline(), '&lt;' ])),
              hardline(),
              [ '</', 'div', '>' ]
            ])
          ]
        ),
        ';'
      ]
    ],
    hardline()
  ]
];
```