### PR TITLE
Fix node 4

### DIFF
--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const assert = require("assert");
 const utils = require("./doc-utils");
 const hasHardLine = utils.hasHardLine;

--- a/src/doc-utils.js
+++ b/src/doc-utils.js
@@ -1,3 +1,4 @@
+"use strict";
 
 function iterDoc(topDoc, func) {
   const docs = [ topDoc ];


### PR DESCRIPTION
It complained that it couldn't recognize const outside of `"use strict";`. It's a good idea to add this anyway.