### PR TITLE
Extract parser.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,11 @@
 "use strict";
-const babylon = require("babylon");
-const flowParser = require("flow-parser");
+
 const comments = require("./src/comments");
 const version = require("./package.json").version;
 const printAstToDoc = require("./src/printer").printAstToDoc;
 const printDocToString = require("./src/doc-printer").printDocToString;
 const normalizeOptions = require("./src/options").normalize;
-
-var babylonOptions = {
-  sourceType: "module",
-  allowImportExportEverywhere: false,
-  allowReturnOutsideFunction: false,
-  plugins: [
-    "jsx",
-    "flow",
-    "doExpressions",
-    "objectRestSpread",
-    "decorators",
-    "classProperties",
-    "exportExtensions",
-    "asyncGenerators",
-    "functionBind",
-    "functionSent",
-    "dynamicImport"
-  ]
-};
+const parser = require("./src/parser");
 
 function format(text, opts) {
   let ast;
@@ -32,22 +13,9 @@ function format(text, opts) {
   opts = normalizeOptions(opts);
 
   if (opts.useFlowParser) {
-    ast = flowParser.parse(text, {
-      esproposal_class_instance_fields: true,
-      esproposal_class_static_fields: true,
-      esproposal_export_star_as: true
-    });
-    if (ast.errors.length > 0) {
-      let msg = ast.errors[0].message +
-        " on line " +
-        ast.errors[0].loc.start.line;
-      if (opts.filename) {
-        msg += " in file " + opts.filename;
-      }
-      throw new Error(msg);
-    }
+    ast = parser.parseWithFlow(text, opts.filename);
   } else {
-    ast = babylon.parse(text, babylonOptions);
+    ast = parser.parseWithBabylon(text);
   }
 
   // Interleave comment nodes

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,53 @@
+"use strict";
+
+function parseWithFlow(text, filename) {
+  // Inline the require to avoid loading all the JS if we don't use it
+  const flowParser = require("flow-parser");
+
+  const ast = flowParser.parse(text, {
+    esproposal_class_instance_fields: true,
+    esproposal_class_static_fields: true,
+    esproposal_export_star_as: true
+  });
+
+  if (ast.errors.length > 0) {
+    let msg = ast.errors[0].message +
+      " on line " +
+      ast.errors[0].loc.start.line;
+    if (filename) {
+      msg += " in file " + filename;
+    }
+    throw new Error(msg);
+  }
+
+  return ast;
+}
+
+function parseWithBabylon(text) {
+  // Inline the require to avoid loading all the JS if we don't use it
+  const babylon = require("babylon");
+
+  return babylon.parse(text, {
+    sourceType: "module",
+    allowImportExportEverywhere: false,
+    allowReturnOutsideFunction: false,
+    plugins: [
+      "jsx",
+      "flow",
+      "doExpressions",
+      "objectRestSpread",
+      "decorators",
+      "classProperties",
+      "exportExtensions",
+      "asyncGenerators",
+      "functionBind",
+      "functionSent",
+      "dynamicImport"
+    ]
+  });
+}
+
+module.exports = {
+  parseWithFlow,
+  parseWithBabylon
+};

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const prettier = require("../");
 const types = require("ast-types");
+const parser = require('../src/parser');
 
 const RUN_AST_TESTS = process.env["AST_COMPARE"];
 
@@ -75,12 +76,7 @@ function stripLocation(ast) {
 }
 
 function parse(string) {
-  const flowParser = require('flow-parser');
-  return stripLocation(flowParser.parse(string, {
-    esproposal_class_instance_fields: true,
-    esproposal_class_static_fields: true,
-    esproposal_export_star_as: true,
-  }));
+  return stripLocation(parser.parseWithFlow(string));
 }
 
 function prettyprint(src, filename, options) {


### PR DESCRIPTION
Before, we would parse things inline in both index.js and run_spec.js. Extracting it should make it easier to manage and understand what is going on.

I ran `AST_COMPARE=1 npm test` and it still works.