### PR TITLE
Introduce --parser/parser option and deprecate --flow-parser/useFlowParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,6 @@ prettier.format(source, {
   // Number of spaces it should use per tab
   tabWidth: 2,
 
-  // Use the flow parser instead of babylon
-  useFlowParser: false,
-
   // If true, will use single instead of double quotes
   singleQuote: false,
 
@@ -149,7 +146,10 @@ prettier.format(source, {
   trailingComma: false,
 
   // Controls the printing of spaces inside array and objects
-  bracketSpacing: true
+  bracketSpacing: true,
+
+  // Which parser to use. Valid options are 'flow' and 'babylon'
+  parser: 'babylon'
 });
 ```
 
@@ -197,7 +197,7 @@ including non-standardized ones. By default it uses the
 [babylon](https://github.com/babel/babylon) parser with all language
 features enabled, but you can also use
 [flow](https://github.com/facebook/flow) parser with the
-`useFlowParser` API or `--flow-parser` CLI option.
+`parser` API or `--parser` CLI option.
 
 All of JSX and Flow syntax is supported. In fact, the test suite in
 `tests` *is* the entire Flow test suite and they all pass.

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -10,13 +10,21 @@ const argv = minimist(process.argv.slice(2), {
   boolean: [
     "write",
     "stdin",
-    "flow-parser",
     "bracket-spacing",
     "single-quote",
     "trailing-comma",
-    "version"
+    "version",
+
+    // Deprecated in 0.0.10
+    "flow-parser"
   ],
-  default: { "bracket-spacing": true }
+  string: [
+    "parser"
+  ],
+  default: {
+    "bracket-spacing": true,
+    parser: "babylon",
+  }
 });
 
 if (argv["version"]) {
@@ -32,16 +40,29 @@ if (!filenames.length && !stdin) {
   console.log(
     "Usage: prettier [opts] [filename ...]\n\n" +
       "Available options:\n" +
-      "  --write              Edit the file in-place (beware!)\n" +
-      "  --stdin              Read input from stdin\n" +
-      "  --print-width <int>  Specify the length of line that the printer will wrap on. Defaults to 80.\n" +
-      "  --tab-width <int>    Specify the number of spaces per indentation-level. Defaults to 2.\n" +
-      "  --flow-parser        Use the flow parser instead of babylon\n" +
-      "  --single-quote       Use single quotes instead of double\n" +
-      "  --trailing-comma     Print trailing commas wherever possible\n" +
-      "  --bracket-spacing    Put spaces between brackets. Defaults to true, set false to turn off"
+      "  --write                  Edit the file in-place (beware!)\n" +
+      "  --stdin                  Read input from stdin\n" +
+      "  --print-width <int>      Specify the length of line that the printer will wrap on. Defaults to 80.\n" +
+      "  --tab-width <int>        Specify the number of spaces per indentation-level. Defaults to 2.\n" +
+      "  --parser <flow|babylon>  Specify which parse to use. Defaults to babylon\n" +
+      "  --single-quote           Use single quotes instead of double\n" +
+      "  --trailing-comma         Print trailing commas wherever possible\n" +
+      "  --bracket-spacing        Put spaces between brackets. Defaults to true, set false to turn off"
   );
   process.exit(1);
+}
+
+function getParser() {
+  // For backward compatibility. Deprecated in 0.0.10
+  if (argv["flow-parser"]) {
+    return "flow";
+  }
+
+  if (argv["parser"] === "flow") {
+    return "flow";
+  }
+
+  return "babylon";
 }
 
 function format(input) {
@@ -49,7 +70,7 @@ function format(input) {
     printWidth: argv["print-width"],
     tabWidth: argv["tab-width"],
     bracketSpacing: argv["bracket-spacing"],
-    useFlowParser: argv["flow-parser"],
+    parser: getParser(),
     singleQuote: argv["single-quote"],
     trailingComma: argv["trailing-comma"]
   });

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const normalizeOptions = require("./src/options").normalize;
 const parser = require("./src/parser");
 
 function parse(text, opts) {
-  if (opts.useFlowParser) {
+  if (opts.parser === 'flow') {
     return parser.parseWithFlow(text, opts.filename);
   }
   return parser.parseWithBabylon(text);

--- a/src/options.js
+++ b/src/options.js
@@ -10,17 +10,27 @@ var defaults = {
   // Controls the printing of trailing commas wherever possible
   trailingComma: false,
   // Controls the printing of spaces inside array and objects
-  bracketSpacing: true
+  bracketSpacing: true,
+  // Which parser to use. Valid options are 'flow' and 'babylon'
+  parser: 'babylon'
 };
 
 // Copy options and fill in default values.
 function normalize(options) {
   const normalized = Object.assign({}, options || {});
+
+  // For backward compatibility. Deprecated in 0.0.10
+  if ('useFlowParser' in normalized) {
+    normalized.parser = normalized.useFlowParser ? 'flow' : 'babylon';
+    delete normalized.useFlowParser;
+  }
+
   Object.keys(defaults).forEach(k => {
     if (normalized[k] == null) {
       normalized[k] = defaults[k];
     }
   });
+
   return normalized;
 };
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -1580,7 +1580,7 @@ function printPropertyKey(path, options, print) {
       isIdentifierName(node.value) &&
       // There's a bug in the flow parser where it throws if there are
       // unquoted unicode literals as keys. Let's quote them for now.
-      (!options.useFlowParser || node.value.match(/[a-zA-Z0-9$_]/))
+      (options.parser !== 'flow' || node.value.match(/[a-zA-Z0-9$_]/))
   ) {
     // 'a' -> a
     return node.value;
@@ -2055,7 +2055,7 @@ function printJSXChildren(path, options, print) {
         // correctly escaped (since it parsed).
         // We really want to use value and re-escape it ourself when possible
         // though.
-        const value = options.useFlowParser ?
+        const value = options.parser === 'flow' ?
           child.raw :
           util.htmlEscapeInsideAngleBracket(child.value);
 
@@ -2331,7 +2331,7 @@ function nodeStr(node, options) {
   // Workaround a bug in the Javascript version of the flow parser where
   // astral unicode characters like \uD801\uDC28 are incorrectly parsed as
   // a sequence of \uFFFD.
-  if (options.useFlowParser && result.indexOf("\\uFFFD") !== -1) {
+  if (options.parser === 'flow' && result.indexOf("\\uFFFD") !== -1) {
     return node.raw;
   }
 

--- a/tests/array_spread/jsfmt.spec.js
+++ b/tests/array_spread/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(__dirname);
-run_spec(__dirname, {useFlowParser: false});
+run_spec(__dirname, {parser: 'babylon'});

--- a/tests/comments/jsfmt.spec.js
+++ b/tests/comments/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(__dirname);
-run_spec(__dirname, {useFlowParser: false});
+run_spec(__dirname, {parser: 'babylon'});

--- a/tests/jsx_escape/jsfmt.spec.js
+++ b/tests/jsx_escape/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(__dirname);
-run_spec(__dirname, {useFlowParser: false});
+run_spec(__dirname, {parser: 'babylon'});

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -82,7 +82,7 @@ function parse(string) {
 function prettyprint(src, filename, options) {
   return prettier.format(src, Object.assign({
     filename,
-    useFlowParser: true,
+    parser: 'flow',
     printWidth: 80,
   }, options));
 }


### PR DESCRIPTION
The previous API was inconsistent. The new one is

```js
--parser flow
--parser babylon

{parser: 'flow'}
{parser: 'babylon'}
```

if we ever want to add new parsers in the future it'll allow that more easily.

I put a console.log in parser.js in both functions and tested that the test suite worked both with and without the change in run_spec. I also tested that both the previous and new command line options are working.

At some point in the future we'll likely want to get rid of the old api but might as well keep supporting it so we don't break anyone for now.