### PR TITLE
Drop jsesc

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "esutils": "2.0.2",
     "flow-parser": "0.38.0",
     "get-stdin": "5.0.1",
-    "jsesc": "2.4.0",
     "minimist": "1.2.0",
     "private": "0.1.6"
   },

--- a/src/doc-debug.js
+++ b/src/doc-debug.js
@@ -1,5 +1,4 @@
 "use strict";
-var jsesc = require("jsesc");
 
 function flattenDoc(doc) {
   if (!doc || typeof doc === "string" || doc.type === "line") {
@@ -47,7 +46,7 @@ function flattenDoc(doc) {
 
 function printDoc(doc) {
   if (typeof doc === "string") {
-    return jsesc(doc, { wrap: true });
+    return JSON.stringify(doc);
   }
 
   if (doc.type === "line") {


### PR DESCRIPTION
Even though JSON.stringify is not 100% correct, this is only used for debugging and doesn't warrant adding a dependency for it.

Note: this needs to land after #355