### PR TITLE
Fix CLI options

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -10,15 +10,15 @@ const argv = minimist(process.argv.slice(2), {
   boolean: [
     "write",
     "stdin",
-    "bracket-spacing",
     "single-quote",
     "trailing-comma",
+    "bracket-spacing",
     "version",
     "debug-print-doc",
     // Deprecated in 0.0.10
     "flow-parser"
   ],
-  string: [ "parser" ],
+  string: [ "print-width", "tab-width", "parser" ],
   default: { "bracket-spacing": true, parser: "babylon" },
   unknown: param => {
     if (param.startsWith("-")) {
@@ -40,14 +40,15 @@ if (!filenames.length && !stdin) {
   console.log(
     "Usage: prettier [opts] [filename ...]\n\n" +
       "Available options:\n" +
-      "  --write                  Edit the file in-place (beware!)\n" +
-      "  --stdin                  Read input from stdin\n" +
+      "  --write                  Edit the file in-place. (Beware!)\n" +
+      "  --stdin                  Read input from stdin.\n" +
       "  --print-width <int>      Specify the length of line that the printer will wrap on. Defaults to 80.\n" +
       "  --tab-width <int>        Specify the number of spaces per indentation-level. Defaults to 2.\n" +
-      "  --parser <flow|babylon>  Specify which parse to use. Defaults to babylon\n" +
-      "  --single-quote           Use single quotes instead of double\n" +
-      "  --trailing-comma         Print trailing commas wherever possible\n" +
-      "  --bracket-spacing        Put spaces between brackets. Defaults to true, set false to turn off"
+      "  --single-quote           Use single quotes instead of double.\n" +
+      "  --trailing-comma         Print trailing commas wherever possible.\n" +
+      "  --bracket-spacing        Put spaces between brackets. Defaults to true, set false to turn off.\n" +
+      "  --parser <flow|babylon>  Specify which parse to use. Defaults to babylon.\n" +
+      "  --version                Print prettier version."
   );
   process.exit(1);
 }


### PR DESCRIPTION
- Add missing options to minimist. This removes "Ignored unknown
  option:" warnings for options that actually exists.
- Put more interesting options closer to the top.
- Consistenly use full sentences.