### PR TITLE
Fix forced trailing comma

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -640,7 +640,7 @@ function genericPrintNoParens(path, options, print) {
                 ])
               ),
               needsForcedTrailingComma ? "," : "",
-              ifBreak(options.trailingComma ? "," : ""),
+              ifBreak(!needsForcedTrailingComma && options.trailingComma ? "," : ""),
               options.bracketSpacing ? line : softline,
               "]"
             ])

--- a/tests/rest/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/rest/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,8 @@ function f(
 ) {}
 
 declare class C { f(...superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong): void; }
+
+[superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,,]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class C {
   f(
@@ -31,5 +33,10 @@ declare class C {
     ...superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong
   ): void,
 }
+
+[
+  superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
+  ,
+];
 "
 `;

--- a/tests/rest/trailing-commas.js
+++ b/tests/rest/trailing-commas.js
@@ -11,3 +11,5 @@ function f(
 ) {}
 
 declare class C { f(...superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong): void; }
+
+[superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,,]


### PR DESCRIPTION
We shouldn't output trailing commas when there is a forced one when we break.

Fixes #380