### PR TITLE
Support multiple standalones in import

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -415,10 +415,8 @@ function genericPrintNoParens(path, options, print) {
           "specifiers"
         );
 
-        assert.ok(standalones.length <= 1);
-
         if (standalones.length > 0) {
-          parts.push(standalones[0]);
+          parts.push(join(", ", standalones));
         }
 
         if (standalones.length > 0 && grouped.length > 0) {

--- a/tests/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import/__snapshots__/jsfmt.spec.js.snap
@@ -51,3 +51,17 @@ import {
 import {fitsIn, oneLine} from \".\";
 "
 `;
+
+exports[`test multiple_standalones.js 1`] = `
+"import a, * as b from \'a\';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import a, * as b from \"a\";
+"
+`;
+
+exports[`test multiple_standalones.js 2`] = `
+"import a, * as b from \'a\';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import a, * as b from \"a\";
+"
+`;

--- a/tests/import/multiple_standalones.js
+++ b/tests/import/multiple_standalones.js
@@ -1,0 +1,1 @@
+import a, * as b from 'a';


### PR DESCRIPTION
There was an assertion that there would be only one, it turned out not to be the case.

Fixes #386