### PR TITLE
Remove unneeded parens for FunctionExpression inside LogicalExpression

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -399,6 +399,9 @@ FPp.needsParens = function(assumeExpressionContext) {
         case "NewExpression":
           return name === "callee";
 
+        case "LogicalExpression":
+          return node.type === "ArrowFunctionExpression";
+
         default:
           return isBinary(parent);
       }

--- a/tests/function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/function/__snapshots__/jsfmt.spec.js.snap
@@ -370,7 +370,8 @@ export default (function() {})();
 (function() {})()\`\`;
 (function() {})\`\`;
 new (function() {});
-(function() {})
+(function() {});
+a = function f() {} || b;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (function() {
 }).length;
@@ -386,6 +387,8 @@ new (function() {
 })();
 (function() {
 });
+a = function f() {
+} || b;
 "
 `;
 

--- a/tests/function/function_expression.js
+++ b/tests/function/function_expression.js
@@ -4,4 +4,5 @@ export default (function() {})();
 (function() {})()``;
 (function() {})``;
 new (function() {});
-(function() {})
+(function() {});
+a = function f() {} || b;


### PR DESCRIPTION
Fixes #374 