### PR TITLE
Proper parenthesis for yield and await in conditional

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -333,13 +333,6 @@ FPp.needsParens = function(assumeExpressionContext) {
       }
 
     case "YieldExpression":
-      if (
-        parent.type === "ConditionalExpression" &&
-          parent.test === node &&
-          !node.argument
-      ) {
-        return true;
-      }
     case "AwaitExpression":
       switch (parent.type) {
         case "TaggedTemplateExpression":
@@ -354,6 +347,9 @@ FPp.needsParens = function(assumeExpressionContext) {
 
         case "CallExpression":
           return parent.callee === node;
+
+        case "ConditionalExpression":
+          return parent.test === node;
 
         default:
           return false;

--- a/tests/yield/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/yield/__snapshots__/jsfmt.spec.js.snap
@@ -2,15 +2,41 @@ exports[`test conditional.js 1`] = `
 "function* f() {
   a = (yield) ? 1 : 1;
   a = yield 1 ? 1 : 1;
+  a = (yield 1) ? 1 : 1;
   a = 1 ? yield : yield;
   a = 1 ? yield 1 : yield 1;
+}
+
+function* f() {
+  a = yield* 1 ? 1 : 1;
+  a = (yield* 1) ? 1 : 1;
+  a = 1 ? yield* 1 : yield* 1;
+}
+
+async function f() {
+  a = await 1 ? 1 : 1;
+  a = (await 1) ? 1 : 1;
+  a = 1 ? await 1 : await 1;
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function* f() {
   a = (yield) ? 1 : 1;
   a = yield 1 ? 1 : 1;
+  a = (yield 1) ? 1 : 1;
   a = 1 ? yield : yield;
   a = 1 ? yield 1 : yield 1;
+}
+
+function* f() {
+  a = yield* 1 ? 1 : 1;
+  a = (yield* 1) ? 1 : 1;
+  a = 1 ? yield* 1 : yield* 1;
+}
+
+async function f() {
+  a = (await 1) ? 1 : 1;
+  a = (await 1) ? 1 : 1;
+  a = 1 ? await 1 : await 1;
 }
 "
 `;

--- a/tests/yield/conditional.js
+++ b/tests/yield/conditional.js
@@ -1,6 +1,19 @@
 function* f() {
   a = (yield) ? 1 : 1;
   a = yield 1 ? 1 : 1;
+  a = (yield 1) ? 1 : 1;
   a = 1 ? yield : yield;
   a = 1 ? yield 1 : yield 1;
+}
+
+function* f() {
+  a = yield* 1 ? 1 : 1;
+  a = (yield* 1) ? 1 : 1;
+  a = 1 ? yield* 1 : yield* 1;
+}
+
+async function f() {
+  a = await 1 ? 1 : 1;
+  a = (await 1) ? 1 : 1;
+  a = 1 ? await 1 : await 1;
 }


### PR DESCRIPTION
Turns out, we need to always parenthesis when it's the first part of a conditional for both yield and await.

Fixes #433