### PR TITLE
Don't print double newlines at EOF to stdout

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -95,7 +95,8 @@ function format(input) {
 if (stdin) {
   getStdin().then(input => {
     try {
-      console.log(format(input));
+      // Don't use `console.log` here since it adds an extra newline at the end.
+      process.stdout.write(format(input));
     } catch (e) {
       process.exitCode = 2;
       console.error("stdin: " + e);
@@ -134,7 +135,8 @@ if (stdin) {
           }
         });
       } else {
-        console.log(output);
+        // Don't use `console.log` here since it adds an extra newline at the end.
+        process.stdout.write(output);
       }
     });
   });


### PR DESCRIPTION
If you use the `--write` option, the files will end with a single
newline as expected. But if you let prettier print to stdout instead and
redirect that into a file, it will contain _two_ newlines at the end.

Demonstration of the correct `--write` behavior:

```js
$ cat tmp.js
function test() {
  return "hello";
}
$ wc -l tmp.js
3 tmp.js
$ ./bin/prettier.js tmp.js --write
tmp.js
$ cat tmp.js
function test() {
  return "hello";
}
$ wc -l tmp.js
3 tmp.js
```

Notice how an extra line is added when redirecting stdout:

```js
$ ./bin/prettier.js tmp.js > tmp2.js
$ cat tmp2.js
function test() {
  return "hello";
}

$ wc -l tmp2.js
4 tmp2.js
```

With this commit things work as expected:

```js
$ ./bin/prettier.js tmp.js > tmp2.js
$ cat tmp2.js
function test() {
  return "hello";
}
$ wc -l tmp2.js
3 tmp2.js
```

Fixes #377.