### PR TITLE
Fix typo in config.useFlowParser variable name

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -6,7 +6,7 @@ const deprecated = {
 
   Prettier now treats your configuration as:
   {
-    ${"\"parser\""}: ${config.seFlowParser ? "\"flow\"" : "\"babylon\""}
+    ${"\"parser\""}: ${config.useFlowParser ? "\"flow\"" : "\"babylon\""}
   }`
 };
 


### PR DESCRIPTION
Fixes a typo

btw, this warning looks like this:

<img width="471" alt="screen shot 2017-01-23 at 22 41 51" src="https://cloud.githubusercontent.com/assets/5106466/22223971/3466af42-e1bd-11e6-960f-bcb1cba3d4b2.png">
