### PR TITLE
Better error message for assertDoc

### DIFF
--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -1,13 +1,11 @@
 "use strict";
-const assert = require("assert");
 const utils = require("./doc-utils");
 const willBreak = utils.willBreak;
 
 function assertDoc(val) {
-  assert(
-    typeof val === "string" || val != null && typeof val.type === "string",
-    "Value is a valid document"
-  );
+  if (!(typeof val === "string" || val != null && typeof val.type === "string")) {
+    throw new Error("Value " + JSON.stringify(val) + " is not a valid document");
+  }
 }
 
 function concat(parts) {


### PR DESCRIPTION
Right now it says that the boolean expression fails which is not super useful. Instead, now it prints the actual value.