### PR TITLE
Remove `multilineGroup`

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -24,11 +24,12 @@ line, but if it doesn't fit it will break the outermost group first
 and try again. It will continue breaking groups until everything fits
 (or there are no more groups to break).
 
-### multilineGroup
-
-This is the same as `group`, but with an additional behavior: if this
-group spans any other groups that have hard breaks (see below) this
-group *always* breaks. Otherwise it acts the same as `group`.
+A document can force parent groups to break by including `breakParent`
+(see below). A hard and literal line automatically include this so
+they always break parent groups. Breaks are propagated to all parent
+groups, so if a deeply nested expression has a hard break, everything
+with break. This only matters for "hard" breaks, i.e. newlines that
+are printed no matter what and can be statically analyzed.
 
 For example, an array will try to fit on one line:
 
@@ -52,6 +53,20 @@ array will *always* break as well:
 Functions always break after the opening curly brace no matter what,
 so the array breaks as well for consistent formatting. See the
 implementation of `ArrayExpression` for an example.
+
+### breakParent
+
+Include this anywhere to force all parent groups to break. See `group`
+for more info. Example:
+
+```js
+group(concat([
+  " ",
+  expr,
+  " ",
+  breakParent
+]))
+```
 
 ### join
 

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -35,13 +35,6 @@ function group(contents, opts) {
   };
 }
 
-function multilineGroup(contents, opts) {
-  return group(
-    contents,
-    Object.assign(opts || {}, { shouldBreak: willBreak(contents) })
-  );
-}
-
 function conditionalGroup(states, opts) {
   return group(
     states[0],
@@ -64,7 +57,7 @@ const breakParent =  { type: "break-parent" };
 const line = { type: "line" };
 const softline = { type: "line", soft: true };
 const hardline = concat([{ type: "line", hard: true }, breakParent ]);
-const literalline = { type: "line", hard: true, literal: true };
+const literalline = concat([{ type: "line", hard: true, literal: true }, breakParent ]);
 
 function join(sep, arr) {
   var res = [];
@@ -88,7 +81,6 @@ module.exports = {
   hardline,
   literalline,
   group,
-  multilineGroup,
   conditionalGroup,
   breakParent,
   ifBreak,

--- a/src/doc-debug.js
+++ b/src/doc-debug.js
@@ -19,8 +19,8 @@ function flattenDoc(doc) {
 
   } else if (doc.type === "if-break") {
     return Object.assign({}, doc, {
-      breakContents: doc.breakContents ? flattenDoc(doc.breakContents) : null,
-      flatContents: doc.flatContents ? flattenDoc(doc.flatContents) : null
+      breakContents: doc.breakContents != null ? flattenDoc(doc.breakContents) : null,
+      flatContents: doc.flatContents != null ? flattenDoc(doc.flatContents) : null
     });
 
   } else if (doc.type === "group") {

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -179,7 +179,8 @@ Observable
 
 /* Comments in JSX tag are placed in a non optimal way*/
 <div
-/* comment*/ />;
+/* comment*/
+/>;
 
 // Comments disappear in empty blocks
 if (1) {
@@ -379,7 +380,8 @@ Observable
 
 // Comments in JSX tag are placed in a non optimal way
 <// comment
-div />;
+div
+/>;
 
 // Comments disappear in empty blocks
 if (1) {

--- a/tests/trailing_whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/trailing_whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -18,7 +18,8 @@ export type Result<T, V> =
 \`
    
    
-\` + \`
+\` +
+  \`
     
     
 \`;


### PR DESCRIPTION
Starting to convert all `multilineGroup`s into normal `group`s. This inverts the logic in some places and we need to be sure that the right nodes break the parents correctly. This is making code a bit more consistent already.