### PR TITLE
docs: add related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ features enabled, but you can also use
 All of JSX and Flow syntax is supported. In fact, the test suite in
 `tests` *is* the entire Flow test suite and they all pass.
 
+## Related Projects
+
+- [`prettier-eslint`](https://github.com/kentcdodds/prettier-eslint)
+passes `prettier` output to `eslint --fix`
+- [`prettier-standard-formatter`](https://github.com/dtinth/prettier-standard-formatter)
+passes `prettier` output to `standard --fix`
+
+
 ## Technical Details
 
 This printer is a fork of

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ All of JSX and Flow syntax is supported. In fact, the test suite in
 passes `prettier` output to `eslint --fix`
 - [`prettier-standard-formatter`](https://github.com/dtinth/prettier-standard-formatter)
 passes `prettier` output to `standard --fix`
+- [`prettier-with-tabs`](https://github.com/arijs/prettier-with-tabs)
+allows you to configure prettier to use `tabs`
 
 
 ## Technical Details


### PR DESCRIPTION
I think it may help adoption of `prettier` if people don't have to change their entire coding style all at once. These projects enable that.

Figured it'd be just as easy to create a PR as it would be to ask first :)