### PR TITLE
Support printing import("a")

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -458,6 +458,10 @@ function genericPrintNoParens(path, options, print) {
       parts.push(path.call(print, "source"), ";");
 
       return concat(parts);
+
+    case "Import": {
+      return "import";
+    }
     case "BlockStatement": {
       var naked = path.call(
         function(bodyPath) {

--- a/tests/dynamic_import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/dynamic_import/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,8 @@
+exports[`test test.js 1`] = `
+"import(\"module.js\");
+import(\"module.js\").then((a) => a);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import(\"module.js\");
+import(\"module.js\").then(a => a);
+"
+`;

--- a/tests/dynamic_import/jsfmt.spec.js
+++ b/tests/dynamic_import/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, {parser: 'babylon'});

--- a/tests/dynamic_import/test.js
+++ b/tests/dynamic_import/test.js
@@ -1,0 +1,2 @@
+import("module.js");
+import("module.js").then((a) => a);


### PR DESCRIPTION
Fixes https://github.com/jlongster/prettier/issues/457

Did the same as babel-generator (https://github.com/babel/babel/pull/4945)