### PR TITLE
Put decorators on the same line

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -51,9 +51,12 @@ function genericPrint(path, options, printPath) {
       // responsible for printing node.decorators.
       !util.getParentExportDeclaration(path)
   ) {
+    const separator = node.decorators.length === 1 &&
+      node.decorators[0].expression.type === "Identifier"
+      ? " " : hardline;
     path.each(
       function(decoratorPath) {
-        parts.push(printPath(decoratorPath), line);
+        parts.push(printPath(decoratorPath), separator);
       },
       "decorators"
     );

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,64 @@
+exports[`test mobx.js 1`] = `
+"import {observable} from \"mobx\";
+
+@observer class OrderLine {
+  @observable price:number = 0;
+  @observable amount:number = 1;
+
+  constructor(price) {
+    this.price = price;
+  }
+
+  @computed get total() {
+    return this.price * this.amount;
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import { observable } from \"mobx\";
+
+@observer class OrderLine {
+  @observable price: number = 0;
+  @observable amount: number = 1;
+
+  constructor(price) {
+    this.price = price;
+  }
+
+  @computed get total() {
+    return this.price * this.amount;
+  }
+}
+"
+`;
+
+exports[`test multiple.js 1`] = `
+"const dog = {
+  @readonly
+  @nonenumerable
+  @doubledValue
+  legs: 4
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const dog = {
+  @readonly
+  @nonenumerable
+  @doubledValue
+  legs: 4
+};
+"
+`;
+
+exports[`test redux.js 1`] = `
+"@connect(mapStateToProps, mapDispatchToProps)
+export class MyApp extends React.Component {}
+
+@connect(state => ({ todos: state.todos }))
+export class Home extends React.Component {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@connect(mapStateToProps, mapDispatchToProps)
+export class MyApp extends React.Component {}
+
+@connect(state => ({ todos: state.todos }))
+export class Home extends React.Component {}
+"
+`;

--- a/tests/decorators/jsfmt.spec.js
+++ b/tests/decorators/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, {parser: 'babylon'});

--- a/tests/decorators/mobx.js
+++ b/tests/decorators/mobx.js
@@ -1,0 +1,14 @@
+import {observable} from "mobx";
+
+@observer class OrderLine {
+  @observable price:number = 0;
+  @observable amount:number = 1;
+
+  constructor(price) {
+    this.price = price;
+  }
+
+  @computed get total() {
+    return this.price * this.amount;
+  }
+}

--- a/tests/decorators/multiple.js
+++ b/tests/decorators/multiple.js
@@ -1,0 +1,6 @@
+const dog = {
+  @readonly
+  @nonenumerable
+  @doubledValue
+  legs: 4
+};

--- a/tests/decorators/redux.js
+++ b/tests/decorators/redux.js
@@ -1,0 +1,5 @@
+@connect(mapStateToProps, mapDispatchToProps)
+export class MyApp extends React.Component {}
+
+@connect(state => ({ todos: state.todos }))
+export class Home extends React.Component {}


### PR DESCRIPTION
Mobx is the only popular JavaScript library that I know about which uses decorators. They put things on the same line so we should follow their conventions.

The logic implemented here is the following: if there is one decorator, it's on the same line. If there is more than one, they are each on their own line.

Fixes #325