### PR TITLE
Make CallExpression a group outside of member chains

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -534,10 +534,10 @@ function genericPrintNoParens(path, options, print) {
         }
       }
 
-      return concat([
+      return group(concat([
         path.call(print, "callee"),
         printArgumentsList(path, options, print)
-      ]);
+      ]));
     }
 
     case "ObjectExpression":

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,116 @@
+exports[`test break-last-call.js 1`] = `
+"export default store => {
+  return callApi(endpoint, schema).then(
+    response => next(actionWith({
+      response,
+      type: successType
+    })),
+    error => next(actionWith({
+      type: failureType,
+      error: error.message || \'Something bad happened\'
+    }))
+  )
+}
+
+it(\'should group messages with same created time\', () => {
+  expect(
+    groupMessages(messages).toJS(),
+  ).toEqual({
+    \'11/01/2017 13:36\': [
+      {message: \'test\', messageType: \'SMS\', status: \'Unknown\', created: \'11/01/2017 13:36\'},
+      {message: \'test\', messageType: \'Email\', status: \'Unknown\', created: \'11/01/2017 13:36\'},
+    ],
+    \'09/01/2017 17:25\': [
+      {message: \'te\', messageType: \'SMS\', status: \'Unknown\', created: \'09/01/2017 17:25\'},
+      {message: \'te\', messageType: \'Email\', status: \'Unknown\', created: \'09/01/2017 17:25\'},
+    ],
+    \'11/01/2017 13:33\': [
+      {message: \'test\', messageType: \'SMS\', status: \'Unknown\', created: \'11/01/2017 13:33\'},
+      {message: \'test\', messageType: \'Email\', status: \'Unknown\', created: \'11/01/2017 13:33\'},
+    ],
+    \'11/01/2017 13:37\': [
+      {message: \'test\', messageType: \'SMS\', status: \'Unknown\', created: \'11/01/2017 13:37\'},
+      {message: \'test\', messageType: \'Email\', status: \'Unknown\', created: \'11/01/2017 13:37\'},
+    ],
+  });
+});
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export default store => {
+  return callApi(endpoint, schema).then(
+    response => next(actionWith({ response, type: successType })),
+    error =>
+      next(
+        actionWith({
+          type: failureType,
+          error: error.message || \"Something bad happened\"
+        })
+      )
+  );
+};
+
+it(\"should group messages with same created time\", () => {
+  expect(groupMessages(messages).toJS()).toEqual({
+    \"11/01/2017 13:36\": [
+      {
+        message: \"test\",
+        messageType: \"SMS\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:36\"
+      },
+      {
+        message: \"test\",
+        messageType: \"Email\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:36\"
+      }
+    ],
+    \"09/01/2017 17:25\": [
+      {
+        message: \"te\",
+        messageType: \"SMS\",
+        status: \"Unknown\",
+        created: \"09/01/2017 17:25\"
+      },
+      {
+        message: \"te\",
+        messageType: \"Email\",
+        status: \"Unknown\",
+        created: \"09/01/2017 17:25\"
+      }
+    ],
+    \"11/01/2017 13:33\": [
+      {
+        message: \"test\",
+        messageType: \"SMS\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:33\"
+      },
+      {
+        message: \"test\",
+        messageType: \"Email\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:33\"
+      }
+    ],
+    \"11/01/2017 13:37\": [
+      {
+        message: \"test\",
+        messageType: \"SMS\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:37\"
+      },
+      {
+        message: \"test\",
+        messageType: \"Email\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:37\"
+      }
+    ]
+  });
+});
+"
+`;
+
 exports[`test test.js 1`] = `
 "method().then(x => x)
   [\"abc\"](x => x)

--- a/tests/method-chain/break-last-call.js
+++ b/tests/method-chain/break-last-call.js
@@ -1,0 +1,35 @@
+export default store => {
+  return callApi(endpoint, schema).then(
+    response => next(actionWith({
+      response,
+      type: successType
+    })),
+    error => next(actionWith({
+      type: failureType,
+      error: error.message || 'Something bad happened'
+    }))
+  )
+}
+
+it('should group messages with same created time', () => {
+  expect(
+    groupMessages(messages).toJS(),
+  ).toEqual({
+    '11/01/2017 13:36': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:36'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:36'},
+    ],
+    '09/01/2017 17:25': [
+      {message: 'te', messageType: 'SMS', status: 'Unknown', created: '09/01/2017 17:25'},
+      {message: 'te', messageType: 'Email', status: 'Unknown', created: '09/01/2017 17:25'},
+    ],
+    '11/01/2017 13:33': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:33'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:33'},
+    ],
+    '11/01/2017 13:37': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:37'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:37'},
+    ],
+  });
+});


### PR DESCRIPTION
This bug has annoyed me for a long time. It turns out that I was looking inside of `printMemberChain` but it actually didn't go through this code path!

Fixes #268