### PR TITLE
Fix spurious whitespace

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -627,7 +627,7 @@ function genericPrintNoParens(path, options, print) {
                   indent(options.tabWidth, concat([softline, printedValue]))
                 ])
               ),
-              line,
+              softline,
               ifBreak(")")
             ])
           );

--- a/tests/flow/logical/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/logical/__snapshots__/jsfmt.spec.js.snap
@@ -901,14 +901,14 @@ function logical12b(y: number): number {
  */
 function logical13(x: number): Array<{ x: string }> {
   return [
-    { x: x && \"bar\"  },
-    { x: true && \"bar\"  },
-    { x: true && false  },
-    { x: false && false  },
-    { x: 1 && \"bar\"  },
-    { x: \"foo\" && \"bar\"  },
-    { x: \"foo\" && \"bar\"  },
-    { x: \"foo\" && \"bar\"  }
+    { x: x && \"bar\" },
+    { x: true && \"bar\" },
+    { x: true && false },
+    { x: false && false },
+    { x: 1 && \"bar\" },
+    { x: \"foo\" && \"bar\" },
+    { x: \"foo\" && \"bar\" },
+    { x: \"foo\" && \"bar\" }
   ];
 }
 
@@ -917,14 +917,14 @@ function logical13(x: number): Array<{ x: string }> {
  */
 function logical14(x: number): Array<{ x: string }> {
   return [
-    { x: x || \"bar\"  },
-    { x: false || \"bar\"  },
-    { x: false || true  },
-    { x: true || false  },
-    { x: 0 || \"bar\"  },
-    { x: \"foo\" || \"bar\"  },
-    { x: \"foo\" || \"bar\"  },
-    { x: \"foo\" || \"bar\"  }
+    { x: x || \"bar\" },
+    { x: false || \"bar\" },
+    { x: false || true },
+    { x: true || false },
+    { x: 0 || \"bar\" },
+    { x: \"foo\" || \"bar\" },
+    { x: \"foo\" || \"bar\" },
+    { x: \"foo\" || \"bar\" }
   ];
 }
 

--- a/tests/trailing_comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/trailing_comma/__snapshots__/jsfmt.spec.js.snap
@@ -77,6 +77,11 @@ const aLong = {
   },
   dHasALongName: \'a-long-value-too\'
 };
+
+const aLong = {
+  dHasALongName: \'a-long-value-too\',
+  eHasABooleanExpression: a === a,
+};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const a = { b: true, c: { c1: \"hello\" }, d: false };
 
@@ -87,6 +92,11 @@ const aLong = {
     c2: \"a-really-really-long-value\"
   },
   dHasALongName: \"a-long-value-too\"
+};
+
+const aLong = {
+  dHasALongName: \"a-long-value-too\",
+  eHasABooleanExpression: a === a
 };
 "
 `;
@@ -108,6 +118,11 @@ const aLong = {
   },
   dHasALongName: \'a-long-value-too\'
 };
+
+const aLong = {
+  dHasALongName: \'a-long-value-too\',
+  eHasABooleanExpression: a === a,
+};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const a = { b: true, c: { c1: \"hello\" }, d: false };
 
@@ -118,6 +133,11 @@ const aLong = {
     c2: \"a-really-really-long-value\",
   },
   dHasALongName: \"a-long-value-too\",
+};
+
+const aLong = {
+  dHasALongName: \"a-long-value-too\",
+  eHasABooleanExpression: a === a,
 };
 "
 `;

--- a/tests/trailing_comma/object.js
+++ b/tests/trailing_comma/object.js
@@ -14,3 +14,8 @@ const aLong = {
   },
   dHasALongName: 'a-long-value-too'
 };
+
+const aLong = {
+  dHasALongName: 'a-long-value-too',
+  eHasABooleanExpression: a === a,
+};


### PR DESCRIPTION
This was introduced by #314 where `line` should have been `softline`. By the way, I was going to propose renaming `line` to `line_or_space` and `softline` to `line_or_nothing` which should make it more explicit what is going on.

Fixes #461