### PR TITLE
Preserve new lines after directives in babylon

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -115,6 +115,9 @@ function genericPrintNoParens(path, options, print) {
         path.each(
           function(childPath) {
             parts.push(print(childPath), ";", hardline);
+            if (util.newlineExistsAfter(options.originalText, util.locEnd(childPath.getValue()))) {
+              parts.push(hardline);
+            }
           },
           "directives"
         );

--- a/tests/directives/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/directives/__snapshots__/jsfmt.spec.js.snap
@@ -1,4 +1,56 @@
+exports[`test newline.js 1`] = `
+"/* @flow */
+
+\"use strict\";
+
+import a from \"a\";
+
+a();
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* @flow */
+
+\"use strict\";
+
+import a from \"a\";
+
+a();
+"
+`;
+
+exports[`test newline.js 2`] = `
+"/* @flow */
+
+\"use strict\";
+
+import a from \"a\";
+
+a();
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* @flow */
+\"use strict\";
+
+import a from \"a\";
+
+a();
+"
+`;
+
 exports[`test test.js 1`] = `
+"\"use strict\";
+
+function fn() {
+  \"use strict\";
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+\"use strict\";
+
+function fn() {
+  \"use strict\";
+}
+"
+`;
+
+exports[`test test.js 2`] = `
 "\"use strict\";
 
 function fn() {

--- a/tests/directives/jsfmt.spec.js
+++ b/tests/directives/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname);
+run_spec(__dirname, {parser: 'babylon'});

--- a/tests/directives/newline.js
+++ b/tests/directives/newline.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+"use strict";
+
+import a from "a";
+
+a();


### PR DESCRIPTION
It's annoying that the line after `"use strict";` gets eaten away on babylon. This fixes it :)

Fixes #216