### PR TITLE
Add break points for class declaration

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1196,7 +1196,7 @@ function genericPrintNoParens(path, options, print) {
       return concat(parts);
     case "ClassDeclaration":
     case "ClassExpression":
-      return concat(printClass(path, print));
+      return concat(printClass(path, options, print));
     case "TemplateElement":
       return join(literalline, n.value.raw.split("\n"));
     case "TemplateLiteral":
@@ -1285,7 +1285,7 @@ function genericPrintNoParens(path, options, print) {
     case "BooleanLiteralTypeAnnotation":
       return "" + n.value;
     case "DeclareClass":
-      return printFlowDeclaration(path, printClass(path, print));
+      return printFlowDeclaration(path, printClass(path, options, print));
     case "DeclareFunction":
       return printFlowDeclaration(path, [
         "function ",
@@ -1954,7 +1954,7 @@ function printFlowDeclaration(path, parts) {
   return concat(parts);
 }
 
-function printClass(path, print) {
+function printClass(path, options, print) {
   const n = path.getValue();
   const parts = [ "class" ];
 
@@ -1962,18 +1962,24 @@ function printClass(path, print) {
     parts.push(" ", path.call(print, "id"), path.call(print, "typeParameters"));
   }
 
+  const partsGroup = [];
   if (n.superClass) {
-    parts.push(
-      " extends ",
+    partsGroup.push(
+      line,
+      "extends ",
       path.call(print, "superClass"),
       path.call(print, "superTypeParameters")
     );
   } else if (n.extends && n.extends.length > 0) {
-    parts.push(" extends ", join(", ", path.map(print, "extends")));
+    partsGroup.push(line, "extends ", join(", ", path.map(print, "extends")));
   }
 
   if (n["implements"] && n["implements"].length > 0) {
-    parts.push(" implements ", join(", ", path.map(print, "implements")));
+    partsGroup.push(line, "implements ", join(", ", path.map(print, "implements")));
+  }
+
+  if (partsGroup.length > 0) {
+    parts.push(group(indent(options.tabWidth, concat(partsGroup))));
   }
 
   parts.push(" ", path.call(print, "body"));

--- a/tests/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/classes/__snapshots__/jsfmt.spec.js.snap
@@ -11,6 +11,19 @@ exports[`test binary.js 1`] = `
 "
 `;
 
+exports[`test break.js 1`] = `
+"class MyContractSelectionWidget extends React.Component<void,  MyContractSelectionWidgetPropsType, void> implements SomethingLarge {
+  method() {}
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class MyContractSelectionWidget
+  extends React.Component<void, MyContractSelectionWidgetPropsType, void>
+  implements SomethingLarge {
+  method() {}
+}
+"
+`;
+
 exports[`test call.js 1`] = `
 "(class {})(class {});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/classes/break.js
+++ b/tests/classes/break.js
@@ -1,0 +1,3 @@
+class MyContractSelectionWidget extends React.Component<void,  MyContractSelectionWidgetPropsType, void> implements SomethingLarge {
+  method() {}
+}


### PR DESCRIPTION
```js
class A extends B implements C {
  method() {}
}
```

now outputs

```js
class A
  extends B
  implements C {
  method() {}
}
```

Fixes #147