### PR TITLE
[RFC] Reimplement MemberExpression printing

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,0 +1,5 @@
+Object.keys(items)
+  // test
+  .map(() => {a})
+  // test 2
+  .filter(() => {a});

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -228,12 +228,14 @@ export type BuckWebSocketMessage =
   };
 
 // Missing one level of indentation because of the comment
-const rootEpic = (actions, store) =>
-  combineEpics(...epics)(actions, store).// Log errors and continue.
-  catch((err, stream) => {
-    getLogger().error(err);
-    return stream;
-  });
+const rootEpic = (actions, store) => combineEpics(...epics)(
+  actions,
+  store
+).// Log errors and continue.
+catch((err, stream) => {
+  getLogger().error(err);
+  return stream;
+});
 
 // Two extra levels of indentation because of the comment
 export type AsyncExecuteOptions =
@@ -258,11 +260,12 @@ const regex = new RegExp(
 import path from \"path\"; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
 
 // Comments disappear in-between MemberExpressions
-Observable.of(process).// Don\'t complete until we say so!
-merge(Observable.never()).// Get the errors.
-takeUntil(
-  throwOnError ? errors.flatMap(Observable.throw) : errors
-).takeUntil(exit);
+Observable.of(process)
+  .// Don\'t complete until we say so!
+  merge(Observable.never())
+  .// Get the errors.
+  takeUntil(throwOnError ? errors.flatMap(Observable.throw) : errors)
+  .takeUntil(exit);
 
 /* Comments disappear inside of JSX*/
 <div>
@@ -455,12 +458,14 @@ export type BuckWebSocketMessage =
   };
 
 // Missing one level of indentation because of the comment
-const rootEpic = (actions, store) =>
-  combineEpics(...epics)(actions, store).// Log errors and continue.
-  catch((err, stream) => {
-    getLogger().error(err);
-    return stream;
-  });
+const rootEpic = (actions, store) => combineEpics(...epics)(
+  actions,
+  store
+).// Log errors and continue.
+catch((err, stream) => {
+  getLogger().error(err);
+  return stream;
+});
 
 // Two extra levels of indentation because of the comment
 export type AsyncExecuteOptions =
@@ -485,11 +490,12 @@ const regex = new RegExp(
 import path from \"path\"; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
 
 // Comments disappear in-between MemberExpressions
-Observable.of(process).// Don\'t complete until we say so!
-merge(Observable.never()).// Get the errors.
-takeUntil(
-  throwOnError ? errors.flatMap(Observable.throw) : errors
-).takeUntil(exit);
+Observable.of(process)
+  .// Don\'t complete until we say so!
+  merge(Observable.never())
+  .// Get the errors.
+  takeUntil(throwOnError ? errors.flatMap(Observable.throw) : errors)
+  .takeUntil(exit);
 
 // Comments disappear inside of JSX
 <div>

--- a/tests/flow/array-filter/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/array-filter/__snapshots__/jsfmt.spec.js.snap
@@ -41,13 +41,15 @@ console.log(filteredItems);
 /* @flow */
 
 function filterItems(items: Array<string | number>): Array<string | number> {
-  return items.map(item => {
-    if (typeof item === \"string\") {
-      return item.length > 2 ? item : null;
-    } else {
-      return item * 10;
-    }
-  }).filter(Boolean);
+  return items
+    .map(item => {
+      if (typeof item === \"string\") {
+        return item.length > 2 ? item : null;
+      } else {
+        return item * 10;
+      }
+    })
+    .filter(Boolean);
 }
 
 const filteredItems = filterItems([\"foo\", \"b\", 1, 2]);

--- a/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
@@ -503,8 +503,7 @@ Promise.reject(Promise.resolve(0)).then(function(num) {
 //////////////////////////////////
 
 // resolvedPromise.then():T -> then(T)
-Promise
-  .resolve(0)
+Promise.resolve(0)
   .then(function(num) {
     return \"asdf\";
   })
@@ -514,8 +513,7 @@ Promise
   });
 
 // resolvedPromise.then():Promise<T> -> then(T)
-Promise
-  .resolve(0)
+Promise.resolve(0)
   .then(function(num) {
     return Promise.resolve(\"asdf\");
   })
@@ -525,8 +523,7 @@ Promise
   });
 
 // resolvedPromise.then():Promise<Promise<T>> -> then(T)
-Promise
-  .resolve(0)
+Promise.resolve(0)
   .then(function(num) {
     return Promise.resolve(Promise.resolve(\"asdf\"));
   })
@@ -536,8 +533,7 @@ Promise
   });
 
 // TODO: resolvedPromise.then(<throw(T)>) -> catch(T)
-Promise
-  .resolve(0)
+Promise.resolve(0)
   .then(function(num) {
     throw \"str\";
   })
@@ -553,8 +549,7 @@ Promise
 ///////////////////////////////////
 
 // rejectedPromise.catch():U -> then(U)
-Promise
-  .reject(0)
+Promise.reject(0)
   .catch(function(num) {
     return \"asdf\";
   })
@@ -564,8 +559,7 @@ Promise
   });
 
 // rejectedPromise.catch():Promise<U> -> then(U)
-Promise
-  .reject(0)
+Promise.reject(0)
   .catch(function(num) {
     return Promise.resolve(\"asdf\");
   })
@@ -575,8 +569,7 @@ Promise
   });
 
 // rejectedPromise.catch():Promise<Promise<U>> -> then(U)
-Promise
-  .reject(0)
+Promise.reject(0)
   .catch(function(num) {
     return Promise.resolve(Promise.resolve(\"asdf\"));
   })
@@ -586,15 +579,12 @@ Promise
   });
 
 // TODO: resolvedPromise<T> -> catch() -> then():T
-Promise
-  .resolve(0)
-  .catch(function(err) {})
-  .then(function(num) {
-    var a: number = num;
+Promise.resolve(0).catch(function(err) {}).then(function(num) {
+  var a: number = num;
 
-    // TODO
-    var b: string = num; // Error: string ~> number
-  });
+  // TODO
+  var b: string = num; // Error: string ~> number
+});
 "
 `;
 

--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -21,8 +21,7 @@ export default function searchUsers(action$) {
     .map(action => action.payload.query)
     .filter(q => !!q)
     .switchMap(q =>
-      Observable
-        .timer(800)
+      Observable.timer(800)
         .takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS))
         .mergeMap(() =>
           Observable.merge(

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,157 @@
+exports[`test break-last-call.js 1`] = `
+"export default store => {
+  return callApi(endpoint, schema).then(
+    response => next(actionWith({
+      response,
+      type: successType
+    })),
+    error => next(actionWith({
+      type: failureType,
+      error: error.message || \'Something bad happened\'
+    }))
+  )
+}
+
+it(\'should group messages with same created time\', () => {
+  expect(
+    groupMessages(messages).toJS(),
+  ).toEqual({
+    \'11/01/2017 13:36\': [
+      {message: \'test\', messageType: \'SMS\', status: \'Unknown\', created: \'11/01/2017 13:36\'},
+      {message: \'test\', messageType: \'Email\', status: \'Unknown\', created: \'11/01/2017 13:36\'},
+    ],
+    \'09/01/2017 17:25\': [
+      {message: \'te\', messageType: \'SMS\', status: \'Unknown\', created: \'09/01/2017 17:25\'},
+      {message: \'te\', messageType: \'Email\', status: \'Unknown\', created: \'09/01/2017 17:25\'},
+    ],
+    \'11/01/2017 13:33\': [
+      {message: \'test\', messageType: \'SMS\', status: \'Unknown\', created: \'11/01/2017 13:33\'},
+      {message: \'test\', messageType: \'Email\', status: \'Unknown\', created: \'11/01/2017 13:33\'},
+    ],
+    \'11/01/2017 13:37\': [
+      {message: \'test\', messageType: \'SMS\', status: \'Unknown\', created: \'11/01/2017 13:37\'},
+      {message: \'test\', messageType: \'Email\', status: \'Unknown\', created: \'11/01/2017 13:37\'},
+    ],
+  });
+});
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export default store => {
+  return callApi(endpoint, schema).then(
+    response => next(
+      actionWith({
+        response,
+        type: successType
+      })
+    ),
+    error => next(
+      actionWith({
+        type: failureType,
+        error: error.message || \"Something bad happened\"
+      })
+    )
+  );
+};
+
+it(\"should group messages with same created time\", () => {
+  expect(groupMessages(messages).toJS()).toEqual({
+    \"11/01/2017 13:36\": [
+      {
+        message: \"test\",
+        messageType: \"SMS\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:36\"
+      },
+      {
+        message: \"test\",
+        messageType: \"Email\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:36\"
+      }
+    ],
+    \"09/01/2017 17:25\": [
+      {
+        message: \"te\",
+        messageType: \"SMS\",
+        status: \"Unknown\",
+        created: \"09/01/2017 17:25\"
+      },
+      {
+        message: \"te\",
+        messageType: \"Email\",
+        status: \"Unknown\",
+        created: \"09/01/2017 17:25\"
+      }
+    ],
+    \"11/01/2017 13:33\": [
+      {
+        message: \"test\",
+        messageType: \"SMS\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:33\"
+      },
+      {
+        message: \"test\",
+        messageType: \"Email\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:33\"
+      }
+    ],
+    \"11/01/2017 13:37\": [
+      {
+        message: \"test\",
+        messageType: \"SMS\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:37\"
+      },
+      {
+        message: \"test\",
+        messageType: \"Email\",
+        status: \"Unknown\",
+        created: \"11/01/2017 13:37\"
+      }
+    ]
+  });
+});
+"
+`;
+
+exports[`test multiple-members.js 1`] = `
+"if (testConfig.ENABLE_ONLINE_TESTS === \"true\") {
+  describe(\"POST /users/me/pet\", function() {
+    it(\"saves pet\", function() {
+      function assert(pet) {
+        expect(pet).to.have.property(\"OwnerAddress\").that.deep.equals({
+          AddressLine1: \"Alexanderstrasse\",
+          AddressLine2: \"\",
+          PostalCode: \"10999\",
+          Region: \"Berlin\",
+          City: \"Berlin\",
+          Country: \"DE\"
+        });
+      }
+    });
+  });
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+if (testConfig.ENABLE_ONLINE_TESTS === \"true\") {
+  describe(\"POST /users/me/pet\", function() {
+    it(\"saves pet\", function() {
+      function assert(pet) {
+        expect(pet).to.have.property(\"OwnerAddress\").that.deep.equals({
+          AddressLine1: \"Alexanderstrasse\",
+          AddressLine2: \"\",
+          PostalCode: \"10999\",
+          Region: \"Berlin\",
+          City: \"Berlin\",
+          Country: \"DE\"
+        });
+      }
+    });
+  });
+}
+"
+`;
+
 exports[`test test.js 1`] = `
 "method().then(x => x)
   [\"abc\"](x => x)
@@ -6,10 +160,7 @@ exports[`test test.js 1`] = `
 ({}.a().b());
 ({}).a().b();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-method()
-  .then(x => x)
-  [\"abc\"](x => x)
-  [abc](x => x);
+method().then(x => x)[\"abc\"](x => x)[abc](x => x);
 
 ({}).a().b();
 ({}).a().b();

--- a/tests/method-chain/break-last-call.js
+++ b/tests/method-chain/break-last-call.js
@@ -1,0 +1,35 @@
+export default store => {
+  return callApi(endpoint, schema).then(
+    response => next(actionWith({
+      response,
+      type: successType
+    })),
+    error => next(actionWith({
+      type: failureType,
+      error: error.message || 'Something bad happened'
+    }))
+  )
+}
+
+it('should group messages with same created time', () => {
+  expect(
+    groupMessages(messages).toJS(),
+  ).toEqual({
+    '11/01/2017 13:36': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:36'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:36'},
+    ],
+    '09/01/2017 17:25': [
+      {message: 'te', messageType: 'SMS', status: 'Unknown', created: '09/01/2017 17:25'},
+      {message: 'te', messageType: 'Email', status: 'Unknown', created: '09/01/2017 17:25'},
+    ],
+    '11/01/2017 13:33': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:33'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:33'},
+    ],
+    '11/01/2017 13:37': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:37'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:37'},
+    ],
+  });
+});

--- a/tests/method-chain/multiple-members.js
+++ b/tests/method-chain/multiple-members.js
@@ -1,0 +1,16 @@
+if (testConfig.ENABLE_ONLINE_TESTS === "true") {
+  describe("POST /users/me/pet", function() {
+    it("saves pet", function() {
+      function assert(pet) {
+        expect(pet).to.have.property("OwnerAddress").that.deep.equals({
+          AddressLine1: "Alexanderstrasse",
+          AddressLine2: "",
+          PostalCode: "10999",
+          Region: "Berlin",
+          City: "Berlin",
+          Country: "DE"
+        });
+      }
+    });
+  });
+}


### PR DESCRIPTION
There are currently three issues related to suboptimal rendering of MemberExpression chains. The previous implementation was trying to flatten only a single group at the same time, but it didn't work well because we didn't have the full context to be able to make decisions.

In this implementation, I'm going through the entire chain at the same time and group it into logical units and make decisions based on this. It solves all the problems I can think of and if we need to tweak it in the future, it should be easy.

Fixes #268
Fixes #212
Fixes #21