### PR TITLE
[RFC] Hug Conditionals in JSX

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1086,14 +1086,20 @@ function genericPrintNoParens(path, options, print) {
       ]);
     case "JSXSpreadAttribute":
       return concat([ "{...", path.call(print, "argument"), "}" ]);
-    case "JSXExpressionContainer":
-      const shouldIndent = n.expression.type !== "ArrayExpression" &&
-        n.expression.type !== "ObjectExpression" &&
-        n.expression.type !== "ArrowFunctionExpression" &&
-        n.expression.type !== "CallExpression" &&
-        n.expression.type !== "FunctionExpression";
+    case "JSXExpressionContainer": {
+      const parent = path.getParentNode(0);
 
-      if (!shouldIndent) {
+      const shouldInline = n.expression.type === "ArrayExpression" ||
+        n.expression.type === "ObjectExpression" ||
+        n.expression.type === "ArrowFunctionExpression" ||
+        n.expression.type === "CallExpression" ||
+        n.expression.type === "FunctionExpression" ||
+        parent.type === "JSXElement" && (
+          n.expression.type === "ConditionalExpression" ||
+          n.expression.type === "LogicalExpression"
+        );
+
+      if (shouldInline) {
         return concat([ "{", path.call(print, "expression"), "}" ]);
       }
 
@@ -1108,6 +1114,7 @@ function genericPrintNoParens(path, options, print) {
           "}"
         ])
       );
+    }
     case "JSXElement": {
       const elem = printJSXElement(path, options, print);
       return maybeWrapJSXElementInParens(path, elem, options);
@@ -2299,7 +2306,8 @@ function maybeWrapJSXElementInParens(path, elem, options) {
     JSXElement: true,
     ExpressionStatement: true,
     CallExpression: true,
-    ConditionalExpression: true
+    ConditionalExpression: true,
+    LogicalExpression: true,
   };
   if (NO_WRAP_PARENTS[parent.type]) {
     return elem;

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -190,45 +190,39 @@ const renderTernary = props => (
     size=\"large\"
     submitLabel=\"Sign in with Google\"
   >
-    {
-      props.showTheThing
-        ? <BaseForm
-          url=\"/auth/google\"
-          method=\"GET\"
-          colour=\"blue\"
-          size=\"large\"
-          submitLabel=\"Sign in with Google\"
-        >
-          Hello world
-        </BaseForm>
-        : \"hello \" + \"howdy! \"
-    }
-    {
-      props.showTheThing
-        ? <BaseForm
-          url=\"/auth/google\"
-          method=\"GET\"
-          colour=\"blue\"
-          size=\"large\"
-          submitLabel=\"Sign in with Google\"
-        >
-          Hello world
-        </BaseForm>
-        : null
-    }
-    {
-      props.showTheThing
-        ? null
-        : <BaseForm
-          url=\"/auth/google\"
-          method=\"GET\"
-          colour=\"blue\"
-          size=\"large\"
-          submitLabel=\"Sign in with Google\"
-        >
-          Hello world
-        </BaseForm>
-    }
+    {props.showTheThing
+      ? <BaseForm
+        url=\"/auth/google\"
+        method=\"GET\"
+        colour=\"blue\"
+        size=\"large\"
+        submitLabel=\"Sign in with Google\"
+      >
+        Hello world
+      </BaseForm>
+      : \"hello \" + \"howdy! \"}
+    {props.showTheThing
+      ? <BaseForm
+        url=\"/auth/google\"
+        method=\"GET\"
+        colour=\"blue\"
+        size=\"large\"
+        submitLabel=\"Sign in with Google\"
+      >
+        Hello world
+      </BaseForm>
+      : null}
+    {props.showTheThing
+      ? null
+      : <BaseForm
+        url=\"/auth/google\"
+        method=\"GET\"
+        colour=\"blue\"
+        size=\"large\"
+        submitLabel=\"Sign in with Google\"
+      >
+        Hello world
+      </BaseForm>}
     {props.showTheOtherThing ? <div>I am here</div> : <div attr=\"blah\" />}
     {props.showTheOtherThing ? <div>I am here!!</div> : null}
   </BaseForm>

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -123,6 +123,66 @@ exports[`test expression.js 1`] = `
 "
 `;
 
+exports[`test hug.js 1`] = `
+"<div>
+  {__DEV__
+    ? this.renderDevApp()
+    : <div>
+      {routes.map(route => (
+        <MatchAsync
+          key={\`\${route.to}-async\`}
+          pattern={route.to}
+          exactly={route.to === \"/\"}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>}
+</div>;
+
+<div>
+  {__DEV__ && <div>
+    {routes.map(route => (
+      <MatchAsync
+        key={\`\${route.to}-async\`}
+        pattern={route.to}
+        exactly={route.to === \"/\"}
+        getComponent={routeES6Modules[route.value]}
+      />
+    ))}
+    </div>}
+</div>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div>
+  {__DEV__
+    ? this.renderDevApp()
+    : <div>
+      {routes.map(route => (
+        <MatchAsync
+          key={\`\${route.to}-async\`}
+          pattern={route.to}
+          exactly={route.to === \"/\"}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>}
+</div>;
+
+<div>
+  {__DEV__ &&
+    <div>
+      {routes.map(route => (
+        <MatchAsync
+          key={\`\${route.to}-async\`}
+          pattern={route.to}
+          exactly={route.to === \"/\"}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>}
+</div>;
+"
+`;
+
 exports[`test quotes.js 1`] = `
 "<div id=\"&quot;\'<>&amp;quot;\" />;
 <div id=\'\"&#39;<>&amp;quot;\' />;

--- a/tests/jsx/hug.js
+++ b/tests/jsx/hug.js
@@ -1,0 +1,27 @@
+<div>
+  {__DEV__
+    ? this.renderDevApp()
+    : <div>
+      {routes.map(route => (
+        <MatchAsync
+          key={`${route.to}-async`}
+          pattern={route.to}
+          exactly={route.to === "/"}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>}
+</div>;
+
+<div>
+  {__DEV__ && <div>
+    {routes.map(route => (
+      <MatchAsync
+        key={`${route.to}-async`}
+        pattern={route.to}
+        exactly={route.to === "/"}
+        getComponent={routeES6Modules[route.value]}
+      />
+    ))}
+    </div>}
+</div>;


### PR DESCRIPTION
Conditionals are very common in JSX and it is unfortunate that they take up so much vertical space in the current prettier.

This pull request does a few tweaks:
 - It hugs ConditionalExpression (ternary) and LogicalExpression (&&) inside of `{}` in a jsx child, not an attribute
 - It doesn't output parenthesis if your parent is a LogicalExpression (&&)

Fixes #317