### PR TITLE
Refactor comment algorithm and improve newline/spaces detection

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -8,6 +8,8 @@ var fromString = docBuilders.fromString;
 var concat = docBuilders.concat;
 var hardline = docBuilders.hardline;
 var breakParent = docBuilders.breakParent;
+var indent = docBuilders.indent;
+var lineSuffix = docBuilders.lineSuffix;
 var util = require("./util");
 var comparePos = util.comparePos;
 var childNodesCacheKey = Symbol("child-nodes");
@@ -70,7 +72,7 @@ function getSortedChildNodes(node, text, resultArray) {
 // least one of which is guaranteed to be defined.
 function decorateComment(node, comment, text) {
   var childNodes = getSortedChildNodes(node, text);
-
+  var precedingNode, followingNode;
   // Time to dust off the old binary search robes and wizard hat.
   var left = 0, right = childNodes.length;
   while (left < right) {
@@ -83,6 +85,14 @@ function decorateComment(node, comment, text) {
     ) {
       // The comment is completely contained by this child node.
       comment.enclosingNode = child;
+
+      if (middle > 0) {
+        // Store the global preceding node separately from
+        // `precedingNode` because they mean different things. This is
+        // the previous node, ignoring any delimiters/blocks/etc.
+        comment.globalPrecedingNode = childNodes[middle - 1];
+      }
+
       decorateComment(child, comment, text);
       return; // Abandon the binary search at this level.
     }
@@ -92,7 +102,7 @@ function decorateComment(node, comment, text) {
       // Because we will never consider this node or any nodes
       // before it again, this node must be the closest preceding
       // node we have encountered so far.
-      var precedingNode = child;
+      precedingNode = child;
       left = middle + 1;
       continue;
     }
@@ -102,7 +112,7 @@ function decorateComment(node, comment, text) {
       // Because we will never consider this node or any nodes after
       // it again, this node must be the closest following node we
       // have encountered so far.
-      var followingNode = child;
+      followingNode = child;
       right = middle;
       continue;
     }
@@ -117,6 +127,7 @@ function decorateComment(node, comment, text) {
   if (followingNode) {
     comment.followingNode = followingNode;
   }
+
 }
 
 function attach(comments, ast, text) {
@@ -129,40 +140,66 @@ function attach(comments, ast, text) {
   comments.forEach(function(comment) {
     decorateComment(ast, comment, text);
 
-    var pn = comment.precedingNode;
-    var en = comment.enclosingNode;
-    var fn = comment.followingNode;
+    const precedingNode = comment.precedingNode;
+    const globalPrecedingNode = comment.globalPrecedingNode;
+    const enclosingNode = comment.enclosingNode;
+    const followingNode = comment.followingNode;
+    const isStartOfFile = comment.loc.start.line === 1;
 
-    if (pn && fn) {
-      var tieCount = tiesToBreak.length;
-      if (tieCount > 0) {
-        var lastTie = tiesToBreak[tieCount - 1];
+    if (
+      util.hasNewline(text, locStart(comment), { backwards: true }) ||
+        isStartOfFile
+    ) {
+      // If a comment exists on its own line, prefer a leading comment.
+      // We also need to check if it's the first line of the file.
 
-        assert.strictEqual(
-          lastTie.precedingNode === comment.precedingNode,
-          lastTie.followingNode === comment.followingNode
-        );
-
-        if (lastTie.followingNode !== comment.followingNode) {
-          breakTies(tiesToBreak, text);
-        }
+      if (followingNode) {
+        // Always a leading comment.
+        addLeadingComment(followingNode, comment);
+      } else if (precedingNode) {
+        addTrailingComment(precedingNode, comment);
+      } else if (enclosingNode) {
+        addDanglingComment(enclosingNode, comment);
+      } else {
+        // TODO: If there are no nodes at all, we should still somehow
+        // print the comment.
       }
 
-      tiesToBreak.push(comment);
-    } else if (pn) {
-      // No contest: we have a trailing comment.
-      breakTies(tiesToBreak, text);
-      addTrailingComment(pn, comment);
-    } else if (fn) {
-      // No contest: we have a leading comment.
-      breakTies(tiesToBreak, text);
-      addLeadingComment(fn, comment);
-    } else if (en) {
-      // The enclosing node has no child nodes at all, so what we
-      // have here is a dangling comment, e.g. [/* crickets */].
-      breakTies(tiesToBreak, text);
-      addDanglingComment(en, comment);
+    } else if(util.hasNewline(text, locEnd(comment))) {
+      // There is content before this comment on the same line, but
+      // none after it, so prefer a trailing comment. A trailing
+      // comment *always* attaches itself to the previous node, no
+      // matter if there's any syntax between them.
+      const lastNode = precedingNode || globalPrecedingNode;
+      if (lastNode) {
+        // Always a trailing comment
+        addTrailingComment(lastNode, comment);
+      }
+      else {
+        throw new Error("Preceding node not found");
+      }
     } else {
+      // Otherwise, text exists both before and after the comment on
+      // the same line. If there is both a preceding and following
+      // node, use a tie-breaking algorithm to determine if it should
+      // be attached to the next or previous node. In the last case,
+      // simply attach the right node;
+      if(precedingNode && followingNode) {
+        const tieCount = tiesToBreak.length;
+        if (tieCount > 0) {
+          var lastTie = tiesToBreak[tieCount - 1];
+          if (lastTie.followingNode !== comment.followingNode) {
+            breakTies(tiesToBreak, text);
+          }
+        }
+        tiesToBreak.push(comment);
+      }
+      else if(precedingNode) {
+        addTrailingComment(precedingNode, comment);
+      }
+      else if(followingNode) {
+        addLeadingComment(followingNode, comment);
+      }
     }
   });
 
@@ -184,13 +221,13 @@ function breakTies(tiesToBreak, text) {
     return;
   }
 
-  var pn = tiesToBreak[0].precedingNode;
-  var fn = tiesToBreak[0].followingNode;
-  var gapEndPos = locStart(fn);
+  var precedingNode = tiesToBreak[0].precedingNode;
+  var followingNode = tiesToBreak[0].followingNode;
+  var gapEndPos = locStart(followingNode);
 
   // Iterate backwards through tiesToBreak, examining the gaps
   // between the tied comments. In order to qualify as leading, a
-  // comment must be separated from fn by an unbroken series of
+  // comment must be separated from followingNode by an unbroken series of
   // whitespace-only gaps (or other comments).
   for (
     var indexOfFirstLeadingComment = tieCount;
@@ -198,8 +235,8 @@ function breakTies(tiesToBreak, text) {
     --indexOfFirstLeadingComment
   ) {
     var comment = tiesToBreak[indexOfFirstLeadingComment - 1];
-    assert.strictEqual(comment.precedingNode, pn);
-    assert.strictEqual(comment.followingNode, fn);
+    assert.strictEqual(comment.precedingNode, precedingNode);
+    assert.strictEqual(comment.followingNode, followingNode);
 
     var gap = text.slice(locEnd(comment), gapEndPos);
     if (/\S/.test(gap)) {
@@ -210,19 +247,11 @@ function breakTies(tiesToBreak, text) {
     gapEndPos = locStart(comment);
   }
 
-  // while (indexOfFirstLeadingComment <= tieCount &&
-  //        (comment = tiesToBreak[indexOfFirstLeadingComment]) &&
-  //        // If the comment is a //-style comment and indented more
-  //        // deeply than the node itself, reconsider it as trailing.
-  //        (comment.type === "Line" || comment.type === "CommentLine") &&
-  //        comment.loc.start.column > fn.loc.start.column) {
-  //   ++indexOfFirstLeadingComment;
-  // }
   tiesToBreak.forEach(function(comment, i) {
     if (i < indexOfFirstLeadingComment) {
-      addTrailingComment(pn, comment);
+      addTrailingComment(precedingNode, comment);
     } else {
-      addLeadingComment(fn, comment);
+      addLeadingComment(followingNode, comment);
     }
   });
 
@@ -252,39 +281,89 @@ function addTrailingComment(node, comment) {
   addCommentHelper(node, comment);
 }
 
-function printLeadingComment(commentPath, print) {
-  var comment = commentPath.getValue();
-  n.Comment.assert(comment);
-  return concat([ print(commentPath), hardline ]);
+function printComment(commentPath) {
+  const comment = commentPath.getValue();
+
+  switch(comment.type) {
+    case "CommentBlock":
+    case "Block":
+      return "/*" + comment.value + "*/";
+    case "CommentLine":
+    case "Line":
+      return "//" + comment.value;
+    default:
+      throw new Error("Not a comment: " + JSON.stringify(comment));
+  }
 }
 
-function printTrailingComment(commentPath, print, options) {
-  const comment = commentPath.getValue(commentPath);
-  n.Comment.assert(comment);
+function printLeadingComment(commentPath, print, options) {
+  const comment = commentPath.getValue();
+  const contents = printComment(commentPath);
   const text = options.originalText;
+  const isBlock = comment.type === "Block" || comment.type === "CommentBlock";
+
+  // Leading block comments should see if they need to stay on the
+  // same line or not.
+  if(isBlock) {
+    return concat([
+      contents,
+      util.hasNewline(options.originalText, locEnd(comment)) ? hardline : " "
+    ]);
+  }
+
+  return concat([contents, hardline]);
+}
+
+function printTrailingComment(commentPath, print, options, parentNode) {
+  const comment = commentPath.getValue();
+  const contents = printComment(commentPath);
+  const isBlock = comment.type === "Block" || comment.type === "CommentBlock";
+
+  if(
+    util.hasNewline(
+      options.originalText,
+      locStart(comment),
+      { backwards: true }
+    )
+  ) {
+    // This allows comments at the end of nested structures:
+    // {
+    //   x: 1,
+    //   y: 2
+    //   // A comment
+    // }
+    // Those kinds of comments are almost always leading comments, but
+    // here it doesn't go "outside" the block and turns it into a
+    // trailing comment for `2`. We can simulate the above by checking
+    // if this a comment on its own line; normal trailing comments are
+    // always at the end of another expression.
+    return concat([
+      hardline,
+      contents
+    ]);
+  } else if (isBlock) {
+    // Trailing block comments never need a newline
+    return concat([" ", contents]);
+  }
 
   return concat([
-    util.newlineExistsBefore(text, locStart(comment)) ? hardline : " ",
-    print(commentPath)
-  ]);
+    lineSuffix(" " + contents),
+    !isBlock ? breakParent : ""
+  ])
 }
 
 function printDanglingComments(path, print, options) {
   const text = options.originalText;
-
   const parts = [];
-  path.each(
-    commentPath => {
-      const comment = commentPath.getValue();
-      if (!comment.leading && !comment.trailing) {
-        parts.push(
-          util.newlineExistsBefore(text, locStart(comment)) ? hardline : " "
-        );
-        parts.push(commentPath.call(print));
+  path.each(commentPath => {
+    const comment = commentPath.getValue();
+    if(!comment.leading && !comment.trailing) {
+      if(util.hasNewline(text, locStart(comment), { backwards: true })) {
+        parts.push(hardline);
       }
-    },
-    "comments"
-  );
+      parts.push(printComment(commentPath));
+    }
+  }, "comments");
   return concat(parts);
 }
 
@@ -309,25 +388,30 @@ function printComments(path, print, options) {
       var trailing = types.getFieldValue(comment, "trailing");
 
       if (
-        leading ||
-          trailing &&
-            !(n.Statement.check(value) ||
-              comment.type === "Block" ||
-              comment.type === "CommentBlock")
+        leading
       ) {
-        leadingParts.push(printLeadingComment(commentPath, print));
+        leadingParts.push(printLeadingComment(commentPath, print, options));
 
         // Support a special case where a comment exists at the very top
         // of the file. Allow the user to add spacing between that file
         // and any code beneath it.
+        const text = options.originalText;
         if (
           isFirstInProgram &&
-            util.newlineExistsAfter(options.originalText, util.locEnd(comment))
+            util.hasNewline(text, util.skipNewline(text, util.locEnd(comment)))
         ) {
           leadingParts.push(hardline);
         }
       } else if (trailing) {
-        trailingParts.push(printTrailingComment(commentPath, print, options));
+        const idx = commentPath.getName();
+        trailingParts.push(
+          printTrailingComment(
+            commentPath,
+            print,
+            options,
+            parent
+          )
+        );
       }
     },
     "comments"
@@ -337,4 +421,10 @@ function printComments(path, print, options) {
   return concat(leadingParts);
 }
 
-module.exports = { attach, printComments, printDanglingComments };
+module.exports = {
+  attach,
+  printComments,
+  printLeadingComment,
+  printTrailingComment,
+  printDanglingComments
+};

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -11,6 +11,12 @@ function assertDoc(val) {
 function concat(parts) {
   parts.forEach(assertDoc);
 
+  // We cannot do this until we change `printJSXElement` to not
+  // access the internals of a document directly.
+  // if(parts.length === 1) {
+  //   // If it's a single document, no need to concat it.
+  //   return parts[0];
+  // }
   return { type: "concat", parts };
 }
 
@@ -51,6 +57,15 @@ function ifBreak(breakContents, flatContents) {
   return { type: "if-break", breakContents, flatContents };
 }
 
+function lineSuffix(contents) {
+  if(typeof contents !== "string") {
+    throw new Error(
+      "lineSuffix only takes a string, but given: " + JSON.stringify(contents)
+    )
+  }
+  return { type: "line-suffix", contents };
+}
+
 const breakParent =  { type: "break-parent" };
 const line = { type: "line" };
 const softline = { type: "line", soft: true };
@@ -80,6 +95,7 @@ module.exports = {
   literalline,
   group,
   conditionalGroup,
+  lineSuffix,
   breakParent,
   ifBreak,
   indent

--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -84,6 +84,8 @@ function printDocToString(doc, w) {
   let cmds = [ [ 0, MODE_BREAK, doc ] ];
   let out = [];
   let shouldRemeasure = false;
+  let lineSuffix = "";
+
   while (cmds.length !== 0) {
     const x = cmds.pop();
     const ind = x[0];
@@ -183,6 +185,9 @@ function printDocToString(doc, w) {
           }
 
           break;
+        case "line-suffix":
+          lineSuffix += doc.contents;
+          break;
         case "line":
           switch (mode) {
             // fallthrough
@@ -207,8 +212,7 @@ function printDocToString(doc, w) {
 
             case MODE_BREAK:
               if (doc.literal) {
-                out.push("\n");
-
+                out.push(lineSuffix + "\n");
                 pos = 0;
               } else {
                 if (out.length > 0) {
@@ -219,11 +223,11 @@ function printDocToString(doc, w) {
                   );
                 }
 
-                out.push("\n" + " ".repeat(ind));
-
+                out.push(lineSuffix + "\n" + " ".repeat(ind));
                 pos = ind;
               }
 
+              lineSuffix = "";
               break;
           }
           break;

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -81,6 +81,22 @@ FPp.getParentNode = function getParentNode(count) {
   return getNodeHelper(this, ~~count + 1);
 };
 
+FPp.isLast = function isLast() {
+  var s = this.stack;
+  if(this.getParentNode()) {
+    var idx = s[s.length - 2];
+    // The name of this node should be an index
+    assert.ok(typeof idx === "number");
+
+    const arr = s[s.length - 3];
+    // We should have an array as a parent node
+    assert.ok(Array.isArray(arr));
+
+    return idx === arr.length - 1;
+  }
+  return false;
+}
+
 // Temporarily push properties named by string arguments given after the
 // callback function onto this.stack, then call the callback with a
 // reference to this (modified) FastPath object. Note that the stack will

--- a/src/util.js
+++ b/src/util.js
@@ -84,63 +84,86 @@ function getLast(arr) {
   return null;
 }
 
-function skipNewLineForward(text, index) {
-  // What the "end" location points to is not consistent in parsers.
-  // For some statement/expressions, it's the character immediately
-  // afterward. For others, it's the last character in it. We need to
-  // scan until we hit a newline in order to skip it.
-  while (index < text.length) {
-    if (text.charAt(index) === "\n") {
+function skip(chars) {
+  return (text, index, opts) => {
+    const backwards = opts && opts.backwards;
+
+    // Allow `skip` functions to be threaded together without having
+    // to check for failures (did someone say monads?).
+    if(index === false) {
+      return false;
+    }
+
+    const length = text.length;
+    let cursor = index;
+    while (cursor >= 0 && cursor < length) {
+      const c = text.charAt(cursor);
+      if(chars instanceof RegExp) {
+        if(!chars.test(c)) {
+          return cursor;
+        }
+      }
+      else if (chars.indexOf(c) === -1) {
+        return cursor;
+      }
+
+      backwards ? cursor-- : cursor++;
+    }
+
+    if(cursor === -1 || cursor === length) {
+      // If we reached the beginning or end of the file, return the
+      // out-of-bounds cursor. It's up to the caller to handle this
+      // correctly. We don't want to indicate `false` though if it
+      // actually skipped valid characters.
+      return cursor;
+    }
+    return false;
+  }
+}
+
+const skipWhitespace = skip(/\s/);
+const skipSpaces = skip(" \t");
+const skipToLineEnd = skip("; \t");
+
+// This one doesn't use the above helper function because it wants to
+// test \r\n in order and `skip` doesn't support ordering and we only
+// want to skip one newline. It's simple to implement.
+function skipNewline(text, index, opts) {
+  const backwards = opts && opts.backwards;
+  if(index === false) {
+    return false;
+  }
+  else if(backwards) {
+    if(text.charAt(index) === "\n") {
+      return index - 1;
+    }
+    if(text.charAt(index - 1) === "\r" && text.charAt(index) === "\n") {
+      return index - 2;
+    }
+  }
+  else {
+    if(text.charAt(index) === "\n") {
       return index + 1;
     }
-    if (text.charAt(index) === "\r" && text.charAt(index + 1) === "\n") {
+    if(text.charAt(index) === "\r" && text.charAt(index + 1) === "\n") {
       return index + 2;
     }
-    index++;
   }
+
   return index;
 }
 
-function findNewline(text, index, backwards) {
-  const length = text.length;
-  let cursor = backwards ? index - 1 : skipNewLineForward(text, index);
-  // Look forward and see if there is a newline after/before this code
-  // by scanning up/back to the next non-indentation character.
-  while (cursor > 0 && cursor < length) {
-    const c = text.charAt(cursor);
-    // Skip any indentation characters
-    if (c !== " " && c !== "\t") {
-      // Check if the next non-indentation character is a newline or
-      // not.
-      return c === "\n" || c === "\r";
-    }
-    backwards ? cursor-- : cursor++;
-  }
-  return false;
+function hasNewline(text, index, opts) {
+  opts = opts || {};
+  const idx = skipSpaces(text, opts.backwards ? index - 1 : index, opts);
+  const idx2 = skipNewline(text, idx, opts);
+  return idx !== idx2;
 }
 
-function newlineExistsBefore(text, index) {
-  return findNewline(text, index, true);
-}
-
-function newlineExistsAfter(text, index) {
-  return findNewline(text, index);
-}
-
-function skipSpaces(text, index, backwards) {
-  const length = text.length;
-  let cursor = backwards ? index - 1 : index;
-  // Look forward and see if there is a newline after/before this code
-  // by scanning up/back to the next non-indentation character.
-  while (cursor > 0 && cursor < length) {
-    const c = text.charAt(cursor);
-    // Skip any whitespace chars
-    if (!c.match(/\S/)) {
-      return cursor;
-    }
-    backwards ? cursor-- : cursor++;
-  }
-  return false;
+function hasSpaces(text, index, opts) {
+  opts = opts || {};
+  const idx = skipSpaces(text, opts.backwards ? index - 1 : index, opts);
+  return idx !== index;
 }
 
 function locStart(node) {
@@ -222,9 +245,12 @@ module.exports = {
   isExportDeclaration,
   getParentExportDeclaration,
   getLast,
-  newlineExistsBefore,
-  newlineExistsAfter,
+  skipWhitespace,
   skipSpaces,
+  skipToLineEnd,
+  skipNewline,
+  hasNewline,
+  hasSpaces,
   locStart,
   locEnd,
   setLocStart,

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,29 @@
+exports[`test blank.js 1`] = `
+"// This file only
+// has comments. This comment
+// should still exist
+//
+// when printed.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"
+`;
+
+exports[`test blank.js 2`] = `
+"// This file only
+// has comments. This comment
+// should still exist
+//
+// when printed.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// This file only
+// has comments. This comment
+// should still exist
+//
+// when printed.
+"
+`;
+
 exports[`test issues.js 1`] = `
 "// Does not need to break as it fits in 80 columns
 this.call(a, /* comment */ b);
@@ -103,25 +129,20 @@ else {
 const result = asyncExecute(\'non_existing_command\', /* args */ []);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Does not need to break as it fits in 80 columns
-this.call(
-  a,
-  /* comment */
-  b
-);
+this.call(a, /* comment */ b);
 
 function f(
   someReallyLongArgument: WithSomeLongType,
-  // Trailing comment should stay after
   someReallyLongArgument2: WithSomeLongType
-) {}
+) // Trailing comment should stay after
+{
+}
 
 // Comments should either stay at the end of the line or always before, but
 // not one before and one after.
 throw new ProcessSystemError({
-  code: acc.error.code,
-  // Alias of errno
-  // Just in case.
-  originalError: acc.error
+  code: acc.error.code, // Alias of errno
+  originalError: acc.error // Just in case.
 });
 
 // Adding a comment stops the pretty printing process and everything is
@@ -132,11 +153,12 @@ export type BuckWebSocketMessage = {
   } | { type: \"BuildProgressUpdated\", progressValue: number } | { type: \"BuildFinished\", exitCode: number } | { type: \"BuildStarted\" } | { type: \"ParseStarted\" } | { type: \"ParseFinished\" } | { type: \"RunStarted\" } | { type: \"RunComplete\" };
 
 // Missing one level of indentation because of the comment
-const rootEpic = (actions, store) => // Log errors and continue.
-combineEpics(...epics)(actions, store).catch((err, stream) => {
-  getLogger().error(err);
-  return stream;
-});
+const rootEpic = (actions, store) =>
+  combineEpics(...epics)(actions, store).// Log errors and continue.
+  catch((err, stream) => {
+    getLogger().error(err);
+    return stream;
+  });
 
 // Two extra levels of indentation because of the comment
 export type AsyncExecuteOptions = child_process$execFileOpts & {
@@ -147,30 +169,22 @@ export type AsyncExecuteOptions = child_process$execFileOpts & {
 
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(
-  // optional trailing comma
-  \"^\\\\s*\" +
-    // beginning of the line
+  \"^\\\\s*\" + // beginning of the line
     \"name\\\\s*=\\\\s*\" +
-    // name =
     \"[\'\\\"]\" +
-    // opening quotation mark
     escapeStringRegExp(target.name) +
-    // target name
     \"[\'\\\"]\" +
-    // closing quotation mark
-    \",?$\"
+    \",?$\" // optional trailing comma
 );
 
 // The comment is moved and doesn\'t trigger the eslint rule anymore
-import path from \"path\";
-
-// eslint-disable-line nuclide-internal/prefer-nuclide-uri
+import path from \"path\"; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
 // Comments disappear in-between MemberExpressions
-Observable
-  .of(process)
-  .merge(Observable.never())
-  .takeUntil(throwOnError ? errors.flatMap(Observable.throw) : errors)
-  .takeUntil(exit);
+Observable.of(process).// Don\'t complete until we say so!
+merge(Observable.never()).// Get the errors.
+takeUntil(
+  throwOnError ? errors.flatMap(Observable.throw) : errors
+).takeUntil(exit);
 
 /* Comments disappear inside of JSX*/
 <div>
@@ -189,13 +203,13 @@ if (1) {
 
 // Comments trigger invalid JavaScript in-between else if
 if (1) {
-}
-// Comment else {
-}
+} else
+  // Comment
+  {
+  }
 
 // The comment makes the line break in a weird way
-const result = asyncExecute(\"non_existing_command\", /* args */
-[]);
+const result = asyncExecute(\"non_existing_command\", /* args */ []);
 "
 `;
 
@@ -304,25 +318,20 @@ else {
 const result = asyncExecute(\'non_existing_command\', /* args */ []);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Does not need to break as it fits in 80 columns
-this.call(
-  a,
-  /* comment */
-  b
-);
+this.call(a, /* comment */ b);
 
 function f(
   someReallyLongArgument: WithSomeLongType,
-  // Trailing comment should stay after
   someReallyLongArgument2: WithSomeLongType
-) {}
+) // Trailing comment should stay after
+{
+}
 
 // Comments should either stay at the end of the line or always before, but
 // not one before and one after.
 throw new ProcessSystemError({
-  code: acc.error.code,
-  // Alias of errno
-  // Just in case.
-  originalError: acc.error
+  code: acc.error.code, // Alias of errno
+  originalError: acc.error // Just in case.
 });
 
 // Adding a comment stops the pretty printing process and everything is
@@ -333,11 +342,12 @@ export type BuckWebSocketMessage = {
   } | { type: \"BuildProgressUpdated\", progressValue: number } | { type: \"BuildFinished\", exitCode: number } | { type: \"BuildStarted\" } | { type: \"ParseStarted\" } | { type: \"ParseFinished\" } | { type: \"RunStarted\" } | { type: \"RunComplete\" };
 
 // Missing one level of indentation because of the comment
-const rootEpic = (actions, store) => // Log errors and continue.
-combineEpics(...epics)(actions, store).catch((err, stream) => {
-  getLogger().error(err);
-  return stream;
-});
+const rootEpic = (actions, store) =>
+  combineEpics(...epics)(actions, store).// Log errors and continue.
+  catch((err, stream) => {
+    getLogger().error(err);
+    return stream;
+  });
 
 // Two extra levels of indentation because of the comment
 export type AsyncExecuteOptions = child_process$execFileOpts & {
@@ -348,30 +358,22 @@ export type AsyncExecuteOptions = child_process$execFileOpts & {
 
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(
-  // optional trailing comma
-  \"^\\\\s*\" +
-    // beginning of the line
+  \"^\\\\s*\" + // beginning of the line
     \"name\\\\s*=\\\\s*\" +
-    // name =
     \"[\'\\\"]\" +
-    // opening quotation mark
     escapeStringRegExp(target.name) +
-    // target name
     \"[\'\\\"]\" +
-    // closing quotation mark
-    \",?$\"
+    \",?$\" // optional trailing comma
 );
 
 // The comment is moved and doesn\'t trigger the eslint rule anymore
-import path from \"path\";
-
-// eslint-disable-line nuclide-internal/prefer-nuclide-uri
+import path from \"path\"; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
 // Comments disappear in-between MemberExpressions
-Observable
-  .of(process)
-  .merge(Observable.never())
-  .takeUntil(throwOnError ? errors.flatMap(Observable.throw) : errors)
-  .takeUntil(exit);
+Observable.of(process).// Don\'t complete until we say so!
+merge(Observable.never()).// Get the errors.
+takeUntil(
+  throwOnError ? errors.flatMap(Observable.throw) : errors
+).takeUntil(exit);
 
 // Comments disappear inside of JSX
 <div>
@@ -379,8 +381,8 @@ Observable
 </div>;
 
 // Comments in JSX tag are placed in a non optimal way
-<// comment
-div
+<div
+// comment
 />;
 
 // Comments disappear in empty blocks
@@ -390,12 +392,12 @@ if (1) {
 
 // Comments trigger invalid JavaScript in-between else if
 if (1) {
-}
-// Comment else {
-}
+} else
+  // Comment
+  {
+  }
 
 // The comment makes the line break in a weird way
-const result = asyncExecute(\"non_existing_command\", /* args */
-[]);
+const result = asyncExecute(\"non_existing_command\", /* args */ []);
 "
 `;

--- a/tests/comments/blank.js
+++ b/tests/comments/blank.js
@@ -1,0 +1,5 @@
+// This file only
+// has comments. This comment
+// should still exist
+//
+// when printed.

--- a/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
@@ -148,18 +148,14 @@ function foo() {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let myClassInstance: MyClass = null;
-
 // forward ref ok, null ~> class error
 function bar(): MyClass {
   return null; // forward ref ok, null ~> class error
 }
 
-class MyClass {}
-
-// looked up above
+class MyClass {} // looked up above
 function foo() {
-  let myClassInstance: MyClass = mk();
-  // ok (no confusion across scopes)
+  let myClassInstance: MyClass = mk(); // ok (no confusion across scopes)
   function mk() {
     return new MyClass();
   }

--- a/tests/flow/arith/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/arith/__snapshots__/jsfmt.spec.js.snap
@@ -102,11 +102,9 @@ function foo() {
   var y = \"...\";
   var z = {};
   num(x + x);
-  num(x + y);
-  // error
+  num(x + y); // error
   str(x + y);
-  str(x + x);
-  // error
+  str(x + x); // error
   str(z + y); // error
 }
 
@@ -134,78 +132,45 @@ function bar5(x: number, y?: ?number) {
   num(x + y);
 }
 
-num(null + null);
-// === 0
-num(undefined + undefined);
-
-// === NaN
-num(null + 1);
-// === 1
-num(1 + null);
-// === 1
-num(undefined + 1);
-// === NaN
-num(1 + undefined);
-
-// === NaN
-num(null + true);
-// === 1
-num(true + null);
-// === 1
-num(undefined + true);
-// === NaN
-num(true + undefined);
-
-// === NaN
-str(\"foo\" + true);
-// error
-str(true + \"foo\");
-// error
-str(\"foo\" + null);
-// error
-str(null + \"foo\");
-// error
-str(\"foo\" + undefined);
-// error
-str(undefined + \"foo\");
-
-// error
+num(null + null); // === 0
+num(undefined + undefined); // === NaN
+num(null + 1); // === 1
+num(1 + null); // === 1
+num(undefined + 1); // === NaN
+num(1 + undefined); // === NaN
+num(null + true); // === 1
+num(true + null); // === 1
+num(undefined + true); // === NaN
+num(true + undefined); // === NaN
+str(\"foo\" + true); // error
+str(true + \"foo\"); // error
+str(\"foo\" + null); // error
+str(null + \"foo\"); // error
+str(\"foo\" + undefined); // error
+str(undefined + \"foo\"); // error
 let tests = [
   function(x: mixed, y: mixed) {
-    x + y;
-    // error
-    x + 0;
-    // error
-    0 + x;
-    // error
-    x + \"\";
-    // error
-    \"\" + x;
-    // error
-    x + {};
-    // error
+    x + y; // error
+    x + 0; // error
+    0 + x; // error
+    x + \"\"; // error
+    \"\" + x; // error
+    x + {}; // error
     ({}) + x; // error
   },
   // when one side is a string or number and the other is invalid, we
   // assume you are expecting a string or number (respectively), rather than
   // erroring twice saying number !~> string and obj !~> string.
   function() {
-    (1 + {}: number);
-    // error: object !~> number
-    ({} + 1: number);
-    // error: object !~> number
-    (\"1\" + {}: string);
-    // error: object !~> string
+    (1 + {}: number); // error: object !~> number
+    ({} + 1: number); // error: object !~> number
+    (\"1\" + {}: string); // error: object !~> string
     ({} + \"1\": string); // error: object !~> string
   },
   function(x: any, y: number, z: string) {
-    (x + y: string);
-    // ok
-    (y + x: string);
-
-    // ok
-    (x + z: empty);
-    // error, string ~> empty
+    (x + y: string); // ok
+    (y + x: string); // ok
+    (x + z: empty); // error, string ~> empty
     (z + x: empty); // error, string ~> empty
   }
 ];
@@ -231,9 +196,7 @@ let x: number = 2 ** 3;
 x **= 4;
 
 let y: string = \"123\";
-y **= 2;
-
-// error
+y **= 2; // error
 1 + 2 ** 3 + 4;
 2 ** 2;
 (-2) ** 2;
@@ -253,20 +216,16 @@ function f<A,B>(a: A, b: B): B {return b + a; } // error
 
 function f<A>(a: A): A {
   return a + a;
-}
-// error
+} // error
 function f<A, B>(a: A, b: B): A {
   return a + b;
-}
-// error
+} // error
 function f<A, B>(a: A, b: B): A {
   return b + a;
-}
-// error
+} // error
 function f<A, B>(a: A, b: B): B {
   return a + b;
-}
-// error
+} // error
 function f<A, B>(a: A, b: B): B {
   return b + a;
 } // error
@@ -337,36 +296,21 @@ let tests = [
 /* @flow */
 
 1 < 2;
-1 < \"foo\";
-// error
-\"foo\" < 1;
-// error
+1 < \"foo\"; // error
+\"foo\" < 1; // error
 \"foo\" < \"bar\";
-1 < { foo: 1 };
-// error
-({ foo: 1 }) < 1;
-// error
-({ foo: 1 }) < { foo: 1 };
-// error
-\"foo\" < { foo: 1 };
-// error
-({ foo: 1 }) < \"foo\";
-
-// error
+1 < { foo: 1 }; // error
+({ foo: 1 }) < 1; // error
+({ foo: 1 }) < { foo: 1 }; // error
+\"foo\" < { foo: 1 }; // error
+({ foo: 1 }) < \"foo\"; // error
 var x = (null: ?number);
-1 < x;
-// 2 errors: null !~> number; undefined !~> number
-x < 1;
-
-// 2 errors: null !~> number; undefined !~> number
-null < null;
-// error
-undefined < null;
-// error
-null < undefined;
-// error
-undefined < undefined;
-// error
+1 < x; // 2 errors: null !~> number; undefined !~> number
+x < 1; // 2 errors: null !~> number; undefined !~> number
+null < null; // error
+undefined < null; // error
+null < undefined; // error
+undefined < undefined; // error
 NaN < 1;
 1 < NaN;
 NaN < NaN;

--- a/tests/flow/arraylib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/arraylib/__snapshots__/jsfmt.spec.js.snap
@@ -63,7 +63,6 @@ function foo(x: string) {}
 var a = [0];
 var b = a.map(function(x) {
   foo(x);
-
   return \"\" + x;
 });
 
@@ -83,9 +82,7 @@ var j: Array<number | string> = h.concat(i);
 var k: Array<number> = h.concat(h);
 var l: Array<number> = h.concat(1, 2, 3);
 var m: Array<number | string> = h.concat(\"a\", \"b\", \"c\");
-var n: Array<number> = h.concat(\"a\", \"b\", \"c\");
-
-// Error
+var n: Array<number> = h.concat(\"a\", \"b\", \"c\"); // Error
 function reduce_test() {
   /* Adapted from the following source:
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce
@@ -111,8 +108,7 @@ function reduce_test() {
 
   /* Added later, because the above is insufficient */
   // acc is element type of array when no init is provided
-  [\"\"].reduce((acc, str) => acc * str.length);
-  // error, string ~> number
+  [\"\"].reduce((acc, str) => acc * str.length); // error, string ~> number
   [\"\"].reduceRight((acc, str) => acc * str.length); // error, string ~> number
 }
 

--- a/tests/flow/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -17,9 +17,7 @@ var ident = <T>(x: T): T => x;
 
 var add = (x: number, y: number): number => x + y;
 
-var bad = (x: number): string => x;
-
-// Error!
+var bad = (x: number): string => x; // Error!
 var ident = <T>(x: T): T => x;
 (ident(1): number);
 (ident(\"hi\"): number); // Error

--- a/tests/flow/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/async/__snapshots__/jsfmt.spec.js.snap
@@ -99,8 +99,7 @@ class C {
   }
   static async m(a): void {
     await a;
-  }
-  // error, void != Promise<void>
+  } // error, void != Promise<void>
   static async mt<T>(a: T): Promise<T> {
     return a;
   }
@@ -315,8 +314,7 @@ function test1() {
 
   async function bar() {
     var a = await foo();
-    var b: number = a;
-    // valid
+    var b: number = a; // valid
     var c: string = a; // Error: number ~> string
   }
 }
@@ -332,17 +330,14 @@ function test2() {
     console.log(\"HEY\");
   }
 
-  var voidoid2: () => Promise<void> = voidoid1;
-
-  // ok
+  var voidoid2: () => Promise<void> = voidoid1; // ok
   var voidoid3: () => void = voidoid1; // error, void != Promise<void>
 }
 
 // annotated return type of Promise<void> should work
 //
 function test3() {
-  async function voidoid4(): Promise<void> {
-    // ok
+  async function voidoid4(): Promise<void> { // ok
     console.log(\"HEY\");
   }
 }
@@ -352,15 +347,13 @@ function test3() {
 // return statements are covered in async.js)
 //
 function test4() {
-  async function voidoid5(): void {
-    // error, void != Promise<void>
+  async function voidoid5(): void { // error, void != Promise<void>
     console.log(\"HEY\");
   }
 }
 
 function test5() {
-  async function voidoid6(): Promise<number> {
-    // error, number != void
+  async function voidoid6(): Promise<number> { // error, number != void
     console.log(\"HEY\");
   }
 }

--- a/tests/flow/binary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/binary/__snapshots__/jsfmt.spec.js.snap
@@ -77,41 +77,31 @@ let tests = [
   },
   // primitives on RHS
   function() {
-    \"foo\" in 123;
-    // error
-    \"foo\" in \"bar\";
-    // error
-    \"foo\" in void 0;
-    // error
+    \"foo\" in 123; // error
+    \"foo\" in \"bar\"; // error
+    \"foo\" in void 0; // error
     \"foo\" in null; // error
   },
   // bogus stuff on LHS
   function() {
-    null in {};
-    // error
-    void 0 in {};
-    // error
-    ({}) in {};
-    // error
-    [] in {};
-    // error
+    null in {}; // error
+    void 0 in {}; // error
+    ({}) in {}; // error
+    [] in {}; // error
     false in []; // error
   },
   // in predicates
   function() {
     if (\"foo\" in 123) {
-    }
-    // error
+    } // error
     if (!\"foo\" in {}) {
-    }
-    // error, !\'foo\' is a boolean
+    } // error, !\'foo\' is a boolean
     if (!(\"foo\" in {})) {
     }
   },
   // annotations on RHS
   function(x: Object, y: mixed) {
-    \"foo\" in x;
-    // ok
+    \"foo\" in x; // ok
     \"foo\" in y; // error
   }
 ];

--- a/tests/flow/binding/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/binding/__snapshots__/jsfmt.spec.js.snap
@@ -46,11 +46,8 @@ x &= 0;
 // regression tests -- OK to assign consts like this:
 const { foo } = { foo: \"foo\" };
 const [bar] = [\"bar\"];
-(foo: number);
-// error: string ~> number
-(bar: number);
-
-// error: string ~> number
+(foo: number); // error: string ~> number
+(bar: number); // error: string ~> number
 declare var bazzes: { baz: string }[];
 for (const { baz } of bazzes) {
   (baz: number); // error: string ~> number
@@ -444,8 +441,7 @@ function type_shadow_nested_scope() {
 // fn params name clash
 function fn_params_name_clash(x, x /* error: x already bound */) {}
 function fn_params_clash_fn_binding(x, y) {
-  let x = 0;
-  // error: x already bound
+  let x = 0; // error: x already bound
   var y = 0; // OK
 }
 "
@@ -566,8 +562,7 @@ function block_scope() {
   let a: number = 0;
   var b: number = 0;
   {
-    let a = \"\";
-    // ok: local to block
+    let a = \"\"; // ok: local to block
     var b = \"\"; // error: string ~> number
   }
 }
@@ -577,14 +572,11 @@ function switch_scope(x: string) {
   var b: number = 0;
   switch (x) {
     case \"foo\":
-      let a = \"\";
-      // ok: local to switch
-      var b = \"\";
-      // error: string ~> number
+      let a = \"\"; // ok: local to switch
+      var b = \"\"; // error: string ~> number
       break;
     case \"bar\":
-      let a = \"\";
-      // error: a already bound in switch
+      let a = \"\"; // error: a already bound in switch
       break;
   }
 }
@@ -595,23 +587,19 @@ function switch_scope(x: string) {
 function switch_scope2(x: number) {
   switch (x) {
     case 0:
-      a = \"\";
-      // error: assign before declaration
+      a = \"\"; // error: assign before declaration
       break;
     case 1:
-      var b = a;
-      // error: use before declaration
+      var b = a; // error: use before declaration
       break;
     case 2:
       let a = \"\";
       break;
     case 3:
-      a = \"\";
-      // error: skipped initializer
+      a = \"\"; // error: skipped initializer
       break;
     case 4:
-      var c: string = a;
-      // error: skipped initializer
+      var c: string = a; // error: skipped initializer
       break;
   }
   a = \"\"; // error: a no longer in scope
@@ -667,8 +655,7 @@ function for_of_scope_var(xs: string[]) {
 function default_param_1() {
   // function binding in scope in default expr
   function f(
-    // error: number ~> string
-    x: () => string = f
+    x: () => string = f // error: number ~> string
   ): number {
     return 0;
   }
@@ -797,8 +784,7 @@ f(a); // ok, a: number (not ?number)
 
 // type aliases are hoisted and always available
 
-type T1 = T2;
-// ok
+type T1 = T2; // ok
 type T2 = number;
 
 // --- lets ---
@@ -814,19 +800,16 @@ type T2 = number;
 // forward references to let/consts from within lambdas entirely,
 // which would be annoying. TODO
 function f0() {
-  var v = x * c;
-  // errors, let + const referenced before decl
+  var v = x * c; // errors, let + const referenced before decl
   let x = 0;
   const c = 0;
 }
 
 function f1(b) {
-  x = 10;
-  // error, attempt to write to let before decl
+  x = 10; // error, attempt to write to let before decl
   let x = 0;
   if (b) {
-    y = 10;
-    // error, attempt to write to let before decl
+    y = 10; // error, attempt to write to let before decl
     let y = 0;
   }
 }
@@ -841,17 +824,14 @@ function f2() {
 
 // functions are let-scoped and hoisted
 function f3() {
-  var s: string = foo();
-  // ok, finds hoisted outer
+  var s: string = foo(); // ok, finds hoisted outer
   {
-    var n: number = foo();
-    // ok, finds hoisted inner
+    var n: number = foo(); // ok, finds hoisted inner
     function foo() {
       return 0;
     }
   }
-  var s2: string = foo();
-  // ok, hoisted outer not clobbered
+  var s2: string = foo(); // ok, hoisted outer not clobbered
   function foo() {
     return \"\";
   }
@@ -861,8 +841,7 @@ function f3() {
 function f4() {
   function g() {
     return x + c;
-  }
-  // ok, g doesn\'t run in TDZ
+  } // ok, g doesn\'t run in TDZ
   let x = 0;
   const c = 0;
 }
@@ -872,8 +851,7 @@ function f5() {
   function g() {
     return x;
   }
-  g();
-  // should error, but doesn\'t currently
+  g(); // should error, but doesn\'t currently
   let x = 0;
   const c = 0;
 }
@@ -882,31 +860,21 @@ function f5() {
 // value (i.e., class or function). this is a basic flaw in our
 // phasing of AST traversal, and will be fixed.
 //
-var x: C;
-
-// ok
-var y = new C();
-
-// error: let ref before decl from value position
+var x: C; // ok
+var y = new C(); // error: let ref before decl from value position
 class C {}
 
-var z: C = new C();
-
-// ok
+var z: C = new C(); // ok
 // --- vars ---
 // it\'s possible to annotate a var with a non-maybe type,
 // but leave it uninitialized until later (as long as it\'s
 // initialized before use)
-var a: number;
-
-// not an error per se - only if used before init
+var a: number; // not an error per se - only if used before init
 function f(n: number) {
   return n;
 }
 
-f(a);
-
-// error: undefined ~/> number
+f(a); // error: undefined ~/> number
 a = 10;
 
 f(a); // ok, a: number (not ?number)

--- a/tests/flow/bom/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/bom/__snapshots__/jsfmt.spec.js.snap
@@ -70,122 +70,68 @@ for (let [x, y]: [number, number] of a.entries()) {} // incorrect
 /* @flow */
 
 // constructor
-const a: FormData = new FormData();
-// correct
-new FormData(\"\");
-// incorrect
-new FormData(document.createElement(\"input\"));
-// incorrect
-new FormData(document.createElement(\"form\"));
-
-// correct
+const a: FormData = new FormData(); // correct
+new FormData(\"\"); // incorrect
+new FormData(document.createElement(\"input\")); // incorrect
+new FormData(document.createElement(\"form\")); // correct
 // has
-const b: boolean = a.has(\"foo\");
-
-// correct
+const b: boolean = a.has(\"foo\"); // correct
 // get
-const c: ?(string | File) = a.get(\"foo\");
-// correct
-const d: string = a.get(\"foo\");
-// incorrect
-const e: Blob = a.get(\"foo\");
-// incorrect
-const f: ?(string | File | Blob) = a.get(\"foo\");
-// incorrect
-a.get(2);
-
-// incorrect
+const c: ?(string | File) = a.get(\"foo\"); // correct
+const d: string = a.get(\"foo\"); // incorrect
+const e: Blob = a.get(\"foo\"); // incorrect
+const f: ?(string | File | Blob) = a.get(\"foo\"); // incorrect
+a.get(2); // incorrect
 // getAll
-const a1: Array<string | File> = a.getAll(\"foo\");
-// correct
-const a2: Array<string | File | number> = a.getAll(\"foo\");
-// incorrect
-const a3: Array<string | Blob | File> = a.getAll(\"foo\");
-// incorrect
-a.getAll(23);
-
-// incorrect
+const a1: Array<string | File> = a.getAll(\"foo\"); // correct
+const a2: Array<string | File | number> = a.getAll(\"foo\"); // incorrect
+const a3: Array<string | Blob | File> = a.getAll(\"foo\"); // incorrect
+a.getAll(23); // incorrect
 // set
-a.set(\"foo\", \"bar\");
-// correct
-a.set(\"foo\", {});
-// incorrect
-a.set(2, \"bar\");
-// incorrect
-a.set(\"foo\", \"bar\", \"baz\");
-// incorrect
-a.set(\"bar\", new File([], \"q\"));
-// correct
-a.set(\"bar\", new File([], \"q\"), \"x\");
-// correct
-a.set(\"bar\", new File([], \"q\"), 2);
-// incorrect
-a.set(\"bar\", new Blob());
-// correct
-a.set(\"bar\", new Blob(), \"x\");
-// correct
-a.set(\"bar\", new Blob(), 2);
-
-// incorrect
+a.set(\"foo\", \"bar\"); // correct
+a.set(\"foo\", {}); // incorrect
+a.set(2, \"bar\"); // incorrect
+a.set(\"foo\", \"bar\", \"baz\"); // incorrect
+a.set(\"bar\", new File([], \"q\")); // correct
+a.set(\"bar\", new File([], \"q\"), \"x\"); // correct
+a.set(\"bar\", new File([], \"q\"), 2); // incorrect
+a.set(\"bar\", new Blob()); // correct
+a.set(\"bar\", new Blob(), \"x\"); // correct
+a.set(\"bar\", new Blob(), 2); // incorrect
 // append
-a.append(\"foo\", \"bar\");
-// correct
-a.append(\"foo\", {});
-// incorrect
-a.append(2, \"bar\");
-// incorrect
-a.append(\"foo\", \"bar\", \"baz\");
-// incorrect
-a.append(\"foo\", \"bar\");
-// incorrect
-a.append(\"bar\", new File([], \"q\"));
-// correct
-a.append(\"bar\", new File([], \"q\"), \"x\");
-// correct
-a.append(\"bar\", new File([], \"q\"), 2);
-// incorrect
-a.append(\"bar\", new Blob());
-// correct
-a.append(\"bar\", new Blob(), \"x\");
-// correct
-a.append(\"bar\", new Blob(), 2);
-
-// incorrect
+a.append(\"foo\", \"bar\"); // correct
+a.append(\"foo\", {}); // incorrect
+a.append(2, \"bar\"); // incorrect
+a.append(\"foo\", \"bar\", \"baz\"); // incorrect
+a.append(\"foo\", \"bar\"); // incorrect
+a.append(\"bar\", new File([], \"q\")); // correct
+a.append(\"bar\", new File([], \"q\"), \"x\"); // correct
+a.append(\"bar\", new File([], \"q\"), 2); // incorrect
+a.append(\"bar\", new Blob()); // correct
+a.append(\"bar\", new Blob(), \"x\"); // correct
+a.append(\"bar\", new Blob(), 2); // incorrect
 // delete
-a.delete(\"xx\");
-// correct
-a.delete(3);
-
-// incorrect
+a.delete(\"xx\"); // correct
+a.delete(3); // incorrect
 // keys
 for (let x: string of a.keys()) {
-}
-// correct
+} // correct
 for (let x: number of a.keys()) {
-}
-
-// incorrect
+} // incorrect
 // values
 for (let x: string | File of a.values()) {
-}
-// correct
+} // correct
 for (let x: string | File | Blob of a.values()) {
-}
-
-// incorrect
+} // incorrect
 // entries
 for (let [x, y]: [string, string | File] of a.entries()) {
-}
-// correct
+} // correct
 for (let [x, y]: [string, string | File | Blob] of a.entries()) {
-}
-// incorrect
+} // incorrect
 for (let [x, y]: [number, string] of a.entries()) {
-}
-// incorrect
+} // incorrect
 for (let [x, y]: [string, number] of a.entries()) {
-}
-// incorrect
+} // incorrect
 for (let [x, y]: [number, number] of a.entries()) {
 } // incorrect
 "
@@ -231,42 +177,24 @@ function callback(
 ): void {
   return;
 }
-const o: MutationObserver = new MutationObserver(callback);
-// correct
-new MutationObserver((arr: Array<MutationRecord>) => true);
-// correct
-new MutationObserver(() => {});
-// correct
-new MutationObserver();
-// incorrect
-new MutationObserver(42);
-// incorrect
-new MutationObserver((n: number) => {});
-
-// incorrect
+const o: MutationObserver = new MutationObserver(callback); // correct
+new MutationObserver((arr: Array<MutationRecord>) => true); // correct
+new MutationObserver(() => {}); // correct
+new MutationObserver(); // incorrect
+new MutationObserver(42); // incorrect
+new MutationObserver((n: number) => {}); // incorrect
 // observe
 const div = document.createElement(\"div\");
-o.observe(div, { attributes: true, attributeFilter: [\"style\"] });
-// correct
-o.observe(div, { characterData: true, invalid: true });
-// correct
-o.observe();
-// incorrect
-o.observe(\"invalid\");
-// incorrect
-o.observe(div);
-// incorrect
-o.observe(div, {});
-// incorrect
-o.observe(div, { subtree: true });
-// incorrect
-o.observe(div, { attributes: true, attributeFilter: true });
-
-// incorrect
+o.observe(div, { attributes: true, attributeFilter: [\"style\"] }); // correct
+o.observe(div, { characterData: true, invalid: true }); // correct
+o.observe(); // incorrect
+o.observe(\"invalid\"); // incorrect
+o.observe(div); // incorrect
+o.observe(div, {}); // incorrect
+o.observe(div, { subtree: true }); // incorrect
+o.observe(div, { attributes: true, attributeFilter: true }); // incorrect
 // takeRecords
-o.takeRecords();
-
-// correct
+o.takeRecords(); // correct
 // disconnect
 o.disconnect(); // correct
 "

--- a/tests/flow/bounded_poly/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/bounded_poly/__snapshots__/jsfmt.spec.js.snap
@@ -41,10 +41,8 @@ var q: number = c.qux(0);
  * result T = string is incompatible with number */
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function foo<T: number>(x: T): T {
-  var _ = x * 1;
-  // OK
-  var y: string = x;
-  // error
+  var _ = x * 1; // OK
+  var y: string = x; // error
   return x; // OK
 }
 
@@ -53,10 +51,8 @@ class C<T: number> {
     return x; // error, since T: number and U: number does not imply U: T
   }
   qux<U: T>(x: U): T {
-    var _ = x * 1;
-    // OK, since T: number and U: T implies U: number
-    var y: string = x;
-    // error
+    var _ = x * 1; // OK, since T: number and U: T implies U: number
+    var y: string = x; // error
     return x; // OK, since U: T
   }
 }
@@ -68,8 +64,7 @@ function example<T: { x: number }>(o: T): T {
 var obj1: { x: number, y: string } = example({ x: 0, y: \"\" });
 var obj2: { x: number } = example({ x: 0 });
 
-var c: C<string> = new C();
-// error, since T = string is incompatible with number
+var c: C<string> = new C(); // error, since T = string is incompatible with number
 var q: number = c.qux(0);
 /* 2 more errors, since argument U = number is incompatible with T = string, and
  * result T = string is incompatible with number */

--- a/tests/flow/break/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/break/__snapshots__/jsfmt.spec.js.snap
@@ -86,12 +86,10 @@ function bar(b) {
   if (x == null) return;
   switch (\"\") {
     case 0:
-      var y: number = x;
-      // error: boolean !~> number
+      var y: number = x; // error: boolean !~> number
       x = \"\";
     case 1:
-      var z: number = x;
-      // 2 errors: (boolean | string) !~> number
+      var z: number = x; // 2 errors: (boolean | string) !~> number
       break;
     case 2:
   }
@@ -103,13 +101,11 @@ function bar2(b) {
   if (x == null) return;
   switch (\"\") {
     case 0: {
-      let y: number = x;
-      // error: boolean !~> number
+      let y: number = x; // error: boolean !~> number
       x = \"\";
     }
     case 1: {
-      let z: number = x;
-      // 2 errors: (boolean | string) !~> number
+      let z: number = x; // 2 errors: (boolean | string) !~> number
       break;
     }
     case 2:
@@ -124,8 +120,7 @@ function qux(b) {
     if (b) {
       z = \"\";
       continue;
-    }
-    // error: string !~> number
+    } // error: string !~> number
     z = 0;
   }
   var w: number = z; // error: string !~> number

--- a/tests/flow/builtins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/builtins/__snapshots__/jsfmt.spec.js.snap
@@ -21,9 +21,7 @@ var a = [\"...\"];
 var b = a.map(function(x) {
   return 0;
 });
-var c: string = b[0];
-
-// error: number !~> string
+var c: string = b[0]; // error: number !~> string
 var array = [];
 function f() {
   array = array.map(function() {
@@ -38,8 +36,7 @@ function g() {
   var foo1 = foo.map(function() {
     return \"...\";
   });
-  var x: number = foo1.get();
-  // error: string !~> number
+  var x: number = foo1.get(); // error: string !~> number
   foo = foo1;
 }
 "

--- a/tests/flow/call_properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/call_properties/__snapshots__/jsfmt.spec.js.snap
@@ -106,15 +106,11 @@ var d: { (): string } = function(x: number): string {
 };
 
 // ...but subtyping rules still apply
-var e: { (x: any): void } = function() {};
-// arity
+var e: { (x: any): void } = function() {}; // arity
 var f: { (): mixed } = function(): string {
   return \"hi\";
-};
-// return type
-var g: { (x: string): void } = function(x: mixed) {};
-
-// param type
+}; // return type
+var g: { (x: string): void } = function(x: mixed) {}; // param type
 // A function can be an object
 var y: {} = function(x: number): string {
   return \"hi\";
@@ -311,15 +307,11 @@ var c: { (x: string): string } = x => x.toFixed();
 var d: { (): string } = x => \"hi\";
 
 // ...but subtyping rules still apply
-var e: { (x: any): void } = () => {};
-// arity
-var f: { (): mixed } = () => \"hi\";
-// return type
+var e: { (x: any): void } = () => {}; // arity
+var f: { (): mixed } = () => \"hi\"; // return type
 var g: { (x: Date): void } = x => {
   x * 2;
-};
-
-// param type (date < number)
+}; // param type (date < number)
 // A function can be an object
 var y: {} = x => \"hi\";
 var z: Object = x => \"hi\";

--- a/tests/flow/callable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/callable/__snapshots__/jsfmt.spec.js.snap
@@ -48,21 +48,15 @@ function foo(fn: (value: any) => boolean) {}
 foo(Boolean);
 
 var dict: { [k: string]: any } = {};
-dict();
-
-// error, callable signature not found
+dict(); // error, callable signature not found
 interface ICall { (x: string): void }
 declare var icall: ICall;
-icall(0);
-// error, number ~> string
-icall.call(null, 0);
-
-// error, number ~> string
+icall(0); // error, number ~> string
+icall.call(null, 0); // error, number ~> string
 type Callable = { (x: string): void };
 
 declare var callable: Callable;
-callable(0);
-// error, number ~> string
+callable(0); // error, number ~> string
 callable.call(null, 0); // error, number ~> string
 "
 `;

--- a/tests/flow/class_statics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/class_statics/__snapshots__/jsfmt.spec.js.snap
@@ -67,25 +67,17 @@ class A {
   static foo(x: number) {}
   static bar(y: string) {}
 }
-A.qux = function(x: string) {};
-
-// error?
+A.qux = function(x: string) {}; // error?
 class B extends A {
-  static x: string;
-  // error?
-  static foo(x: string) {}
-  // error?
+  static x: string; // error?
+  static foo(x: string) {} // error?
   static main() {
-    B.x = 0;
-    // error
+    B.x = 0; // error
     B.x = \"\";
-    B.foo(0);
-    // error
+    B.foo(0); // error
     B.foo(\"\");
-    B.y = 0;
-    // error
-    B.bar(0);
-    // error
+    B.y = 0; // error
+    B.bar(0); // error
     B.qux(0); // error
   }
   static create(): A {
@@ -107,9 +99,7 @@ class C<X> {
 
 class D extends C<string> {
   static main() {
-    D.foo(0);
-
-    // error?
+    D.foo(0); // error?
     D.bar(0);
   }
 }
@@ -121,8 +111,7 @@ var d: C<*> = D.create();
 class E {
   static x: number;
   static foo(): string {
-    this.bar();
-    // error
+    this.bar(); // error
     return this.x; // error
   }
 }

--- a/tests/flow/class_subtyping/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/class_subtyping/__snapshots__/jsfmt.spec.js.snap
@@ -44,8 +44,7 @@ class A<X, Y, Z> {}
 class B extends A<string, number, boolean> {}
 class C<X, Y, Z> extends B {}
 
-var c: C<number, string, Array<boolean>> = new C();
-// none of the type args matter
+var c: C<number, string, Array<boolean>> = new C(); // none of the type args matter
 var a: A<string, number, Array<boolean>> = c; // the third type arg is incorrect
 "
 `;

--- a/tests/flow/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/classes/__snapshots__/jsfmt.spec.js.snap
@@ -28,9 +28,7 @@ var A = require(\"./A\");
 class B extends A {}
 
 let b = new B();
-(b.foo: number);
-
-// error, number !~> function
+(b.foo: number); // error, number !~> function
 module.exports = B;
 "
 `;
@@ -54,9 +52,7 @@ class C extends B {
 }
 
 let c = new C();
-(c.foo: number);
-
-// error, number !~> function
+(c.foo: number); // error, number !~> function
 module.exports = C;
 "
 `;
@@ -112,12 +108,9 @@ var w : Foo = z;
 /* @flow */
 
 type Foo = {
-  a: string,
-  // exists in TestClass
-  b: string,
-  // doesn\'t exist
-  c?: ?string,
-  // exists in TestClass, optional
+  a: string, // exists in TestClass
+  b: string, // doesn\'t exist
+  c?: ?string, // exists in TestClass, optional
   d?: number /* doesn\'t exist*/
 };
 
@@ -128,24 +121,15 @@ class TestClass {
 
 var x = new TestClass();
 
-x.a;
-// ok
-x.b;
-// error, TestClass has no b
-x.c;
-// ok
-x.d;
-
-// error, TestClass has no d
+x.a; // ok
+x.b; // error, TestClass has no b
+x.c; // ok
+x.d; // error, TestClass has no d
 var y: Foo = x;
-y.b;
-// error, doesn\'t exist in TestClass
-y.d;
-
-// ok, it\'s optional
+y.b; // error, doesn\'t exist in TestClass
+y.d; // ok, it\'s optional
 class Test2Superclass {
-  a: number;
-  // conflicts with cast to Foo
+  a: number; // conflicts with cast to Foo
   c: ?number; // conflicts with cast to Foo
 }
 class Test2Class extends Test2Superclass {
@@ -190,27 +174,19 @@ var alias1: Alias = new _Alias(); // error: bad pun
 var alias2: Alias = _Alias.factory(); // error: bad pun
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var Bar = class Foo {
-  static factory(): Foo {
-    // OK: Foo is a type in this scope
+  static factory(): Foo { // OK: Foo is a type in this scope
     return new Foo(); // OK: Foo is a runtime binding in this scope
   }
 };
 
-var bar1: Bar = new Bar();
-// OK
-var bar2: Bar = Bar.factory();
-
-// OK
+var bar1: Bar = new Bar(); // OK
+var bar2: Bar = Bar.factory(); // OK
 // NB: Don\'t write expected errors using Foo to avoid error collapse hiding an
 // unexpected failure in the above code.
 var B = class Baz {};
-var b = new Baz();
-
-// error: Baz is not a runtime binding in this scope
+var b = new Baz(); // error: Baz is not a runtime binding in this scope
 var C = class Qux {};
-var c: Qux = new C();
-
-// error: Qux is not a type in this scope
+var c: Qux = new C(); // error: Qux is not a type in this scope
 // OK: anon classes create no binding, but can be bound manually
 var Anon = class {};
 var anon: Anon = new Anon();
@@ -221,8 +197,7 @@ var _Alias = class Alias {
     return new Alias();
   }
 };
-var alias1: Alias = new _Alias();
-// error: bad pun
+var alias1: Alias = new _Alias(); // error: bad pun
 var alias2: Alias = _Alias.factory(); // error: bad pun
 "
 `;
@@ -265,11 +240,8 @@ class C {
 C.p = \"hi\";
 
 // Class static fields are compatible with object types
-(C: { p: string });
-// ok
-(C: { p: number });
-
-// errors, string ~> number & vice versa (unify)
+(C: { p: string }); // ok
+(C: { p: number }); // errors, string ~> number & vice versa (unify)
 declare var o: { p: number };
 (o: Class<C>); // error, object type incompatible with class type
 "

--- a/tests/flow/closure/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/closure/__snapshots__/jsfmt.spec.js.snap
@@ -97,16 +97,10 @@ function global_g() {
 }
 
 global_f();
-takes_string(global_x);
-
-// ok
+takes_string(global_x); // ok
 global_g();
-takes_string(global_x);
-
-// error
-global_x = 42;
-
-// shouldn\'t pollute linear refinement
+takes_string(global_x); // error
+global_x = 42; // shouldn\'t pollute linear refinement
 // local write from function
 //
 function local_func() {
@@ -118,13 +112,9 @@ function local_func() {
   }
 
   local_f();
-  takes_string(local_x);
-
-  // ok
+  takes_string(local_x); // ok
   local_g();
-  takes_string(local_x);
-
-  // error
+  takes_string(local_x); // error
   local_x = 42; // shouldn\'t pollute linear refinement
 }
 
@@ -140,16 +130,10 @@ var global_o = {
 };
 
 global_o.f();
-takes_string(global_y);
-
-// ok
+takes_string(global_y); // ok
 global_o.g();
-takes_string(global_y);
-
-// error
-global_y = 42;
-
-// shouldn\'t pollute linear refinement
+takes_string(global_y); // error
+global_y = 42; // shouldn\'t pollute linear refinement
 // local write from method
 //
 function local_meth() {
@@ -163,13 +147,9 @@ function local_meth() {
   };
 
   local_o.f();
-  takes_string(local_y);
-
-  // ok
+  takes_string(local_y); // ok
   local_o.g();
-  takes_string(local_y);
-
-  // error
+  takes_string(local_y); // error
   local_y = 42; // shouldn\'t pollute linear refinement
 }
 "

--- a/tests/flow/computed_props/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/computed_props/__snapshots__/jsfmt.spec.js.snap
@@ -33,12 +33,8 @@ var ColorIdToNumber = {
   [ColorId.BLUE]: ColorNumber.BLUE
 };
 
-(ColorIdToNumber[ColorId.RED]: \"ffffff\");
-
-// oops
-ColorIdToNumber.XXX;
-
-// oops
+(ColorIdToNumber[ColorId.RED]: \"ffffff\"); // oops
+ColorIdToNumber.XXX; // oops
 module.exports = { ColorId, ColorNumber };
 "
 `;
@@ -62,9 +58,7 @@ var ColorIdToNumber = {
   [ColorId.BLUE]: ColorNumber.BLUE
 };
 
-(ColorIdToNumber[ColorId.GREEN]: \"ffffff\");
-
-// oops
+(ColorIdToNumber[ColorId.GREEN]: \"ffffff\"); // oops
 module.exports = ColorIdToNumber;
 "
 `;
@@ -126,9 +120,7 @@ var obj = {
     return this.x;
   }
 };
-var x: string = obj[\"m\"]();
-
-// error, number ~> string
+var x: string = obj[\"m\"](); // error, number ~> string
 var arr = [
   function() {
     return this.length;

--- a/tests/flow/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -43,8 +43,7 @@ function c(): number {
   return temp ? temp : 0;
 }
 
-function d(): string {
-  // expected \`: number | boolean\`
+function d(): string { // expected \`: number | boolean\`
   // equivalent to \`return x != null && x\`
   var x: ?number = null;
   return x != null ? x : x != null;

--- a/tests/flow/config_module_name_mapper_filetype/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/config_module_name_mapper_filetype/__snapshots__/jsfmt.spec.js.snap
@@ -7,8 +7,6 @@ import {doesntExist} from \"./SomeCSSFile.css\"; // Error: \`doestExist\` isn\'t
 // @flow
 
 import { className } from \"./SomeCSSFile.css\";
-import {
-  doesntExist
-} from \"./SomeCSSFile.css\"; // Error: \`doestExist\` isn\'t an export
+import { doesntExist } from \"./SomeCSSFile.css\"; // Error: \`doestExist\` isn\'t an export
 "
 `;

--- a/tests/flow/config_module_name_rewrite_haste/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/config_module_name_rewrite_haste/__snapshots__/jsfmt.spec.js.snap
@@ -24,8 +24,7 @@ var a_2: number = numVal1;
 //
 // This tests that, for haste, the first name_mapper regexp that happens to
 // match the given module name string is picked.
-var m2 = require(\"2DoesntExist\");
-// Error
+var m2 = require(\"2DoesntExist\"); // Error
 import { numVal as numVal2 } from \"3DoesntExist\"; // Error
 "
 `;

--- a/tests/flow/config_module_name_rewrite_node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/config_module_name_rewrite_node/__snapshots__/jsfmt.spec.js.snap
@@ -29,29 +29,22 @@ var c_4: string = numVal3; // Error: number ~> string
 
 var m1 = require(\"./1DoesntExist\");
 var a_1: number = m1.numVal;
-var a_2: string = m1.numVal;
-// Error: number ~> string
+var a_2: string = m1.numVal; // Error: number ~> string
 import { numVal } from \"./1DoesntExist\";
 var a_3: number = numVal;
-var a_4: string = numVal;
-
-// Error: number ~> string
+var a_4: string = numVal; // Error: number ~> string
 // This tests that, for node, the first name mapping that both matches *and*
 // results in a valid module filename is picked.
 var m2 = require(\"./2DoesntExist\");
 var b_1: number = m2.numVal;
-var b_2: string = m2.numVal;
-// Error: number ~> string
+var b_2: string = m2.numVal; // Error: number ~> string
 import { numVal as numVal2 } from \"./3DoesntExist\";
 var b_3: number = numVal2;
-var b_4: string = numVal2;
-
-// Error: number ~> string
+var b_4: string = numVal2; // Error: number ~> string
 // node_modules/Exists/index.js
 var m3 = require(\"4DoesntExist\");
 var c_1: number = m3.numVal;
-var c_2: string = m3.numVal;
-// Error: number ~> string
+var c_2: string = m3.numVal; // Error: number ~> string
 import { numVal as numVal3 } from \"5DoesntExist\";
 var c_3: number = numVal3;
 var c_4: string = numVal3; // Error: number ~> string

--- a/tests/flow/config_module_system_node_resolve_dirname/subdir/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/config_module_system_node_resolve_dirname/subdir/__snapshots__/jsfmt.spec.js.snap
@@ -10,8 +10,7 @@ import {name} from \"testproj2\";
 
 import { name } from \"testproj2\";
 
-(name: \"node_modules/testproj2\");
-// Error: Resolve from sibling \'custom_resolve_dir\' first!
+(name: \"node_modules/testproj2\"); // Error: Resolve from sibling \'custom_resolve_dir\' first!
 (name: \"subdir/custom_resolve_dir/testproj2\");
 "
 `;

--- a/tests/flow/constructor_annots/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/constructor_annots/__snapshots__/jsfmt.spec.js.snap
@@ -25,8 +25,7 @@ exports.Foo2 = (Foo: Class<IFoo>);
 function Foo() {
   this.x = 0; // constructs objects with property x
 }
-Foo.y = 0;
-// has static property y
+Foo.y = 0; // has static property y
 Foo.prototype = {
   m() {
     return 0;
@@ -40,9 +39,8 @@ exports.Foo = Foo;
 // so you want to type Foo, by declaring it as a class
 interface IFooPrototype { m(): number }
 interface IFoo extends IFooPrototype {
-  /* error, should have declared x: number instead*/
   static (): void,
-  x: boolean,
+  x: boolean /* error, should have declared x: number instead*/,
   static y: boolean /* error, should have declared static y: number instead*/
 }
 exports.Foo2 = (Foo: Class<IFoo>);
@@ -61,17 +59,13 @@ var y2: string = Foo2.y; // error, found boolean instead of string
 var z2: string = new Foo2().m();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var Foo = require(\"./constructors\").Foo;
-var x: string = new Foo().x;
-// error, found number instead of string
-var y: string = Foo.y;
-// error, found number instead of string
+var x: string = new Foo().x; // error, found number instead of string
+var y: string = Foo.y; // error, found number instead of string
 var z: string = new Foo().m();
 
 var Foo2 = require(\"./constructors\").Foo2;
-var x2: string = new Foo2().x;
-// error, found boolean instead of string
-var y2: string = Foo2.y;
-// error, found boolean instead of string
+var x2: string = new Foo2().x; // error, found boolean instead of string
+var y2: string = Foo2.y; // error, found boolean instead of string
 var z2: string = new Foo2().m();
 "
 `;

--- a/tests/flow/core_tests/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/core_tests/__snapshots__/jsfmt.spec.js.snap
@@ -139,14 +139,12 @@ let tests = [
   },
   // bad constructors
   function() {
-    let x = new Map([\"foo\", 123]);
-    // error
+    let x = new Map([\"foo\", 123]); // error
     let y: Map<number, string> = new Map([[\"foo\", 123]]); // error
   },
   // get()
   function(x: Map<string, number>) {
-    (x.get(\"foo\"): boolean);
-    // error, string | void
+    (x.get(\"foo\"): boolean); // error, string | void
     x.get(123); // error, wrong key type
   }
 ];
@@ -193,8 +191,7 @@ let tests = [
     new RegExp(/foo/);
     new RegExp(\"foo\", \"i\");
     new RegExp(\"foo\", \"ig\");
-    new RegExp(/foo/, \"i\");
-    // invalid in ES5, valid in ES6
+    new RegExp(/foo/, \"i\"); // invalid in ES5, valid in ES6
     new RegExp(/foo/g, \"i\"); // invalid in ES5, valid in ES6
   },
   // called as a function (equivalent to the constructor per ES6 21.2.3)
@@ -203,14 +200,12 @@ let tests = [
     RegExp(/foo/);
     RegExp(\"foo\", \"i\");
     RegExp(\"foo\", \"ig\");
-    RegExp(/foo/, \"i\");
-    // invalid in ES5, valid in ES6
+    RegExp(/foo/, \"i\"); // invalid in ES5, valid in ES6
     RegExp(/foo/g, \"i\"); // invalid in ES5, valid in ES6
   },
   // invalid flags
   function() {
-    RegExp(\"foo\", \"z\");
-    // error
+    RegExp(\"foo\", \"z\"); // error
     new RegExp(\"foo\", \"z\"); // error
   }
 ];
@@ -273,9 +268,7 @@ ws.delete(dict);
 
 let ws2 = new WeakSet([obj, dict]);
 
-let ws3 = new WeakSet([1, 2, 3]);
-
-// error, must be objects
+let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
 function* generator(): Iterable<{ foo: string }> {
   while (true) {
     yield { foo: \"bar\" };

--- a/tests/flow/covariance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/covariance/__snapshots__/jsfmt.spec.js.snap
@@ -52,9 +52,7 @@ n.x = [0];
 type CovArrayVerbose<X, Y: X> = Array<Y>;
 var b: CovArrayVerbose<number, *> = [];
 var y: CovArrayVerbose<mixed, *> = b;
-y[0] = \"\";
-
-// error
+y[0] = \"\"; // error
 class NVerbose<E, I: E> {
   x: CovArrayVerbose<E, I>;
   foo(): CovArrayVerbose<mixed, I> {
@@ -64,8 +62,7 @@ class NVerbose<E, I: E> {
 
 var nv: NVerbose<number, *> = new NVerbose();
 nv.x = [0];
-(nv.x[0]: string);
-// error
+(nv.x[0]: string); // error
 (nv.foo()[0]: string); // error
 /* TODO: use existentials for non-verbose covariance?
 

--- a/tests/flow/declaration_files_incremental_haste/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declaration_files_incremental_haste/__snapshots__/jsfmt.spec.js.snap
@@ -90,13 +90,9 @@ var ExplicitDifferentName = require(\'ExplicitProvidesModuleDifferentName\');
 /* @flow */
 
 var Implicit = require(\"ImplicitProvidesModule\");
-(Implicit.fun(): boolean);
-
-// Error: Either Implementation ~> boolean or Declaration ~> boolean
+(Implicit.fun(): boolean); // Error: Either Implementation ~> boolean or Declaration ~> boolean
 var ExplicitSameName = require(\"ExplicitProvidesModuleSameName\");
-(ExplicitSameName.fun(): boolean);
-
-// Error: Either Implementation ~> boolean or Declaration ~> boolean
+(ExplicitSameName.fun(): boolean); // Error: Either Implementation ~> boolean or Declaration ~> boolean
 var ExplicitDifferentName = require(\"ExplicitProvidesModuleDifferentName\");
 (ExplicitDifferentName.fun(): boolean); // Error: Either Implementation ~> boolean or Declaration ~> boolean
 "

--- a/tests/flow/declaration_files_incremental_haste/foo/bar/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declaration_files_incremental_haste/foo/bar/__snapshots__/jsfmt.spec.js.snap
@@ -15,10 +15,8 @@ var docblock = require(\"qux/docblock\");
 var min = require(\"d3/min.js\");
 var corge = require(\"qux/corge\");
 
-(docblock.fun(): boolean);
-// Error: Either Implementation ~> boolean or Declaration ~> boolean
-(min.fun(): boolean);
-// Error: Either Implementation ~> boolean or Declaration ~> boolean
+(docblock.fun(): boolean); // Error: Either Implementation ~> boolean or Declaration ~> boolean
+(min.fun(): boolean); // Error: Either Implementation ~> boolean or Declaration ~> boolean
 (corge.fun(): boolean); // Error: Either Implementation ~> boolean or Declaration ~> boolean
 "
 `;

--- a/tests/flow/declaration_files_incremental_node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declaration_files_incremental_node/__snapshots__/jsfmt.spec.js.snap
@@ -56,52 +56,30 @@ var F = require(\'package_with_dir_main\');
 
 // This will require ./node_modules/B.js.flow
 var B1 = require(\"B\");
-(B1.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(B1.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 // This will require ./node_modules/B.js.flow
 var B2 = require(\"B.js\");
-(B2.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(B2.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 var C = require(\"package_with_full_main\");
-(C.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(C.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 var D = require(\"package_with_partial_main\");
-(D.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(D.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 var E = require(\"package_with_no_package_json\");
-(E.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(E.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 var F = require(\"package_with_dir_main\");
-(F.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(F.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 // This will require ./node_modules/B.js.flow
 var B1 = require(\"B\");
-(B1.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(B1.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 // This will require ./node_modules/B.js.flow
 var B2 = require(\"B.js\");
-(B2.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(B2.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 var C = require(\"package_with_full_main\");
-(C.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(C.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 var D = require(\"package_with_partial_main\");
-(D.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(D.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 var E = require(\"package_with_no_package_json\");
-(E.fun(): boolean);
-
-// Error either Implementation ~> boolean or Declaration ~> boolean
+(E.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 var F = require(\"package_with_dir_main\");
 (F.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 "

--- a/tests/flow/declaration_files_node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declaration_files_node/__snapshots__/jsfmt.spec.js.snap
@@ -45,26 +45,16 @@ var F = require(\'package_with_dir_main\');
 
 // This will require ./node_modules/B.js.flow
 var B1 = require(\"B\");
-(B1.fun(): string);
-
-// Error number ~> string
+(B1.fun(): string); // Error number ~> string
 // This will require ./node_modules/B.js.flow
 var B2 = require(\"B.js\");
-(B2.fun(): string);
-
-// Error number ~> string
+(B2.fun(): string); // Error number ~> string
 var C = require(\"package_with_full_main\");
-(C.fun(): string);
-
-// Error number ~> string
+(C.fun(): string); // Error number ~> string
 var D = require(\"package_with_partial_main\");
-(D.fun(): string);
-
-// Error number ~> string
+(D.fun(): string); // Error number ~> string
 var E = require(\"package_with_no_package_json\");
-(E.fun(): string);
-
-// Error number ~> string
+(E.fun(): string); // Error number ~> string
 var F = require(\"package_with_dir_main\");
 (F.fun(): string); // Error number ~> string
 "
@@ -89,14 +79,10 @@ var CJS = require(\'./CJS.js\');
 
 // This will require ./A.js.flow
 var A1 = require(\"./A\");
-(A1.fun(): string);
-
-// Error number ~> string
+(A1.fun(): string); // Error number ~> string
 // This will require ./A.js.flow
 var A2 = require(\"./A.js\");
-(A2.fun(): string);
-
-// Error number ~> string
+(A2.fun(): string); // Error number ~> string
 var CJS = require(\"./CJS.js\");
 (CJS: string);
 (CJS: number); // Error: string ~> number

--- a/tests/flow/declare_export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_export/__snapshots__/jsfmt.spec.js.snap
@@ -888,294 +888,185 @@ var at4: string = numberValue9; // Error: number ~> string
 // @providesModule
 import * as DefaultA from \"A\";
 var a1: number = DefaultA.numberValue1;
-var a2: string = DefaultA.numberValue1;
-
-// Error: number ~> string
+var a2: string = DefaultA.numberValue1; // Error: number ~> string
 // File path
 import * as DefaultB from \"./B\";
 var b1: number = DefaultB.numberValue;
-var b2: string = DefaultB.numberValue;
-
-// Error: number ~> string
+var b2: string = DefaultB.numberValue; // Error: number ~> string
 // C.js exists, but not as a providesModule
-import DefaultC from \"C\";
-
-// Error: No such module
+import DefaultC from \"C\"; // Error: No such module
 // @providesModule D exists, but not as a filename
-import DefaultD from \"./D\";
-
-// Error: No such module
+import DefaultD from \"./D\"; // Error: No such module
 // ================================================ //
 // == CommonJS Clobbering Literal Exports -> ES6 == //
 // ================================================ //
-import { doesntExist1 } from \"CommonJS_Clobbering_Lit\";
-
-// Error: Not an exported binding
+import { doesntExist1 } from \"CommonJS_Clobbering_Lit\"; // Error: Not an exported binding
 import { numberValue1 } from \"CommonJS_Clobbering_Lit\";
 var c1: number = numberValue1;
-var c2: string = numberValue1;
-
-// Error: number ~> string
+var c2: string = numberValue1; // Error: number ~> string
 import { numberValue2 as numVal1 } from \"CommonJS_Clobbering_Lit\";
 var d1: number = numVal1;
-var d2: string = numVal1;
-
-// Error: number ~> string
+var d2: string = numVal1; // Error: number ~> string
 import CJS_Clobb_Lit from \"CommonJS_Clobbering_Lit\";
 var e1: number = CJS_Clobb_Lit.numberValue3;
-var e2: string = CJS_Clobb_Lit.numberValue3;
-// Error: number ~> string
-CJS_Clobb_Lit.doesntExist;
-
-// Error: doesntExist isn\'t a property
+var e2: string = CJS_Clobb_Lit.numberValue3; // Error: number ~> string
+CJS_Clobb_Lit.doesntExist; // Error: doesntExist isn\'t a property
 import * as CJS_Clobb_Lit_NS from \"CommonJS_Clobbering_Lit\";
 var f1: number = CJS_Clobb_Lit_NS.numberValue4;
 var f2: number = CJS_Clobb_Lit_NS.default.numberValue4;
-CJS_Clobb_Lit_NS.default.default;
-// Error: No \'default\' property on the exported obj
-var f3: string = CJS_Clobb_Lit_NS.numberValue4;
-// Error: number ~> string
-var f4: string = CJS_Clobb_Lit_NS.default.numberValue5;
-
-// Error: number ~> string
+CJS_Clobb_Lit_NS.default.default; // Error: No \'default\' property on the exported obj
+var f3: string = CJS_Clobb_Lit_NS.numberValue4; // Error: number ~> string
+var f4: string = CJS_Clobb_Lit_NS.default.numberValue5; // Error: number ~> string
 // ============================================== //
 // == CommonJS Clobbering Class Exports -> ES6 == //
 // ============================================== //
-import { doesntExist2 } from \"CommonJS_Clobbering_Class\";
-
-// Error: Not an exported binding
+import { doesntExist2 } from \"CommonJS_Clobbering_Class\"; // Error: Not an exported binding
 // The following import should error because class statics are not turned into
 // named exports for now. This avoids complexities with polymorphic static
 // members (where the polymophism is defined on the class itself rather than the
 // method).
-import { staticNumber1, baseProp, childProp } from \"CommonJS_Clobbering_Class\";
-
-// Error
+import { staticNumber1, baseProp, childProp } from \"CommonJS_Clobbering_Class\"; // Error
 import CJS_Clobb_Class from \"CommonJS_Clobbering_Class\";
 new CJS_Clobb_Class();
-new CJS_Clobb_Class().doesntExist;
-// Error: Class has no \`doesntExist\` property
+new CJS_Clobb_Class().doesntExist; // Error: Class has no \`doesntExist\` property
 var h1: number = CJS_Clobb_Class.staticNumber2();
-var h2: string = CJS_Clobb_Class.staticNumber2();
-// Error: number ~> string
+var h2: string = CJS_Clobb_Class.staticNumber2(); // Error: number ~> string
 var h3: number = new CJS_Clobb_Class().instNumber1();
-var h4: string = new CJS_Clobb_Class().instNumber1();
-
-// Error: number ~> string
+var h4: string = new CJS_Clobb_Class().instNumber1(); // Error: number ~> string
 import * as CJS_Clobb_Class_NS from \"CommonJS_Clobbering_Class\";
-new CJS_Clobb_Class_NS();
-// Error: Namespace object isn\'t constructable
-var i1: number = CJS_Clobb_Class_NS.staticNumber3();
-// Error: Class statics not copied to Namespace object
+new CJS_Clobb_Class_NS(); // Error: Namespace object isn\'t constructable
+var i1: number = CJS_Clobb_Class_NS.staticNumber3(); // Error: Class statics not copied to Namespace object
 var i2: number = new CJS_Clobb_Class_NS.default().instNumber2();
-var i3: string = new CJS_Clobb_Class_NS.default().instNumber2();
-
-// Error: number ~> string
+var i3: string = new CJS_Clobb_Class_NS.default().instNumber2(); // Error: number ~> string
 // =================================== //
 // == CommonJS Named Exports -> ES6 == //
 // =================================== //
-import { doesntExist3 } from \"CommonJS_Named\";
-
-// Error: Not an exported binding
+import { doesntExist3 } from \"CommonJS_Named\"; // Error: Not an exported binding
 import { numberValue2 } from \"CommonJS_Named\";
 var j1: number = numberValue2;
-var j2: string = numberValue2;
-
-// Error: number ~> string
+var j2: string = numberValue2; // Error: number ~> string
 import { numberValue3 as numVal3 } from \"CommonJS_Named\";
 var k1: number = numVal3;
-var k2: string = numVal3;
-
-// Error: number ~> string
+var k2: string = numVal3; // Error: number ~> string
 import * as CJS_Named from \"CommonJS_Named\";
 var l1: number = CJS_Named.numberValue1;
-var l2: string = CJS_Named.numberValue1;
-// Error: number ~> string
-CJS_Named.doesntExist;
-
-// Error: doesntExist isn\'t a property
+var l2: string = CJS_Named.numberValue1; // Error: number ~> string
+CJS_Named.doesntExist; // Error: doesntExist isn\'t a property
 import * as CJS_Named_NS from \"CommonJS_Named\";
 var m1: number = CJS_Named_NS.numberValue4;
-var m2: string = CJS_Named_NS.default.numberValue4;
-// Error: CommonJS_Named has no default export
-var m3: string = CJS_Named_NS.numberValue4;
-
-// Error: number ~> string
+var m2: string = CJS_Named_NS.default.numberValue4; // Error: CommonJS_Named has no default export
+var m3: string = CJS_Named_NS.numberValue4; // Error: number ~> string
 //////////////////////////////
 // == ES6 Default -> ES6 == //
 //////////////////////////////
-import { doesntExist4 } from \"ES6_Default_AnonFunction1\";
-
-// Error: Not an exported binding
+import { doesntExist4 } from \"ES6_Default_AnonFunction1\"; // Error: Not an exported binding
 import ES6_Def_AnonFunc1 from \"ES6_Default_AnonFunction1\";
 var n1: number = ES6_Def_AnonFunc1();
-var n2: string = ES6_Def_AnonFunc1();
-
-// Error: number ~> string
+var n2: string = ES6_Def_AnonFunc1(); // Error: number ~> string
 import ES6_Def_NamedFunc1 from \"ES6_Default_NamedFunction1\";
 var o1: number = ES6_Def_NamedFunc1();
-var o2: string = ES6_Def_NamedFunc1();
-
-// Error: number ~> string
+var o2: string = ES6_Def_NamedFunc1(); // Error: number ~> string
 import ES6_Def_NamedClass1 from \"ES6_Default_NamedClass1\";
 var q1: number = new ES6_Def_NamedClass1().givesANum();
-var q2: string = new ES6_Def_NamedClass1().givesANum();
-
-// Error: number ~> string
+var q2: string = new ES6_Def_NamedClass1().givesANum(); // Error: number ~> string
 ////////////////////////////
 // == ES6 Named -> ES6 == //
 ////////////////////////////
-import doesntExist5 from \"ES6_Named1\";
-
-// Error: Not an exported binding
+import doesntExist5 from \"ES6_Named1\"; // Error: Not an exported binding
 import { specifierNumber1 as specifierNumber1_1 } from \"ES6_Named1\";
 var r1: number = specifierNumber1_1;
-var r2: string = specifierNumber1_1;
-
-// Error: number ~> string
+var r2: string = specifierNumber1_1; // Error: number ~> string
 import { specifierNumber2Renamed } from \"ES6_Named1\";
 var s1: number = specifierNumber2Renamed;
-var s2: string = specifierNumber2Renamed;
-
-// Error: number ~> string
+var s2: string = specifierNumber2Renamed; // Error: number ~> string
 import { specifierNumber3 as specifierNumber3Renamed } from \"ES6_Named1\";
 var t1: number = specifierNumber3Renamed;
-var t2: string = specifierNumber3Renamed;
-
-// Error: number ~> string
+var t2: string = specifierNumber3Renamed; // Error: number ~> string
 import { groupedSpecifierNumber1, groupedSpecifierNumber2 } from \"ES6_Named1\";
 var u1: number = groupedSpecifierNumber1;
 var u2: number = groupedSpecifierNumber2;
-var u3: string = groupedSpecifierNumber1;
-// Error: number ~> string
-var u4: string = groupedSpecifierNumber2;
-
-// Error: number ~> string
+var u3: string = groupedSpecifierNumber1; // Error: number ~> string
+var u4: string = groupedSpecifierNumber2; // Error: number ~> string
 import { givesANumber } from \"ES6_Named1\";
 var v1: number = givesANumber();
-var v2: string = givesANumber();
-
-// Error: number ~> string
+var v2: string = givesANumber(); // Error: number ~> string
 import { NumberGenerator } from \"ES6_Named1\";
 var w1: number = new NumberGenerator().givesANumber();
-var w2: string = new NumberGenerator().givesANumber();
-
-// Error: number ~> string
+var w2: string = new NumberGenerator().givesANumber(); // Error: number ~> string
 import { varDeclNumber1, varDeclNumber2 } from \"ES6_Named1\";
 var x1: number = varDeclNumber1;
 var x2: number = varDeclNumber2;
-var x3: string = varDeclNumber1;
-// Error: number ~> string
-var x4: string = varDeclNumber2;
-
-// Error: number ~> string
+var x3: string = varDeclNumber1; // Error: number ~> string
+var x4: string = varDeclNumber2; // Error: number ~> string
 import { numberValue1 as numberValue4 } from \"ES6_ExportFrom_Intermediary1\";
 var aa1: number = numberValue4;
-var aa2: string = numberValue4;
-
-// Error: number ~> string
+var aa2: string = numberValue4; // Error: number ~> string
 import { numberValue2_renamed } from \"ES6_ExportFrom_Intermediary1\";
 var ab1: number = numberValue2_renamed;
-var ab2: string = numberValue2_renamed;
-
-// Error: number ~> string
+var ab2: string = numberValue2_renamed; // Error: number ~> string
 import { numberValue1 as numberValue5 } from \"ES6_ExportAllFrom_Intermediary1\";
 var ac1: number = numberValue5;
-var ac2: string = numberValue5;
-
-// Error: number ~> string
+var ac2: string = numberValue5; // Error: number ~> string
 ///////////////////////////////////
 // == ES6 Default -> CommonJS == //
 ///////////////////////////////////
-require(\"ES6_Default_AnonFunction2\").doesntExist;
-
-// Error: \'doesntExist\' isn\'t an export
+require(\"ES6_Default_AnonFunction2\").doesntExist; // Error: \'doesntExist\' isn\'t an export
 var ES6_Def_AnonFunc2 = require(\"ES6_Default_AnonFunction2\").default;
 var ad1: number = ES6_Def_AnonFunc2();
-var ad2: string = ES6_Def_AnonFunc2();
-
-// Error: number ~> string
+var ad2: string = ES6_Def_AnonFunc2(); // Error: number ~> string
 var ES6_Def_NamedFunc2 = require(\"ES6_Default_NamedFunction2\").default;
 var ae1: number = ES6_Def_NamedFunc2();
-var ae2: string = ES6_Def_NamedFunc2();
-
-// Error: number ~> string
+var ae2: string = ES6_Def_NamedFunc2(); // Error: number ~> string
 var ES6_Def_NamedClass2 = require(\"ES6_Default_NamedClass2\").default;
 var ag1: number = new ES6_Def_NamedClass2().givesANum();
-var ag2: string = new ES6_Def_NamedClass2().givesANum();
-
-// Error: number ~> string
+var ag2: string = new ES6_Def_NamedClass2().givesANum(); // Error: number ~> string
 /////////////////////////////////
 // == ES6 Named -> CommonJS == //
 /////////////////////////////////
 var specifierNumber4 = require(\"ES6_Named2\").specifierNumber4;
 var ah1: number = specifierNumber4;
-var ah2: string = specifierNumber4;
-
-// Error: number ~> string
+var ah2: string = specifierNumber4; // Error: number ~> string
 var specifierNumber5Renamed = require(\"ES6_Named2\").specifierNumber5Renamed;
 var ai1: number = specifierNumber5Renamed;
-var ai2: string = specifierNumber5Renamed;
-
-// Error: number ~> string
+var ai2: string = specifierNumber5Renamed; // Error: number ~> string
 var groupedSpecifierNumber3 = require(\"ES6_Named2\").groupedSpecifierNumber3;
 var groupedSpecifierNumber4 = require(\"ES6_Named2\").groupedSpecifierNumber4;
 var aj1: number = groupedSpecifierNumber3;
 var aj2: number = groupedSpecifierNumber4;
-var aj3: string = groupedSpecifierNumber3;
-// Error: number ~> string
-var aj4: string = groupedSpecifierNumber4;
-
-// Error: number ~> string
+var aj3: string = groupedSpecifierNumber3; // Error: number ~> string
+var aj4: string = groupedSpecifierNumber4; // Error: number ~> string
 var givesANumber2 = require(\"ES6_Named2\").givesANumber2;
 var ak1: number = givesANumber2();
-var ak2: string = givesANumber2();
-
-// Error: number ~> string
+var ak2: string = givesANumber2(); // Error: number ~> string
 var NumberGenerator2 = require(\"ES6_Named2\").NumberGenerator2;
 var al1: number = new NumberGenerator2().givesANumber();
-var al2: string = new NumberGenerator2().givesANumber();
-
-// Error: number ~> string
+var al2: string = new NumberGenerator2().givesANumber(); // Error: number ~> string
 var varDeclNumber3 = require(\"ES6_Named2\").varDeclNumber3;
 var varDeclNumber4 = require(\"ES6_Named2\").varDeclNumber4;
 var am1: number = varDeclNumber3;
 var am2: number = varDeclNumber4;
-var am3: string = varDeclNumber3;
-// Error: number ~> string
-var am4: string = varDeclNumber4;
-
-// Error: number ~> string
+var am3: string = varDeclNumber3; // Error: number ~> string
+var am4: string = varDeclNumber4; // Error: number ~> string
 var numberValue6 = require(\"ES6_ExportFrom_Intermediary2\").numberValue1;
 var ap1: number = numberValue6;
-var ap2: string = numberValue6;
-
-// Error: number ~> string
+var ap2: string = numberValue6; // Error: number ~> string
 var numberValue2_renamed2 = require(
   \"ES6_ExportFrom_Intermediary2\"
 ).numberValue2_renamed2;
 var aq1: number = numberValue2_renamed2;
-var aq2: string = numberValue2_renamed2;
-
-// Error: number ~> string
+var aq2: string = numberValue2_renamed2; // Error: number ~> string
 var numberValue7 = require(\"ES6_ExportAllFrom_Intermediary2\").numberValue2;
 var ar1: number = numberValue7;
-var ar2: string = numberValue7;
-
-// Error: number ~> string
+var ar2: string = numberValue7; // Error: number ~> string
 ////////////////////////////////////////////////////////
 // == ES6 Default+Named -> ES6 import Default+Named== //
 ////////////////////////////////////////////////////////
 import defaultNum, { str as namedStr } from \"./ES6_DefaultAndNamed\";
 
 var as1: number = defaultNum;
-var as2: string = defaultNum;
-
-// Error: number ~> string
+var as2: string = defaultNum; // Error: number ~> string
 var as3: string = namedStr;
-var as4: number = namedStr;
-
-// Error: string ~> number
+var as4: number = namedStr; // Error: string ~> number
 ////////////////////////////////////////
 // == Side-effect only ES6 imports == //
 ////////////////////////////////////////
@@ -1184,11 +1075,8 @@ import \"./SideEffects\";
 //////////////////////////////////////////////
 // == Suggest export name on likely typo == //
 //////////////////////////////////////////////
-import specifierNumber1 from \"ES6_Named1\";
-// Error: Did you mean \`import {specifierNumber1} from ...\`?
-import { specifierNumber } from \"ES6_Named1\";
-
-// Error: Did you mean \`specifierNumber1\`?
+import specifierNumber1 from \"ES6_Named1\"; // Error: Did you mean \`import {specifierNumber1} from ...\`?
+import { specifierNumber } from \"ES6_Named1\"; // Error: Did you mean \`specifierNumber1\`?
 ///////////////////////////////////////////////////
 // == Multi \`export *\` should combine exports == //
 ///////////////////////////////////////////////////
@@ -1198,9 +1086,7 @@ import {
 } from \"./ES6_ExportAllFromMulti\";
 
 var at1: number = numberValue8;
-var at2: string = numberValue8;
-
-// Error: number ~> string
+var at2: string = numberValue8; // Error: number ~> string
 var at3: number = numberValue9;
 var at4: string = numberValue9; // Error: number ~> string
 "

--- a/tests/flow/declare_fun/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_fun/__snapshots__/jsfmt.spec.js.snap
@@ -11,10 +11,8 @@ declare function foo(x: number): string;
 declare function foo(x: string): number;
 declare function foo<X>(x: X): X;
 
-(foo(0): string);
-// OK
-(foo(\"hello\"): number);
-// OK
+(foo(0): string); // OK
+(foo(\"hello\"): number); // OK
 (foo(false): void); // error, boolean ~/~ undefined
 "
 `;

--- a/tests/flow/declare_module_exports/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_module_exports/__snapshots__/jsfmt.spec.js.snap
@@ -29,26 +29,20 @@ import declare_m_e_with_declare_var_e from \"declare_m_e_with_declare_var_e\";
 
 import declare_module_exports from \"declare_module_exports\";
 (declare_module_exports: number);
-(declare_module_exports: string);
-
-// Error: number ~> string
+(declare_module_exports: string); // Error: number ~> string
 // Error: Has no named export \"str\"!
 import { str } from \"declare_m_e_with_other_value_declares\";
 
 import type { str2 } from \"declare_m_e_with_other_type_declares\";
 (\"asdf\": str2);
-(42: str2);
-
-// Error: number ~> string
+(42: str2); // Error: number ~> string
 /**
  * \`declare var exports\` is deprecated, so we have a grace period where both
  * syntaxes will work.
  */
 import DEPRECATED__declare_var_exports from \"DEPRECATED__declare_var_exports\";
 (DEPRECATED__declare_var_exports: number);
-(DEPRECATED__declare_var_exports: string);
-
-// Error: number ~> string
+(DEPRECATED__declare_var_exports: string); // Error: number ~> string
 import declare_m_e_with_declare_var_e from \"declare_m_e_with_declare_var_e\";
 (declare_m_e_with_declare_var_e: number);
 (declare_m_e_with_declare_var_e: string); // Error: number ~> string

--- a/tests/flow/declare_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_type/__snapshots__/jsfmt.spec.js.snap
@@ -40,15 +40,10 @@ blah(0, 0);
 import type { baz } from \"ModuleAliasFoo\";
 import { foo } from \"ModuleAliasFoo\";
 var k1: baz = 42;
-var k2: baz = \"shab\";
-// Error: string to int
-var k3: toz = foo(k1);
-
-// works
+var k2: baz = \"shab\"; // Error: string to int
+var k3: toz = foo(k1); // works
 import type { toz } from \"ModuleAliasFoo\";
-var k4: toz = foo(k1);
-
-// works
+var k4: toz = foo(k1); // works
 //////////////////////////////////////////////////////////
 // == Declared Module with exports prop (issue 880) == //
 ////////////////////////////////////////////////////////
@@ -57,12 +52,8 @@ import type { Foo, Bar, Id } from \"foo\";
 
 blah(0, 0);
 
-({ toz: 3 }: Foo);
-
-// error : {toz : number} ~> string
-(3: Bar);
-
-// error : number ~> A
+({ toz: 3 }: Foo); // error : {toz : number} ~> string
+(3: Bar); // error : number ~> A
 (\"lol\": Id<number>); // error : string ~> number
 "
 `;

--- a/tests/flow/def_site_variance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/def_site_variance/__snapshots__/jsfmt.spec.js.snap
@@ -44,35 +44,22 @@ class A {}
 class B extends A {}
 
 function subtyping(v1: Variance<A, B>, v2: Variance<B, A>) {
-  (v1: Variance<B, A>);
-  // error on both targs (A ~/~> B)
+  (v1: Variance<B, A>); // error on both targs (A ~/~> B)
   (v2: Variance<A, B>); // OK for both targs (B ~> A)
 }
 
 class PropVariance<+Out, -In> {
-  inv1: Out;
-  // error
-  inv2: In;
-  // error
-  -co1: Out;
-  // error
-  -co2: In;
-  // ok
-  +con1: Out;
-  // ok
-  +con2: In;
-
-  // error
-  inv_dict1: { [k: string]: Out };
-  // error
-  inv_dict2: { [k: string]: In };
-  // error
-  co_dict1: { +[k: string]: Out };
-  // ok
-  co_dict2: { +[k: string]: In };
-  // error
-  con_dict1: { -[k: string]: Out };
-  // error
+  inv1: Out; // error
+  inv2: In; // error
+  -co1: Out; // error
+  -co2: In; // ok
+  +con1: Out; // ok
+  +con2: In; // error
+  inv_dict1: { [k: string]: Out }; // error
+  inv_dict2: { [k: string]: In }; // error
+  co_dict1: { +[k: string]: Out }; // ok
+  co_dict2: { +[k: string]: In }; // error
+  con_dict1: { -[k: string]: Out }; // error
   con_dict2: { -[k: string]: In }; // ok
 }
 "

--- a/tests/flow/demo/2/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/demo/2/__snapshots__/jsfmt.spec.js.snap
@@ -22,8 +22,7 @@ module.exports = A;
 /* @providesModule Demo */
 
 class A {
-  x: number;
-  // instance field declaration
+  x: number; // instance field declaration
   constructor(x) {
     this.x = x;
   }

--- a/tests/flow/destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -15,20 +15,12 @@ let [...e] = 0;
 let xs = [0, \"\", true];
 let [a, ...ys] = xs;
 let [b, ...zs] = ys;
-let c = zs[0];
-// retain tuple info
-let d = zs[1];
-
-// run off the end
-(a: void);
-// error: number ~> void
-(b: void);
-// error: string ~> void
-(c: void);
-// error: boolean ~> void
-(d: void);
-
-// error: number|string|boolean ~> void
+let c = zs[0]; // retain tuple info
+let d = zs[1]; // run off the end
+(a: void); // error: number ~> void
+(b: void); // error: string ~> void
+(c: void); // error: boolean ~> void
+(d: void); // error: number|string|boolean ~> void
 let [...e] = 0;
 "
 `;
@@ -45,14 +37,10 @@ var { [\"key\"]: val3, ...spread } = { key: \"val\" };
 (spread.key: void); // error (gasp!) in general we don\'t know if a computed prop should be excluded from spread
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var { [\"key\"]: val1 } = { key: \"val\" };
-(val1: void);
-
-// error: string ~> void
+(val1: void); // error: string ~> void
 var key: string = \"key\";
 var { [key]: val2 } = { key: \"val\" };
-(val2: void);
-
-// ok (gasp!) by existing StrT -> ElemT rule
+(val2: void); // ok (gasp!) by existing StrT -> ElemT rule
 var { [\"key\"]: val3, ...spread } = { key: \"val\" };
 (spread.key: void); // error (gasp!) in general we don\'t know if a computed prop should be excluded from spread
 "
@@ -152,15 +140,10 @@ function obj_prop_fun({ p: { q = 0 } = { q: true } } = { p: { q: \"\" } }) {
   // * null    ~> void, from call below
   (q: void);
 }
-obj_prop_fun();
-// ok
-obj_prop_fun({});
-// ok
-obj_prop_fun({ p: {} });
-// ok
-obj_prop_fun({ p: { q: null } });
-
-// ok, provides add\'l lower bound
+obj_prop_fun(); // ok
+obj_prop_fun({}); // ok
+obj_prop_fun({ p: {} }); // ok
+obj_prop_fun({ p: { q: null } }); // ok, provides add\'l lower bound
 function obj_prop_var(o = { p: { q: \"\" } }) {
   var { p: { q = 0 } = { q: true } } = o;
   // errors:
@@ -170,15 +153,10 @@ function obj_prop_var(o = { p: { q: \"\" } }) {
   // * null    ~> void, from call below
   (q: void);
 }
-obj_prop_var();
-// ok
-obj_prop_var({});
-// ok
-obj_prop_var({ p: {} });
-// ok
-obj_prop_var({ p: { q: null } });
-
-// ok, provides add\'l lower bound
+obj_prop_var(); // ok
+obj_prop_var({}); // ok
+obj_prop_var({ p: {} }); // ok
+obj_prop_var({ p: { q: null } }); // ok, provides add\'l lower bound
 function obj_rest(
   { p: { q, ...o } = { q: 0, r: 0 } } = { p: { q: 0, r: \"\" } }
 ) {
@@ -188,55 +166,38 @@ function obj_rest(
   // * null    ~> void, from call below
   (o.r: void);
 }
-obj_rest();
-// ok
-obj_rest({});
-// ok
-obj_rest({ p: {} });
-// ok
+obj_rest(); // ok
+obj_rest({}); // ok
+obj_rest({ p: {} }); // ok
 obj_rest({ p: { q: 0, r: null } });
 
 function obj_prop_annot(
   {
-    // error: boolean ~> string
-    p = true
+    p = true // error: boolean ~> string
   }: { p: string } = {
-    // error: number ~> string
-    p: 0
+    p: 0 // error: number ~> string
   }
 ) {
   (p: void); // error: string ~> void
 }
 
 var {
-  // error: boolean ~> string
-  p = true
+  p = true // error: boolean ~> string
 }: { p: string } = {
-  // error: number ~> string
-  p: 0
+  p: 0 // error: number ~> string
 };
-(p: void);
-
-// error: string ~> void
-function obj_prop_err({ x: { y } } = null) {}
-// error: property \`x\` cannot be accessed on null
-function obj_rest_err({ ...o } = 0) {}
-// error: expected object instead of number
-function arr_elem_err([x] = null) {}
-// error: element 0 cannot be accessed on null
-function arr_rest_err([...a] = null) {}
-
-// error: expected array instead of null
+(p: void); // error: string ~> void
+function obj_prop_err({ x: { y } } = null) {} // error: property \`x\` cannot be accessed on null
+function obj_rest_err({ ...o } = 0) {} // error: expected object instead of number
+function arr_elem_err([x] = null) {} // error: element 0 cannot be accessed on null
+function arr_rest_err([...a] = null) {} // error: expected array instead of null
 function gen<T>(x: T, { p = x }: { p: T }): T {
   return p;
 }
 
 // Default values in destructuring unwrap optional types
-obj_prop_fun(({}: { p?: { q?: null } }));
-// ok
-obj_prop_var(({}: { p?: { q?: null } }));
-
-// ok
+obj_prop_fun(({}: { p?: { q?: null } })); // ok
+obj_prop_var(({}: { p?: { q?: null } })); // ok
 // union-like upper bounds preserved through destructuring
 function obj_prop_opt({ p }: { p?: string } = { p: 0 }) {}
 function obj_prop_maybe({ p }: { p: ?string } = { p: 0 }) {}
@@ -359,16 +320,14 @@ corge({ b: 0 });
 var { n }: { n: number } = { n: \"\" };
 
 function test() {
-  var { foo } = { bar: 123 };
-  // error on foo
+  var { foo } = { bar: 123 }; // error on foo
   var { bar, baz } = { bar: 123 }; // error on baz
 }
 
 function test() {
   var x = { foo: \"abc\", bar: 123 };
   var { foo, ...rest } = x;
-  (x.baz: string);
-  // error, baz doesn\'t exist
+  (x.baz: string); // error, baz doesn\'t exist
   (rest.baz: string); // no error, rest is unsealed
 }
 
@@ -387,15 +346,11 @@ class Child extends Base {
 var { baseprop1, childprop1, ...others } = new Child();
 
 var bp1: number = baseprop1;
-var bp1_err: string = baseprop1;
-// Error: number ~> string
+var bp1_err: string = baseprop1; // Error: number ~> string
 var bp2: number = others.baseprop2;
-var bp2_err: string = others.baseprop2;
-
-// Error: number ~> string
+var bp2_err: string = others.baseprop2; // Error: number ~> string
 var cp1: number = childprop1;
-var cp1_err: string = childprop1;
-// Error: number ~> string
+var cp1_err: string = childprop1; // Error: number ~> string
 var cp2: number = others.childprop1;
 var cp2_err: string = others.childprop2; // Error: number ~> string
 "
@@ -474,46 +429,38 @@ function arr_rest_pattern<X>([ _, ...a ] : ArrRest<X>) { // a: [X]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // @flow
 
-function obj_pattern<X>({ prop }: { prop: X }) {}
-// prop: X
+function obj_pattern<X>({ prop }: { prop: X }) {} // prop: X
 type Prop<X> = { prop: X };
-function obj_pattern2<X>({ prop }: Prop<X>) {}
-
-// prop: X
-function arr_pattern<X>([elem]: X[]) {}
-// elem: X
+function obj_pattern2<X>({ prop }: Prop<X>) {} // prop: X
+function arr_pattern<X>([elem]: X[]) {} // elem: X
 type Elem<X> = X[];
-function arr_pattern2<X>([elem]: Elem<X>) {}
-
-// elem: X
-function tup_pattern<X>([proj]: [X]) {}
-// proj: X
+function arr_pattern2<X>([elem]: Elem<X>) {} // elem: X
+function tup_pattern<X>([proj]: [X]) {} // proj: X
 type Proj<X> = [X];
-function tup_pattern2<X>([proj]: Proj<X>) {}
-
-// proj: X
-function rest_antipattern<T>(...t: T) {}
-// nonsense
-function rest_pattern<X>(...r: X[]) {}
-
-// r: X[]
-function obj_rest_pattern<X>({ _, ...o }: { _: any, x: X }) {
-  // o: { x: X }
+function tup_pattern2<X>([proj]: Proj<X>) {} // proj: X
+function rest_antipattern<T>(...t: T) {} // nonsense
+function rest_pattern<X>(...r: X[]) {} // r: X[]
+function obj_rest_pattern<X>(
+  { _, ...o }: { _: any, x: X } // o: { x: X }
+) {
   o.x;
 }
 type ObjRest<X> = { _: any, x: X };
-function obj_rest_pattern<X>({ _, ...o }: ObjRest<X>) {
-  // o: { x: X }
+function obj_rest_pattern<X>(
+  { _, ...o }: ObjRest<X> // o: { x: X }
+) {
   o.x;
 }
 
-function arr_rest_pattern<X>([_, ...a]: [any, X]) {
-  // a: [X]
+function arr_rest_pattern<X>(
+  [_, ...a]: [any, X] // a: [X]
+) {
   a[0];
 }
 type ArrRest<X> = [any, X];
-function arr_rest_pattern<X>([_, ...a]: ArrRest<X>) {
-  // a: [X]
+function arr_rest_pattern<X>(
+  [_, ...a]: ArrRest<X> // a: [X]
+) {
   a[0];
 }
 "
@@ -571,9 +518,7 @@ var { \"with-dash\": with_dash } = { \"with-dash\": \"motivating example\" };
 (with_dash: \"motivating example\"); // ok
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var { key: val } = { key: \"val\" };
-(val: void);
-
-// error: string ~> void
+(val: void); // error: string ~> void
 var { \"with-dash\": with_dash } = { \"with-dash\": \"motivating example\" };
 (with_dash: \"motivating example\"); // ok
 "

--- a/tests/flow/dictionary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/dictionary/__snapshots__/jsfmt.spec.js.snap
@@ -406,26 +406,21 @@ function set_prop_to_string_key(o: { [k: string]: any }) {
 // This is allowed by design. We don\'t track get/set and we don\'t wrap the
 // return type in a maybe.
 function unsound_dict_has_every_key(o: { [k: string]: X }) {
-  (o.p: X);
-  // ok
+  (o.p: X); // ok
   (o[\"p\"]: X); // ok
 }
 
 // As with any object type, we can assign subtypes to properties.
 function set_prop_covariant(o: { [k: string]: B }) {
-  o.p = new A();
-  // error, A ~> B
-  o.p = new B();
-  // ok
+  o.p = new A(); // error, A ~> B
+  o.p = new B(); // ok
   o.p = new C(); // ok
 }
 
 // This isn\'t specific behavior to dictionaries, but for completeness...
 function get_prop_contravariant(o: { [k: string]: B }) {
-  (o.p: A);
-  // ok
-  (o.p: B);
-  // ok
+  (o.p: A); // ok
+  (o.p: B); // ok
   (o.p: C); // error, C ~> B
 }
 
@@ -444,12 +439,9 @@ function add_prop_to_nonstring_key_bracket(o: { [k: number]: any }) {
 
 // Objects can be part dict, part not by mixing an indexer with declared props.
 function mix_with_declared_props(o: { [k: number]: X, p: Y }, x: X, y: Y) {
-  (o[0]: X);
-  // ok
-  (o.p: Y);
-  // ok
-  o[0] = x;
-  // ok
+  (o[0]: X); // ok
+  (o.p: Y); // ok
+  o[0] = x; // ok
   o.p = y; // ok
 }
 
@@ -457,8 +449,7 @@ function mix_with_declared_props(o: { [k: number]: X, p: Y }, x: X, y: Y) {
 function object_prototype(
   o: { [k: string]: number }
 ): { [k: string]: number, +toString: () => string } {
-  (o.toString(): boolean);
-  // error: string ~> boolean
+  (o.toString(): boolean); // error: string ~> boolean
   return o; // ok
 }
 
@@ -472,59 +463,38 @@ function unsound_string_conversion_alias_declared_prop(
 }
 
 function unification_dict_values_invariant(x: Array<{ [k: string]: B }>) {
-  let a: Array<{ [k: string]: A }> = x;
-  // error
-  a[0].p = new A();
-
-  // in[0].p no longer B
-  let b: Array<{ [k: string]: B }> = x;
-
-  // ok
-  let c: Array<{ [k: string]: C }> = x;
-  // error
+  let a: Array<{ [k: string]: A }> = x; // error
+  a[0].p = new A(); // in[0].p no longer B
+  let b: Array<{ [k: string]: B }> = x; // ok
+  let c: Array<{ [k: string]: C }> = x; // error
   (x[0].p: C); // not true
 }
 
 function subtype_dict_values_invariant(x: { [k: string]: B }) {
-  let a: { [k: string]: A } = x;
-  // error
-  a.p = new A();
-
-  // x[0].p no longer B
-  let b: { [k: string]: B } = x;
-
-  // ok
-  let c: { [k: string]: C } = x;
-  // error
+  let a: { [k: string]: A } = x; // error
+  a.p = new A(); // x[0].p no longer B
+  let b: { [k: string]: B } = x; // ok
+  let c: { [k: string]: C } = x; // error
   (x.p: C); // not true
 }
 
 function subtype_dict_values_fresh_exception() {
   let a: { [k: string]: A } = {
-    a: new A(),
-    // ok, A == A
-    b: new B(),
-    // ok, B <: A
-    // ok, C <: A
-    c: new C()
+    a: new A(), // ok, A == A
+    b: new B(), // ok, B <: A
+    c: new C() // ok, C <: A
   };
 
   let b: { [k: string]: B } = {
-    a: new A(),
-    // error, A not <: B
-    b: new B(),
-    // ok, B == B
-    // ok, C <: A
-    c: new C()
+    a: new A(), // error, A not <: B
+    b: new B(), // ok, B == B
+    c: new C() // ok, C <: A
   };
 
   let c: { [k: string]: C } = {
-    a: new A(),
-    // error, A not <: C
-    b: new B(),
-    // error, A not <: C
-    // ok, C == C
-    c: new C()
+    a: new A(), // error, A not <: C
+    b: new B(), // error, A not <: C
+    c: new C() // ok, C == C
   };
 }
 
@@ -534,34 +504,24 @@ function subtype_dict_values_fresh_exception() {
 // Barring some compelling use case for that in this context, though, we choose
 // to be strict.
 function unification_dict_keys_invariant(x: Array<{ [k: B]: any }>) {
-  let a: Array<{ [k: A]: any }> = x;
-  // error
-  let b: Array<{ [k: B]: any }> = x;
-  // ok
+  let a: Array<{ [k: A]: any }> = x; // error
+  let b: Array<{ [k: B]: any }> = x; // ok
   let c: Array<{ [k: C]: any }> = x; // error
 }
 
 function subtype_dict_keys_invariant(x: { [k: B]: any }) {
-  let a: { [k: A]: any } = x;
-  // error
-  let b: { [k: B]: any } = x;
-  // ok
+  let a: { [k: A]: any } = x; // error
+  let b: { [k: B]: any } = x; // ok
   let c: { [k: C]: any } = x; // error
 }
 
 function unification_mix_with_declared_props_invariant_l(
   x: Array<{ [k: string]: B }>
 ) {
-  let a: Array<{ [k: string]: B, p: A }> = x;
-  // error: A ~> B
-  a[0].p = new A();
-
-  // x[0].p no longer B
-  let b: Array<{ [k: string]: B, p: B }> = x;
-
-  // ok
-  let c: Array<{ [k: string]: B, p: C }> = x;
-  // error
+  let a: Array<{ [k: string]: B, p: A }> = x; // error: A ~> B
+  a[0].p = new A(); // x[0].p no longer B
+  let b: Array<{ [k: string]: B, p: B }> = x; // ok
+  let c: Array<{ [k: string]: B, p: C }> = x; // error
   (x[0].p: C); // not true
 }
 
@@ -570,30 +530,18 @@ function unification_mix_with_declared_props_invariant_r(
   xb: Array<{ [k: string]: B, p: B }>,
   xc: Array<{ [k: string]: C, p: B }>
 ) {
-  let a: Array<{ [k: string]: A }> = xa;
-  // error
-  a[0].p = new A();
-
-  // xa[0].p no longer B
-  let b: Array<{ [k: string]: B }> = xb;
-
-  // ok
-  let c: Array<{ [k: string]: C }> = xc;
-  // error
+  let a: Array<{ [k: string]: A }> = xa; // error
+  a[0].p = new A(); // xa[0].p no longer B
+  let b: Array<{ [k: string]: B }> = xb; // ok
+  let c: Array<{ [k: string]: C }> = xc; // error
   (xc[0].p: C); // not true
 }
 
 function subtype_mix_with_declared_props_invariant_l(x: { [k: string]: B }) {
-  let a: { [k: string]: B, p: A } = x;
-  // error: A ~> B
-  a.p = new A();
-
-  // x.p no longer B
-  let b: { [k: string]: B, p: B } = x;
-
-  // ok
-  let c: { [k: string]: B, p: C } = x;
-  // error
+  let a: { [k: string]: B, p: A } = x; // error: A ~> B
+  a.p = new A(); // x.p no longer B
+  let b: { [k: string]: B, p: B } = x; // ok
+  let c: { [k: string]: B, p: C } = x; // error
   (x.p: C); // not true
 }
 
@@ -602,16 +550,10 @@ function subtype_mix_with_declared_props_invariant_r(
   xb: { [k: string]: B, p: B },
   xc: { [k: string]: C, p: B }
 ) {
-  let a: { [k: string]: A } = xa;
-  // error
-  a.p = new A();
-
-  // xa.p no longer B
-  let b: { [k: string]: B } = xb;
-
-  // ok
-  let c: { [k: string]: C } = xc;
-  // error
+  let a: { [k: string]: A } = xa; // error
+  a.p = new A(); // xa.p no longer B
+  let b: { [k: string]: B } = xb; // ok
+  let c: { [k: string]: C } = xc; // error
   (xc.p: C); // not true
 }
 
@@ -628,55 +570,39 @@ function unification_obj_to_dict(
 }
 
 function subtype_dict_to_obj(x: { [k: string]: B }) {
-  let a: { p: A } = x;
-  // error
-  a.p = new A();
-
-  // x.p no longer B
-  let b: { p: B } = x;
-
-  // ok
-  let c: { p: C } = x;
-  // error
+  let a: { p: A } = x; // error
+  a.p = new A(); // x.p no longer B
+  let b: { p: B } = x; // ok
+  let c: { p: C } = x; // error
   (x.p: C); // not true
 }
 
 function subtype_obj_to_dict(x: { p: B }) {
-  let a: { [k: string]: A } = x;
-  // error
-  a.p = new A();
-
-  // x.p no longer B
+  let a: { [k: string]: A } = x; // error
+  a.p = new A(); // x.p no longer B
   let b: { [k: string]: B } = x;
 
-  let c: { [k: string]: C } = x;
-  // error
+  let c: { [k: string]: C } = x; // error
   (x.p: C); // not true
 }
 
 // Only props in l which are not in u must match indexer, but must do so
 // exactly.
 function subtype_obj_to_mixed(x: { p: B, x: X }) {
-  let a: { [k: string]: A, x: X } = x;
-  // error (as above), but exclusive of x
-  let b: { [k: string]: B, x: X } = x;
-  // ok,
+  let a: { [k: string]: A, x: X } = x; // error (as above), but exclusive of x
+  let b: { [k: string]: B, x: X } = x; // ok,
   let c: { [k: string]: C, x: X } = x; // error (as above), but exclusive of x
 }
 
 function unification_dict_to_mixed(x: Array<{ [k: string]: B }>) {
-  let a: Array<{ [k: string]: B, p: A }> = x;
-  // error
-  let b: Array<{ [k: string]: B, p: B }> = x;
-  // ok
+  let a: Array<{ [k: string]: B, p: A }> = x; // error
+  let b: Array<{ [k: string]: B, p: B }> = x; // ok
   let c: Array<{ [k: string]: B, p: C }> = x; // error
 }
 
 function subtype_dict_to_mixed(x: { [k: string]: B }) {
-  let a: { [k: string]: B, p: A } = x;
-  // error
-  let b: { [k: string]: B, p: B } = x;
-  // ok
+  let a: { [k: string]: B, p: A } = x; // error
+  let b: { [k: string]: B, p: B } = x; // ok
   let c: { [k: string]: B, p: C } = x; // error
 }
 
@@ -692,18 +618,21 @@ function subtype_dict_to_optional_c(x: { [k: string]: B }) {
   let c: { p?: C } = x; // error
 }
 
-function subtype_optional_a_to_dict(x: { p?: A }): { [k: string]: B } {
-  // error: A ~> B
+function subtype_optional_a_to_dict(
+  x: { p?: A }
+): { [k: string]: B } { // error: A ~> B
   return x;
 }
 
-function subtype_optional_b_to_dict(x: { p?: B }): { [k: string]: B } {
-  // ok
+function subtype_optional_b_to_dict(
+  x: { p?: B }
+): { [k: string]: B } { // ok
   return x;
 }
 
-function subtype_optional_c_to_dict(x: { p?: C }): { [k: string]: B } {
-  // error: C ~> B
+function subtype_optional_c_to_dict(
+  x: { p?: C }
+): { [k: string]: B } { // error: C ~> B
   return x;
 }
 "
@@ -771,17 +700,11 @@ function foo8(x: {[key: string]: number}) {
 /* @flow */
 
 var x: { [key: string]: string } = {};
-var y: { [key: string]: number } = x;
-// 2 errors, number !~> string & vice versa
-var z: { [key: number]: string } = x;
-
-// 2 errors, string !~> number & vice versa
+var y: { [key: string]: number } = x; // 2 errors, number !~> string & vice versa
+var z: { [key: number]: string } = x; // 2 errors, string !~> number & vice versa
 var a: { [key: string]: ?string } = {};
-var b: { [key: string]: string } = a;
-// 2 errors (null & undefined)
-var c: { [key: string]: ?string } = b;
-
-// 2 errors, since c[\'x\'] = null updates b
+var b: { [key: string]: string } = a; // 2 errors (null & undefined)
+var c: { [key: string]: ?string } = b; // 2 errors, since c[\'x\'] = null updates b
 // 2 errors (number !~> string, string !~> number)
 function foo0(
   x: Array<{ [key: string]: number }>
@@ -799,8 +722,7 @@ function foo1(
 function foo2(
   x: Array<{ [key: string]: mixed }>
 ): Array<{ [key: string]: mixed, fooBar: string }> {
-  x[0].fooBar = 123;
-  // OK, since number ~> mixed (x elem\'s dictionary)
+  x[0].fooBar = 123; // OK, since number ~> mixed (x elem\'s dictionary)
   return x; // error: mixed ~> string
 }
 
@@ -831,8 +753,7 @@ function foo7(x: { [key: string]: number, bar: string }) {
 }
 
 function foo8(x: { [key: string]: number }) {
-  (x.foo: string);
-  // error
+  (x.foo: string); // error
   (x.foo: number);
 }
 "

--- a/tests/flow/disjoint-union-perf/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/disjoint-union-perf/__snapshots__/jsfmt.spec.js.snap
@@ -256,8 +256,7 @@ function getBinaryOp(
 
 export function emitExpression(node: TypedNode): t.Expression {
   switch (node.exprNodeType) {
-    case \"string_literal\":
-    // FALLTHROUGH
+    case \"string_literal\": // FALLTHROUGH
     case \"number\":
       return b.literal(node.value);
     case \"variable\":

--- a/tests/flow/dom/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/dom/__snapshots__/jsfmt.spec.js.snap
@@ -201,8 +201,7 @@ let tests = [
   // setRangeText
   function(el: HTMLInputElement) {
     el.setRangeText(\"foo\");
-    el.setRangeText(\"foo\", 123);
-    // end is required
+    el.setRangeText(\"foo\", 123); // end is required
     el.setRangeText(\"foo\", 123, 234);
     el.setRangeText(\"foo\", 123, 234, \"select\");
     el.setRangeText(\"foo\", 123, 234, \"bogus\"); // invalid value
@@ -235,39 +234,22 @@ const r: string = c.username; // correct
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
 
-const a = new URL(\"http://flowtype.org/\");
-// correct
-const b = new URL(\"/docs\", a);
-// correct
-const c = new URL(\"/docs\", \"http://flowtype.org/\");
-
-// correct
-const d: URLSearchParams = c.searchParams;
-// correct
-const e: string = c.path;
-// not correct
-const f: string = c.pathname;
-// correct
-const g: string = c.hash;
-// correct
-const h: string = c.host;
-// correct
-const i: string = c.hostname;
-// correct
-const j: string = c.href;
-// correct
-const l: string = c.origin;
-// correct
-const m: string = c.password;
-// correct
-const n: string = c.pathname;
-// correct
-const o: string = c.port;
-// correct
-const p: string = c.protocol;
-// correct
-const q: string = c.search;
-// correct
+const a = new URL(\"http://flowtype.org/\"); // correct
+const b = new URL(\"/docs\", a); // correct
+const c = new URL(\"/docs\", \"http://flowtype.org/\"); // correct
+const d: URLSearchParams = c.searchParams; // correct
+const e: string = c.path; // not correct
+const f: string = c.pathname; // correct
+const g: string = c.hash; // correct
+const h: string = c.host; // correct
+const i: string = c.hostname; // correct
+const j: string = c.href; // correct
+const l: string = c.origin; // correct
+const m: string = c.password; // correct
+const n: string = c.pathname; // correct
+const o: string = c.port; // correct
+const p: string = c.protocol; // correct
+const q: string = c.search; // correct
 const r: string = c.username; // correct
 "
 `;
@@ -307,15 +289,13 @@ let tests = [
   // attachEvent
   function() {
     let target = new EventTarget();
-    (target.attachEvent(\"foo\", listener): void);
-    // invalid, may be undefined
+    (target.attachEvent(\"foo\", listener): void); // invalid, may be undefined
     (target.attachEvent && target.attachEvent(\"foo\", listener): void); // valid
   },
   // detachEvent
   function() {
     let target = new EventTarget();
-    (target.detachEvent(\"foo\", listener): void);
-    // invalid, may be undefined
+    (target.detachEvent(\"foo\", listener): void); // invalid, may be undefined
     (target.detachEvent && target.detachEvent(\"foo\", listener): void); // valid
   },
   function() {
@@ -346,10 +326,8 @@ let tests = [
   // arcTo
   function() {
     let path = new Path2D();
-    (path.arcTo(0, 0, 0, 0, 10): void);
-    // valid
-    (path.arcTo(0, 0, 0, 0, 10, 20, 5): void);
-    // valid
+    (path.arcTo(0, 0, 0, 0, 10): void); // valid
+    (path.arcTo(0, 0, 0, 0, 10, 20, 5): void); // valid
     (path.arcTo(0, 0, 0, 0, 10, \"20\", 5): void); // invalid
   }
 ];
@@ -459,10 +437,8 @@ let tests = [
       prototype: {
         attributeChangedCallback(
           localName: string,
-          oldVal: string,
-          // Error: This might be null
-          newVal: string,
-          // Error: This might be null
+          oldVal: string, // Error: This might be null
+          newVal: string, // Error: This might be null
           namespace: string
         ) {}
       }
@@ -691,8 +667,7 @@ let tests = [
   },
   // rootNode must be a Node
   function() {
-    document.createNodeIterator(document.body);
-    // valid
+    document.createNodeIterator(document.body); // valid
     document.createNodeIterator({}); // invalid
   },
   function() {
@@ -859,18 +834,14 @@ let tests = [
       document.body,
       -1,
       node => NodeFilter.FILTER_ACCEPT
-    );
-    // valid
-    document.createNodeIterator(document.body, -1, node => \"accept\");
-    // invalid
+    ); // valid
+    document.createNodeIterator(document.body, -1, node => \"accept\"); // invalid
     document.createNodeIterator(document.body, -1, {
       accept: node => NodeFilter.FILTER_ACCEPT
-    });
-    // valid
+    }); // valid
     document.createNodeIterator(document.body, -1, {
       accept: node => \"accept\"
-    });
-    // invalid
+    }); // invalid
     document.createNodeIterator(document.body, -1, {}); // invalid
   },
   function() {
@@ -878,16 +849,12 @@ let tests = [
       document.body,
       -1,
       node => NodeFilter.FILTER_ACCEPT
-    );
-    // valid
-    document.createTreeWalker(document.body, -1, node => \"accept\");
-    // invalid
+    ); // valid
+    document.createTreeWalker(document.body, -1, node => \"accept\"); // invalid
     document.createTreeWalker(document.body, -1, {
       accept: node => NodeFilter.FILTER_ACCEPT
-    });
-    // valid
-    document.createTreeWalker(document.body, -1, { accept: node => \"accept\" });
-    // invalid
+    }); // valid
+    document.createTreeWalker(document.body, -1, { accept: node => \"accept\" }); // invalid
     document.createTreeWalker(document.body, -1, {}); // invalid
   }
 ];

--- a/tests/flow/encaps/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/encaps/__snapshots__/jsfmt.spec.js.snap
@@ -18,12 +18,9 @@ var s3 = tag2 \`la la la\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class A {}
 var a = new A();
-var s1 = \`l\${a.x}r\`;
-
-// error: no prop x in A
+var s1 = \`l\${a.x}r\`; // error: no prop x in A
 function tag(strings, ...values) {
-  var x: number = strings[0];
-  // error: string ~> number
+  var x: number = strings[0]; // error: string ~> number
   return x;
 }
 var s2 = tag\`l\${42}r\`;

--- a/tests/flow/enumerror/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/enumerror/__snapshots__/jsfmt.spec.js.snap
@@ -46,8 +46,7 @@ type Union = \"x\" | \"y\";
 
 function keys2union(s: Keys): Union {
   return s;
-}
-// ok
+} // ok
 function union2keys(s: Union): Keys {
   return s;
 } // ok

--- a/tests/flow/equals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/equals/__snapshots__/jsfmt.spec.js.snap
@@ -18,11 +18,8 @@ var x = (null : ?number);
 \"foo\" == \"bar\";
 1 == null;
 null == 1;
-1 == \"\";
-// error
-\"\" == 1;
-
-// error
+1 == \"\"; // error
+\"\" == 1; // error
 var x = (null: ?number);
 x == 1;
 1 == x;

--- a/tests/flow/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -991,324 +991,203 @@ import {typeAlias} from \"./ExportType\"; // Error: Cannot vanilla-import a type
 // @providesModule
 import * as DefaultA from \"A\";
 var a1: number = DefaultA.numberValue1;
-var a2: string = DefaultA.numberValue1;
-
-// Error: number ~> string
+var a2: string = DefaultA.numberValue1; // Error: number ~> string
 // File path
 import * as DefaultB from \"./B\";
 var b1: number = DefaultB.numberValue;
-var b2: string = DefaultB.numberValue;
-
-// Error: number ~> string
+var b2: string = DefaultB.numberValue; // Error: number ~> string
 // C.js exists, but not as a providesModule
-import DefaultC from \"C\";
-
-// Error: No such module
+import DefaultC from \"C\"; // Error: No such module
 // @providesModule D exists, but not as a filename
-import DefaultD from \"./D\";
-
-// Error: No such module
+import DefaultD from \"./D\"; // Error: No such module
 // ================================================ //
 // == CommonJS Clobbering Literal Exports -> ES6 == //
 // ================================================ //
-import { doesntExist1 } from \"CommonJS_Clobbering_Lit\";
-
-// Error: Not an exported binding
+import { doesntExist1 } from \"CommonJS_Clobbering_Lit\"; // Error: Not an exported binding
 import { numberValue1 } from \"CommonJS_Clobbering_Lit\";
 var c1: number = numberValue1;
-var c2: string = numberValue1;
-
-// Error: number ~> string
+var c2: string = numberValue1; // Error: number ~> string
 import { numberValue2 as numVal1 } from \"CommonJS_Clobbering_Lit\";
 var d1: number = numVal1;
-var d2: string = numVal1;
-
-// Error: number ~> string
+var d2: string = numVal1; // Error: number ~> string
 import CJS_Clobb_Lit from \"CommonJS_Clobbering_Lit\";
 var e1: number = CJS_Clobb_Lit.numberValue3;
-var e2: string = CJS_Clobb_Lit.numberValue3;
-// Error: number ~> string
-CJS_Clobb_Lit.doesntExist;
-
-// Error: doesntExist isn\'t a property
+var e2: string = CJS_Clobb_Lit.numberValue3; // Error: number ~> string
+CJS_Clobb_Lit.doesntExist; // Error: doesntExist isn\'t a property
 import * as CJS_Clobb_Lit_NS from \"CommonJS_Clobbering_Lit\";
 var f1: number = CJS_Clobb_Lit_NS.numberValue4;
 var f2: number = CJS_Clobb_Lit_NS.default.numberValue4;
-CJS_Clobb_Lit_NS.default.default;
-// Error: No \'default\' property on the exported obj
-var f3: string = CJS_Clobb_Lit_NS.numberValue4;
-// Error: number ~> string
-var f4: string = CJS_Clobb_Lit_NS.default.numberValue5;
-
-// Error: number ~> string
+CJS_Clobb_Lit_NS.default.default; // Error: No \'default\' property on the exported obj
+var f3: string = CJS_Clobb_Lit_NS.numberValue4; // Error: number ~> string
+var f4: string = CJS_Clobb_Lit_NS.default.numberValue5; // Error: number ~> string
 // ============================================== //
 // == CommonJS Clobbering Class Exports -> ES6 == //
 // ============================================== //
-import { doesntExist2 } from \"CommonJS_Clobbering_Class\";
-
-// Error: Not an exported binding
+import { doesntExist2 } from \"CommonJS_Clobbering_Class\"; // Error: Not an exported binding
 // The following import should error because class statics are not turned into
 // named exports for now. This avoids complexities with polymorphic static
 // members (where the polymophism is defined on the class itself rather than the
 // method).
-import { staticNumber1, baseProp, childProp } from \"CommonJS_Clobbering_Class\";
-
-// Error
+import { staticNumber1, baseProp, childProp } from \"CommonJS_Clobbering_Class\"; // Error
 import CJS_Clobb_Class from \"CommonJS_Clobbering_Class\";
 new CJS_Clobb_Class();
-new CJS_Clobb_Class().doesntExist;
-// Error: Class has no \`doesntExist\` property
+new CJS_Clobb_Class().doesntExist; // Error: Class has no \`doesntExist\` property
 var h1: number = CJS_Clobb_Class.staticNumber2();
-var h2: string = CJS_Clobb_Class.staticNumber2();
-// Error: number ~> string
+var h2: string = CJS_Clobb_Class.staticNumber2(); // Error: number ~> string
 var h3: number = new CJS_Clobb_Class().instNumber1();
-var h4: string = new CJS_Clobb_Class().instNumber1();
-
-// Error: number ~> string
+var h4: string = new CJS_Clobb_Class().instNumber1(); // Error: number ~> string
 import * as CJS_Clobb_Class_NS from \"CommonJS_Clobbering_Class\";
-new CJS_Clobb_Class_NS();
-// Error: Namespace object isn\'t constructable
-var i1: number = CJS_Clobb_Class_NS.staticNumber3();
-// Error: Class statics not copied to Namespace object
+new CJS_Clobb_Class_NS(); // Error: Namespace object isn\'t constructable
+var i1: number = CJS_Clobb_Class_NS.staticNumber3(); // Error: Class statics not copied to Namespace object
 var i2: number = new CJS_Clobb_Class_NS.default().instNumber2();
-var i3: string = new CJS_Clobb_Class_NS.default().instNumber2();
-
-// Error: number ~> string
+var i3: string = new CJS_Clobb_Class_NS.default().instNumber2(); // Error: number ~> string
 // =================================== //
 // == CommonJS Named Exports -> ES6 == //
 // =================================== //
-import { doesntExist3 } from \"CommonJS_Named\";
-
-// Error: Not an exported binding
+import { doesntExist3 } from \"CommonJS_Named\"; // Error: Not an exported binding
 import { numberValue2 } from \"CommonJS_Named\";
 var j1: number = numberValue2;
-var j2: string = numberValue2;
-
-// Error: number ~> string
+var j2: string = numberValue2; // Error: number ~> string
 import { numberValue3 as numVal3 } from \"CommonJS_Named\";
 var k1: number = numVal3;
-var k2: string = numVal3;
-
-// Error: number ~> string
+var k2: string = numVal3; // Error: number ~> string
 import * as CJS_Named from \"CommonJS_Named\";
 var l1: number = CJS_Named.numberValue1;
-var l2: string = CJS_Named.numberValue1;
-// Error: number ~> string
-CJS_Named.doesntExist;
-
-// Error: doesntExist isn\'t a property
+var l2: string = CJS_Named.numberValue1; // Error: number ~> string
+CJS_Named.doesntExist; // Error: doesntExist isn\'t a property
 import * as CJS_Named_NS from \"CommonJS_Named\";
 var m1: number = CJS_Named_NS.numberValue4;
-var m2: string = CJS_Named_NS.default.numberValue4;
-// Error: CommonJS_Named has no default export
-var m3: string = CJS_Named_NS.numberValue4;
-
-// Error: number ~> string
+var m2: string = CJS_Named_NS.default.numberValue4; // Error: CommonJS_Named has no default export
+var m3: string = CJS_Named_NS.numberValue4; // Error: number ~> string
 //////////////////////////////
 // == ES6 Default -> ES6 == //
 //////////////////////////////
-import { doesntExist4 } from \"ES6_Default_AnonFunction1\";
-
-// Error: Not an exported binding
+import { doesntExist4 } from \"ES6_Default_AnonFunction1\"; // Error: Not an exported binding
 import ES6_Def_AnonFunc1 from \"ES6_Default_AnonFunction1\";
 var n1: number = ES6_Def_AnonFunc1();
-var n2: string = ES6_Def_AnonFunc1();
-
-// Error: number ~> string
+var n2: string = ES6_Def_AnonFunc1(); // Error: number ~> string
 import ES6_Def_NamedFunc1 from \"ES6_Default_NamedFunction1\";
 var o1: number = ES6_Def_NamedFunc1();
-var o2: string = ES6_Def_NamedFunc1();
-
-// Error: number ~> string
+var o2: string = ES6_Def_NamedFunc1(); // Error: number ~> string
 import ES6_Def_AnonClass1 from \"ES6_Default_AnonClass1\";
 var p1: number = new ES6_Def_AnonClass1().givesANum();
-var p2: string = new ES6_Def_AnonClass1().givesANum();
-
-// Error: number ~> string
+var p2: string = new ES6_Def_AnonClass1().givesANum(); // Error: number ~> string
 import ES6_Def_NamedClass1 from \"ES6_Default_NamedClass1\";
 var q1: number = new ES6_Def_NamedClass1().givesANum();
-var q2: string = new ES6_Def_NamedClass1().givesANum();
-
-// Error: number ~> string
+var q2: string = new ES6_Def_NamedClass1().givesANum(); // Error: number ~> string
 ////////////////////////////
 // == ES6 Named -> ES6 == //
 ////////////////////////////
-import doesntExist5 from \"ES6_Named1\";
-
-// Error: Not an exported binding
+import doesntExist5 from \"ES6_Named1\"; // Error: Not an exported binding
 import { specifierNumber1 as specifierNumber1_1 } from \"ES6_Named1\";
 var r1: number = specifierNumber1_1;
-var r2: string = specifierNumber1_1;
-
-// Error: number ~> string
+var r2: string = specifierNumber1_1; // Error: number ~> string
 import { specifierNumber2Renamed } from \"ES6_Named1\";
 var s1: number = specifierNumber2Renamed;
-var s2: string = specifierNumber2Renamed;
-
-// Error: number ~> string
+var s2: string = specifierNumber2Renamed; // Error: number ~> string
 import { specifierNumber3 as specifierNumber3Renamed } from \"ES6_Named1\";
 var t1: number = specifierNumber3Renamed;
-var t2: string = specifierNumber3Renamed;
-
-// Error: number ~> string
+var t2: string = specifierNumber3Renamed; // Error: number ~> string
 import { groupedSpecifierNumber1, groupedSpecifierNumber2 } from \"ES6_Named1\";
 var u1: number = groupedSpecifierNumber1;
 var u2: number = groupedSpecifierNumber2;
-var u3: string = groupedSpecifierNumber1;
-// Error: number ~> string
-var u4: string = groupedSpecifierNumber2;
-
-// Error: number ~> string
+var u3: string = groupedSpecifierNumber1; // Error: number ~> string
+var u4: string = groupedSpecifierNumber2; // Error: number ~> string
 import { givesANumber } from \"ES6_Named1\";
 var v1: number = givesANumber();
-var v2: string = givesANumber();
-
-// Error: number ~> string
+var v2: string = givesANumber(); // Error: number ~> string
 import { NumberGenerator } from \"ES6_Named1\";
 var w1: number = new NumberGenerator().givesANumber();
-var w2: string = new NumberGenerator().givesANumber();
-
-// Error: number ~> string
+var w2: string = new NumberGenerator().givesANumber(); // Error: number ~> string
 import { varDeclNumber1, varDeclNumber2 } from \"ES6_Named1\";
 var x1: number = varDeclNumber1;
 var x2: number = varDeclNumber2;
-var x3: string = varDeclNumber1;
-// Error: number ~> string
-var x4: string = varDeclNumber2;
-
-// Error: number ~> string
+var x3: string = varDeclNumber1; // Error: number ~> string
+var x4: string = varDeclNumber2; // Error: number ~> string
 import { destructuredObjNumber } from \"ES6_Named1\";
 var y1: number = destructuredObjNumber;
-var y2: string = destructuredObjNumber;
-
-// Error: number ~> string
+var y2: string = destructuredObjNumber; // Error: number ~> string
 import { destructuredArrNumber } from \"ES6_Named1\";
 var z1: number = destructuredArrNumber;
-var z2: string = destructuredArrNumber;
-
-// Error: number ~> string
+var z2: string = destructuredArrNumber; // Error: number ~> string
 import { numberValue1 as numberValue4 } from \"ES6_ExportFrom_Intermediary1\";
 var aa1: number = numberValue4;
-var aa2: string = numberValue4;
-
-// Error: number ~> string
+var aa2: string = numberValue4; // Error: number ~> string
 import { numberValue2_renamed } from \"ES6_ExportFrom_Intermediary1\";
 var ab1: number = numberValue2_renamed;
-var ab2: string = numberValue2_renamed;
-
-// Error: number ~> string
+var ab2: string = numberValue2_renamed; // Error: number ~> string
 import { numberValue1 as numberValue5 } from \"ES6_ExportAllFrom_Intermediary1\";
 var ac1: number = numberValue5;
-var ac2: string = numberValue5;
-
-// Error: number ~> string
+var ac2: string = numberValue5; // Error: number ~> string
 ///////////////////////////////////
 // == ES6 Default -> CommonJS == //
 ///////////////////////////////////
-require(\"ES6_Default_AnonFunction2\").doesntExist;
-
-// Error: \'doesntExist\' isn\'t an export
+require(\"ES6_Default_AnonFunction2\").doesntExist; // Error: \'doesntExist\' isn\'t an export
 var ES6_Def_AnonFunc2 = require(\"ES6_Default_AnonFunction2\").default;
 var ad1: number = ES6_Def_AnonFunc2();
-var ad2: string = ES6_Def_AnonFunc2();
-
-// Error: number ~> string
+var ad2: string = ES6_Def_AnonFunc2(); // Error: number ~> string
 var ES6_Def_NamedFunc2 = require(\"ES6_Default_NamedFunction2\").default;
 var ae1: number = ES6_Def_NamedFunc2();
-var ae2: string = ES6_Def_NamedFunc2();
-
-// Error: number ~> string
+var ae2: string = ES6_Def_NamedFunc2(); // Error: number ~> string
 var ES6_Def_AnonClass2 = require(\"ES6_Default_AnonClass2\").default;
 var af1: number = new ES6_Def_AnonClass2().givesANum();
-var af2: string = new ES6_Def_AnonClass2().givesANum();
-
-// Error: number ~> string
+var af2: string = new ES6_Def_AnonClass2().givesANum(); // Error: number ~> string
 var ES6_Def_NamedClass2 = require(\"ES6_Default_NamedClass2\").default;
 var ag1: number = new ES6_Def_NamedClass2().givesANum();
-var ag2: string = new ES6_Def_NamedClass2().givesANum();
-
-// Error: number ~> string
+var ag2: string = new ES6_Def_NamedClass2().givesANum(); // Error: number ~> string
 /////////////////////////////////
 // == ES6 Named -> CommonJS == //
 /////////////////////////////////
 var specifierNumber4 = require(\"ES6_Named2\").specifierNumber4;
 var ah1: number = specifierNumber4;
-var ah2: string = specifierNumber4;
-
-// Error: number ~> string
+var ah2: string = specifierNumber4; // Error: number ~> string
 var specifierNumber5Renamed = require(\"ES6_Named2\").specifierNumber5Renamed;
 var ai1: number = specifierNumber5Renamed;
-var ai2: string = specifierNumber5Renamed;
-
-// Error: number ~> string
+var ai2: string = specifierNumber5Renamed; // Error: number ~> string
 var groupedSpecifierNumber3 = require(\"ES6_Named2\").groupedSpecifierNumber3;
 var groupedSpecifierNumber4 = require(\"ES6_Named2\").groupedSpecifierNumber4;
 var aj1: number = groupedSpecifierNumber3;
 var aj2: number = groupedSpecifierNumber4;
-var aj3: string = groupedSpecifierNumber3;
-// Error: number ~> string
-var aj4: string = groupedSpecifierNumber4;
-
-// Error: number ~> string
+var aj3: string = groupedSpecifierNumber3; // Error: number ~> string
+var aj4: string = groupedSpecifierNumber4; // Error: number ~> string
 var givesANumber2 = require(\"ES6_Named2\").givesANumber2;
 var ak1: number = givesANumber2();
-var ak2: string = givesANumber2();
-
-// Error: number ~> string
+var ak2: string = givesANumber2(); // Error: number ~> string
 var NumberGenerator2 = require(\"ES6_Named2\").NumberGenerator2;
 var al1: number = new NumberGenerator2().givesANumber();
-var al2: string = new NumberGenerator2().givesANumber();
-
-// Error: number ~> string
+var al2: string = new NumberGenerator2().givesANumber(); // Error: number ~> string
 var varDeclNumber3 = require(\"ES6_Named2\").varDeclNumber3;
 var varDeclNumber4 = require(\"ES6_Named2\").varDeclNumber4;
 var am1: number = varDeclNumber3;
 var am2: number = varDeclNumber4;
-var am3: string = varDeclNumber3;
-// Error: number ~> string
-var am4: string = varDeclNumber4;
-
-// Error: number ~> string
+var am3: string = varDeclNumber3; // Error: number ~> string
+var am4: string = varDeclNumber4; // Error: number ~> string
 var destructuredObjNumber2 = require(\"ES6_Named2\").destructuredObjNumber2;
 var an1: number = destructuredObjNumber2;
-var an2: string = destructuredObjNumber2;
-
-// Error: number ~> string
+var an2: string = destructuredObjNumber2; // Error: number ~> string
 var destructuredArrNumber2 = require(\"ES6_Named2\").destructuredArrNumber2;
 var ao1: number = destructuredArrNumber2;
-var ao2: string = destructuredArrNumber2;
-
-// Error: number ~> string
+var ao2: string = destructuredArrNumber2; // Error: number ~> string
 var numberValue6 = require(\"ES6_ExportFrom_Intermediary2\").numberValue1;
 var ap1: number = numberValue6;
-var ap2: string = numberValue6;
-
-// Error: number ~> string
+var ap2: string = numberValue6; // Error: number ~> string
 var numberValue2_renamed2 = require(
   \"ES6_ExportFrom_Intermediary2\"
 ).numberValue2_renamed2;
 var aq1: number = numberValue2_renamed2;
-var aq2: string = numberValue2_renamed2;
-
-// Error: number ~> string
+var aq2: string = numberValue2_renamed2; // Error: number ~> string
 var numberValue7 = require(\"ES6_ExportAllFrom_Intermediary2\").numberValue2;
 var ar1: number = numberValue7;
-var ar2: string = numberValue7;
-
-// Error: number ~> string
+var ar2: string = numberValue7; // Error: number ~> string
 ////////////////////////////////////////////////////////
 // == ES6 Default+Named -> ES6 import Default+Named== //
 ////////////////////////////////////////////////////////
 import defaultNum, { str as namedStr } from \"./ES6_DefaultAndNamed\";
 
 var as1: number = defaultNum;
-var as2: string = defaultNum;
-
-// Error: number ~> string
+var as2: string = defaultNum; // Error: number ~> string
 var as3: string = namedStr;
-var as4: number = namedStr;
-
-// Error: string ~> number
+var as4: number = namedStr; // Error: string ~> number
 ////////////////////////////////////////
 // == Side-effect only ES6 imports == //
 ////////////////////////////////////////
@@ -1317,11 +1196,8 @@ import \"./SideEffects\";
 //////////////////////////////////////////////
 // == Suggest export name on likely typo == //
 //////////////////////////////////////////////
-import specifierNumber1 from \"ES6_Named1\";
-// Error: Did you mean \`import {specifierNumber1} from ...\`?
-import { specifierNumber } from \"ES6_Named1\";
-
-// Error: Did you mean \`specifierNumber1\`?
+import specifierNumber1 from \"ES6_Named1\"; // Error: Did you mean \`import {specifierNumber1} from ...\`?
+import { specifierNumber } from \"ES6_Named1\"; // Error: Did you mean \`specifierNumber1\`?
 ///////////////////////////////////////////////////
 // == Multi \`export *\` should combine exports == //
 ///////////////////////////////////////////////////
@@ -1331,19 +1207,13 @@ import {
 } from \"./ES6_ExportAllFromMulti\";
 
 var at1: number = numberValue8;
-var at2: string = numberValue8;
-
-// Error: number ~> string
+var at2: string = numberValue8; // Error: number ~> string
 var at3: number = numberValue9;
-var at4: string = numberValue9;
-
-// Error: number ~> string
+var at4: string = numberValue9; // Error: number ~> string
 /////////////////////////////////////////////////////////////
 // == Vanilla \`import\` cannot import a type-only export == //
 /////////////////////////////////////////////////////////////
-import {
-  typeAlias
-} from \"./ExportType\"; // Error: Cannot vanilla-import a type alias!
+import { typeAlias } from \"./ExportType\"; // Error: Cannot vanilla-import a type alias!
 "
 `;
 
@@ -1409,55 +1279,35 @@ function testRequires() {
 
 // CommonJS module
 import * as DefaultA from \"A\";
-DefaultA.numberValue1 = 123;
-
-// Error: DefaultA is frozen
+DefaultA.numberValue1 = 123; // Error: DefaultA is frozen
 // ES6 module
 import * as ES6_Named1 from \"ES6_Named1\";
-ES6_Named1.varDeclNumber1 = 123;
-
-// Error: ES6_Named1 is frozen
+ES6_Named1.varDeclNumber1 = 123; // Error: ES6_Named1 is frozen
 // CommonJS module that clobbers module.exports
 import * as CommonJS_Star from \"CommonJS_Clobbering_Lit\";
-CommonJS_Star.numberValue1 = 123;
-// Error: frozen
-CommonJS_Star.default.numberValue1 = 123;
-
-// ok
+CommonJS_Star.numberValue1 = 123; // Error: frozen
+CommonJS_Star.default.numberValue1 = 123; // ok
 import CommonJS_Clobbering_Lit from \"CommonJS_Clobbering_Lit\";
-CommonJS_Clobbering_Lit.numberValue1 = 123;
-
-// ok
+CommonJS_Clobbering_Lit.numberValue1 = 123; // ok
 // CommonJS module that clobbers module.exports with a frozen object
 import * as CommonJS_Frozen_Star from \"CommonJS_Clobbering_Frozen\";
-CommonJS_Frozen_Star.numberValue1 = 123;
-// Error: frozen
-CommonJS_Frozen_Star.default.numberValue1 = 123;
-
-// Error: frozen
+CommonJS_Frozen_Star.numberValue1 = 123; // Error: frozen
+CommonJS_Frozen_Star.default.numberValue1 = 123; // Error: frozen
 import CommonJS_Clobbering_Frozen from \"CommonJS_Clobbering_Frozen\";
-CommonJS_Clobbering_Frozen.numberValue1 = 123;
-
-// Error: exports are frozen
+CommonJS_Clobbering_Frozen.numberValue1 = 123; // Error: exports are frozen
 //
 // Requires
 //
 function testRequires() {
   // CommonJS module
   var DefaultA = require(\"A\");
-  DefaultA.numberValue1 = 123;
-
-  // ok, not frozen by default
+  DefaultA.numberValue1 = 123; // ok, not frozen by default
   // ES6 module
   var ES6_Named1 = require(\"ES6_Named1\");
-  ES6_Named1.numberValue = 123;
-
-  // error, es6 exports are frozen
+  ES6_Named1.numberValue = 123; // error, es6 exports are frozen
   // CommonJS module that clobbers module.exports
   var CommonJS_Star = require(\"CommonJS_Clobbering_Lit\");
-  CommonJS_Star.numberValue1 = 123;
-
-  // ok, not frozen by default
+  CommonJS_Star.numberValue1 = 123; // ok, not frozen by default
   // CommonJS module that clobbers module.exports with a frozen object
   var CommonJS_Frozen_Star = require(\"CommonJS_Clobbering_Frozen\");
   CommonJS_Frozen_Star.numberValue1 = 123; // Error: frozen

--- a/tests/flow/es_declare_module/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/es_declare_module/__snapshots__/jsfmt.spec.js.snap
@@ -46,54 +46,35 @@ import {exports as nope} from \"ES\"; // Error: Not an export
 import { num1, str1 } from \"CJS_Named\";
 import CJS_Named from \"CJS_Named\";
 (num1: number);
-(num1: string);
-// Error: number ~> string
+(num1: string); // Error: number ~> string
 (str1: string);
-(str1: number);
-// Error: string ~> number
+(str1: number); // Error: string ~> number
 (CJS_Named: { num1: number, str1: string });
-(CJS_Named: number);
-
-// Error: Module ~> number
-import { num2 } from \"CJS_Clobbered\";
-// Error: No such export!
+(CJS_Named: number); // Error: Module ~> number
+import { num2 } from \"CJS_Clobbered\"; // Error: No such export!
 import { numExport } from \"CJS_Clobbered\";
 (numExport: number);
-(numExport: string);
-// Error: number ~> string
+(numExport: string); // Error: number ~> string
 import type { numType } from \"CJS_Clobbered\";
 (42: numType);
-(\"asdf\": numType);
-
-// Error: string ~> number
-import { strHidden } from \"ES\";
-// Error: No such export!
+(\"asdf\": numType); // Error: string ~> number
+import { strHidden } from \"ES\"; // Error: No such export!
 import { str3 } from \"ES\";
 (str3: string);
-(str3: number);
-
-// Error: string ~> number
+(str3: number); // Error: string ~> number
 import { num3 } from \"ES\";
 (num3: number);
-(num3: string);
-
-// Error: number ~> string
+(num3: string); // Error: number ~> string
 import { C } from \"ES\";
 import type { C as CType } from \"ES\";
 (new C(): C);
-(42: C);
-// Error: number ~> C
+(42: C); // Error: number ~> C
 (new C(): CType);
-(42: CType);
-
-// Error: number ~> CType
-import { T } from \"ES\";
-// Error: T is a type import, not a value
+(42: CType); // Error: number ~> CType
+import { T } from \"ES\"; // Error: T is a type import, not a value
 import type { T as T2 } from \"ES\";
 (42: T2);
-(\"asdf\": T2);
-
-// Error: string ~> number
+(\"asdf\": T2); // Error: string ~> number
 import { exports as nope } from \"ES\"; // Error: Not an export
 "
 `;

--- a/tests/flow/esproposal_export_star_as.enable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/esproposal_export_star_as.enable/__snapshots__/jsfmt.spec.js.snap
@@ -14,9 +14,7 @@ var d: number = source.str; // Error: num ~> string
 import { source } from \"./test\";
 
 var a: number = source.num;
-var b: string = source.num;
-
-// Error: num ~> string
+var b: string = source.num; // Error: num ~> string
 var c: string = source.str;
 var d: number = source.str; // Error: num ~> string
 "

--- a/tests/flow/esproposal_export_star_as.ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/esproposal_export_star_as.ignore/__snapshots__/jsfmt.spec.js.snap
@@ -14,9 +14,7 @@ var d: number = source.str; // Ignored error: num ~> string
 import { source } from \"./test\";
 
 var a: number = source.num;
-var b: string = source.num;
-
-// Error: num ~> string
+var b: string = source.num; // Error: num ~> string
 var c: string = source.str;
 var d: number = source.str; // Ignored error: num ~> string
 "

--- a/tests/flow/export_default/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/export_default/__snapshots__/jsfmt.spec.js.snap
@@ -17,11 +17,9 @@ N.z = Q(N.z);
 var M = require(\"M\");
 var N = require(\"N\");
 N.x = M(N.x);
-var P = require(\"./P\");
-// implementation of P redirects to module M
+var P = require(\"./P\"); // implementation of P redirects to module M
 N.y = P(N.y);
-var Q = require(\"Q\");
-// declaration of Q redirects to module M
+var Q = require(\"Q\"); // declaration of Q redirects to module M
 N.z = Q(N.z);
 "
 `;

--- a/tests/flow/export_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/export_type/__snapshots__/jsfmt.spec.js.snap
@@ -59,32 +59,20 @@ import type {
 } from \"./types_only\";
 
 var a: inlinedType1 = 42;
-var b: inlinedType1 = \"asdf\";
-
-// Error: string ~> number
+var b: inlinedType1 = \"asdf\"; // Error: string ~> number
 var c: standaloneType1 = 42;
-var d: standaloneType1 = \"asdf\";
-
-// Error: string ~> number
+var d: standaloneType1 = \"asdf\"; // Error: string ~> number
 var e: talias1 = 42;
-var f: talias1 = \"asdf\";
-
-// Error: string ~> number
+var f: talias1 = \"asdf\"; // Error: string ~> number
 var g: talias3 = 42;
-var h: talias3 = \"asdf\";
-
-// Error: string ~> number
+var h: talias3 = \"asdf\"; // Error: string ~> number
 import type { talias4 } from \"./cjs_with_types\";
 var i: talias4 = 42;
-var j: talias4 = \"asdf\";
-
-// Error: string ~> number
+var j: talias4 = \"asdf\"; // Error: string ~> number
 import { IFoo, IFoo2 } from \"./types_only\";
 
 var k: IFoo = { prop: 42 };
-var l: IFoo = { prop: \"asdf\" };
-
-// Error: {prop:string} ~> {prop:number}
+var l: IFoo = { prop: \"asdf\" }; // Error: {prop:string} ~> {prop:number}
 var m: IFoo2 = { prop: \"asdf\" };
 var n: IFoo2 = { prop: 42 }; // Error: {prop:number} ~> {prop:string}
 "
@@ -111,16 +99,12 @@ export interface IFoo { prop: number };
 
 export type inlinedType1 = number;
 var a: inlinedType1 = 42;
-var b: inlinedType1 = \"asdf\";
-
-// Error: string ~> number
+var b: inlinedType1 = \"asdf\"; // Error: string ~> number
 type standaloneType1 = number;
 export type { standaloneType1 };
 
 type standaloneType2 = number;
-export { standaloneType2 };
-
-// Error: Missing \`type\` keyword
+export { standaloneType2 }; // Error: Missing \`type\` keyword
 export type { talias1, talias2 as talias3, IFoo2 } from \"./types_only2\";
 
 export interface IFoo { prop: number }

--- a/tests/flow/fetch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/fetch/__snapshots__/jsfmt.spec.js.snap
@@ -34,9 +34,7 @@ const myRequest = new Request(\"http://google.com\");
 
 const a: Promise<string> = fetch(myRequest).then(response => response.text());
 
-const b: Promise<string> = fetch(myRequest);
-
-// incorrect
+const b: Promise<string> = fetch(myRequest); // incorrect
 var myInit = {
   method: \"GET\",
   headers: { \"Content-Type\": \"image/jpeg\" },
@@ -44,9 +42,7 @@ var myInit = {
   cache: \"default\"
 };
 
-const c: Promise<Blob> = fetch(\"image.png\").then(response => response.blob());
-
-// correct
+const c: Promise<Blob> = fetch(\"image.png\").then(response => response.blob()); // correct
 const d: Promise<Blob> = fetch(\"image.png\"); // incorrect
 "
 `;
@@ -83,37 +79,20 @@ e.getAll(\'content-type\').forEach((v: string) => {}); // correct
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
 
-const a = new Headers(\"\'Content-Type\': \'image/jpeg\'\");
-// not correct
-const b = new Headers([\"Content-Type\", \"image/jpeg\"]);
-// not correct
-const c = new Headers({ \"Content-Type\", \"image/jpeg\" });
-// correct
-const d = new Headers(c);
-// correct
-const e: Headers = new Headers();
-// correct
-e.append(\"Content-Type\", \"image/jpeg\");
-// correct
-e.append(\"Content-Type\");
-// not correct
-e.append({ \"Content-Type\", \"image/jpeg\" });
-// not correct
-e.set(\"Content-Type\", \"image/jpeg\");
-// correct
-e.set(\"Content-Type\");
-// not correct
-e.set({ \"Content-Type\", \"image/jpeg\" });
-
-// not correct
-const f: Headers = e.append(\"Content-Type\", \"image/jpeg\");
-
-// not correct
-const g: string = e.get(\"Content-Type\");
-// correct
-const h: number = e.get(\"Content-Type\");
-
-// not correct
+const a = new Headers(\"\'Content-Type\': \'image/jpeg\'\"); // not correct
+const b = new Headers([\"Content-Type\", \"image/jpeg\"]); // not correct
+const c = new Headers({ \"Content-Type\", \"image/jpeg\" }); // correct
+const d = new Headers(c); // correct
+const e: Headers = new Headers(); // correct
+e.append(\"Content-Type\", \"image/jpeg\"); // correct
+e.append(\"Content-Type\"); // not correct
+e.append({ \"Content-Type\", \"image/jpeg\" }); // not correct
+e.set(\"Content-Type\", \"image/jpeg\"); // correct
+e.set(\"Content-Type\"); // not correct
+e.set({ \"Content-Type\", \"image/jpeg\" }); // not correct
+const f: Headers = e.append(\"Content-Type\", \"image/jpeg\"); // not correct
+const g: string = e.get(\"Content-Type\"); // correct
+const h: number = e.get(\"Content-Type\"); // not correct
 for (let v of e) {
   const [i, j]: [string, string] = v; // correct
 }
@@ -180,63 +159,43 @@ h.arrayBuffer().then((ab: ArrayBuffer) => ab); // correct
 h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
-const a: Request = new Request();
-// incorrect
-const b: Request = new Request(\"http://example.org\");
-// correct
-const c: Request = new Request(b);
-// correct
-const d: Request = new Request(c.clone());
-// correct (doesn\'t make much sense though)
-const e: Request = new Request(b, c);
-
-// incorrect
-const f: Request = new Request({});
-// incorrect
-const g: Request = new Request(\"http://example.org\", {});
-
-// correct
+const a: Request = new Request(); // incorrect
+const b: Request = new Request(\"http://example.org\"); // correct
+const c: Request = new Request(b); // correct
+const d: Request = new Request(c.clone()); // correct (doesn\'t make much sense though)
+const e: Request = new Request(b, c); // incorrect
+const f: Request = new Request({}); // incorrect
+const g: Request = new Request(\"http://example.org\", {}); // correct
 const h: Request = new Request(\"http://example.org\", {
   method: \"GET\",
   headers: { \"Content-Type\": \"image/jpeg\" },
   mode: \"cors\",
   cache: \"default\"
-});
-
-// correct
+}); // correct
 const i: Request = new Request(\"http://example.org\", {
   method: \"POST\",
   headers: { \"Content-Type\": \"image/jpeg\" },
   body: new URLSearchParams(\"key=value\"),
   mode: \"cors\",
   cache: \"default\"
-});
-
-// correct
+}); // correct
 const j: Request = new Request(\"http://example.org\", {
   method: \"GET\",
   headers: \"Content-Type: image/jpeg\",
   mode: \"cors\",
   cache: \"default\"
-});
-
-// incorrect - headers is string
+}); // incorrect - headers is string
 const k: Request = new Request(\"http://example.org\", {
   method: \"CONNECT\",
   headers: { \"Content-Type\": \"image/jpeg\" },
   mode: \"cors\",
   cache: \"default\"
-});
-
-// incorrect - CONNECT is forbidden
+}); // incorrect - CONNECT is forbidden
 var l: boolean = h.bodyUsed;
 
-h.text().then((t: string) => t);
-// correct
-h.text().then((t: Buffer) => t);
-// incorrect
-h.arrayBuffer().then((ab: ArrayBuffer) => ab);
-// correct
+h.text().then((t: string) => t); // correct
+h.text().then((t: Buffer) => t); // incorrect
+h.arrayBuffer().then((ab: ArrayBuffer) => ab); // correct
 h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
 "
 `;
@@ -290,52 +249,33 @@ h.arrayBuffer().then((ab: ArrayBuffer) => ab); // correct
 h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
-const a: Response = new Response();
-// correct
-const b: Response = new Response(new Blob());
-// correct
-const c: Response = new Response(new FormData());
-
-// correct
-const d: Response = new Response(new FormData(), { status: 404 });
-
-// correct
-const e: Response = new Response(\"responsebody\", { status: \"404\" });
-
-// incorrect
+const a: Response = new Response(); // correct
+const b: Response = new Response(new Blob()); // correct
+const c: Response = new Response(new FormData()); // correct
+const d: Response = new Response(new FormData(), { status: 404 }); // correct
+const e: Response = new Response(\"responsebody\", { status: \"404\" }); // incorrect
 const f: Response = new Response(\"responsebody\", {
   status: 404,
   headers: \"\'Content-Type\': \'image/jpeg\'\"
-});
-
-// incorrect
+}); // incorrect
 const g: Response = new Response(\"responsebody\", {
   status: 404,
   headers: { \"Content-Type\": \"image/jpeg\" }
-});
-
-// correct
+}); // correct
 const h: Response = new Response(\"responsebody\", {
   status: 404,
   headers: new Headers({ \"Content-Type\": \"image/jpeg\" })
-});
-
-// correct, if verbose
+}); // correct, if verbose
 const i: Response = new Response({
   status: 404,
   headers: new Headers({ \"Content-Type\": \"image/jpeg\" })
-});
-
-// incorrect
+}); // incorrect
 const ok: boolean = h.ok;
 const status: number = h.status;
 
-h.text().then((t: string) => t);
-// correct
-h.text().then((t: Buffer) => t);
-// incorrect
-h.arrayBuffer().then((ab: ArrayBuffer) => ab);
-// correct
+h.text().then((t: string) => t); // correct
+h.text().then((t: Buffer) => t); // incorrect
+h.arrayBuffer().then((ab: ArrayBuffer) => ab); // correct
 h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
 "
 `;
@@ -372,37 +312,20 @@ e.getAll(\'key1\').forEach((v: string) => {}); // correct
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
 
-const a = new URLSearchParams(\"key1=value1\");
-// correct
-const b = new URLSearchParams([\"key1\", \"value1\"]);
-// not correct
-const c = new URLSearchParams({ \"key1\", \"value1\" });
-// not correct
-const d = new URLSearchParams(c);
-// correct
-const e: URLSearchParams = new URLSearchParams();
-// correct
-e.append(\"key1\", \"value1\");
-// correct
-e.append(\"key1\");
-// not correct
-e.append({ \"key1\", \"value1\" });
-// not correct
-e.set(\"key1\", \"value1\");
-// correct
-e.set(\"key1\");
-// not correct
-e.set({ \"key1\", \"value1\" });
-
-// not correct
-const f: URLSearchParams = e.append(\"key1\", \"value1\");
-
-// not correct
-const g: string = e.get(\"key1\");
-// correct
-const h: number = e.get(\"key1\");
-
-// not correct
+const a = new URLSearchParams(\"key1=value1\"); // correct
+const b = new URLSearchParams([\"key1\", \"value1\"]); // not correct
+const c = new URLSearchParams({ \"key1\", \"value1\" }); // not correct
+const d = new URLSearchParams(c); // correct
+const e: URLSearchParams = new URLSearchParams(); // correct
+e.append(\"key1\", \"value1\"); // correct
+e.append(\"key1\"); // not correct
+e.append({ \"key1\", \"value1\" }); // not correct
+e.set(\"key1\", \"value1\"); // correct
+e.set(\"key1\"); // not correct
+e.set({ \"key1\", \"value1\" }); // not correct
+const f: URLSearchParams = e.append(\"key1\", \"value1\"); // not correct
+const g: string = e.get(\"key1\"); // correct
+const h: number = e.get(\"key1\"); // not correct
 for (let v of e) {
   const [i, j]: [string, string] = v; // correct
 }

--- a/tests/flow/forof/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/forof/__snapshots__/jsfmt.spec.js.snap
@@ -90,8 +90,7 @@ function testMap1(map: Map<string, number>): void {
 
 function testMap2(map: Map<*, *>): void {
   for (var elem of map) {
-    (elem: [number, string]);
-    // Any tuple is fine
+    (elem: [number, string]); // Any tuple is fine
     (elem: number); // Error - tuple ~> number
   }
 }

--- a/tests/flow/function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/function/__snapshots__/jsfmt.spec.js.snap
@@ -50,34 +50,21 @@ function test(a: string, b: number): number {
 test.apply(\"\", [\"\", 0]);
 
 // wrong this is an error
-test.apply(0, [\"\", 0]);
-
-// error: lookup \`length\` on Number
+test.apply(0, [\"\", 0]); // error: lookup \`length\` on Number
 // not enough arguments is an error (via incompatible RestT)
-test.apply(\"\", [\"\"]);
-
-// error: string ~> number
+test.apply(\"\", [\"\"]); // error: string ~> number
 // mistyped arguments is an error
-test.apply(\"\", [\"\", \"\"]);
-// error: string ~> number (2nd arg)
-test.apply(\"\", [0, 0]);
-
-// error: number ~> string (1st arg)
+test.apply(\"\", [\"\", \"\"]); // error: string ~> number (2nd arg)
+test.apply(\"\", [0, 0]); // error: number ~> string (1st arg)
 // resolve args array from tvar
 function f(args) {
   test.apply(\"\", args);
 }
-f([\"\", 0]);
-// OK
-f([\"\", \"\"]);
-// error: string ~> number (2nd arg)
-f([0, 0]);
-
-// error: number ~> string (1st arg)
+f([\"\", 0]); // OK
+f([\"\", \"\"]); // error: string ~> number (2nd arg)
+f([0, 0]); // error: number ~> string (1st arg)
 // expect array
-test.apply(\"\", \"not array\");
-
-// error: expect array of args
+test.apply(\"\", \"not array\"); // error: expect array of args
 // expect 4 errors:
 // - lookup length on Number (because 0 is used as \`this\`)
 // - 123 is not a string
@@ -115,8 +102,7 @@ let tests = [
 let tests = [
   function(x: (a: string, b: string) => void) {
     let y = x.bind(x, \"foo\");
-    y(\"bar\");
-    // ok
+    y(\"bar\"); // ok
     y(123); // error, number !~> string
   }
 ];
@@ -170,30 +156,19 @@ function test(a: string, b: number): number {
 test.call(\"\", \"\", 0);
 
 // wrong this is an error
-test.call(0, \"\", 0);
-
-// error: lookup \`length\` on Number
+test.call(0, \"\", 0); // error: lookup \`length\` on Number
 // not enough arguments is an error (via incompatible RestT)
-test.call(\"\", \"\");
-
-// error: string ~> number
+test.call(\"\", \"\"); // error: string ~> number
 // mistyped arguments is an error
-test.call(\"\", \"\", \"\");
-// error: string ~> number (2nd arg)
-test.call(\"\", 0, 0);
-
-// error: number ~> string (1st arg)
+test.call(\"\", \"\", \"\"); // error: string ~> number (2nd arg)
+test.call(\"\", 0, 0); // error: number ~> string (1st arg)
 // resolve args array from tvar
 function f(args) {
   test.call(\"\", args[0], args[1]);
 }
-f([\"\", 0]);
-// OK
-f([\"\", \"\"]);
-// error: string ~> number (2nd arg)
-f([0, 0]);
-
-// error: number ~> string (1st arg)
+f([\"\", 0]); // OK
+f([\"\", \"\"]); // error: string ~> number (2nd arg)
+f([0, 0]); // error: number ~> string (1st arg)
 // expect 3 errors:
 // - lookup length on Number (0 used as \`this\`)
 // - number !~> string (param a)
@@ -295,8 +270,7 @@ class C {}
 var c: Function = C;
 
 function good(x: Function, MyThing: Function): number {
-  var o: Object = x;
-  // Function is an Object
+  var o: Object = x; // Function is an Object
   x.foo = 123;
   x[\"foo\"] = 456;
   x();
@@ -308,45 +282,29 @@ function good(x: Function, MyThing: Function): number {
 }
 
 function bad(x: Function, y: Object): void {
-  var a: number = x;
-  // Error
-  var b: string = x;
-  // Error
+  var a: number = x; // Error
+  var b: string = x; // Error
   var c: Function = y; // Object is not a Function
 }
 
 let tests = [
   function(y: () => void, z: Function) {
     function x() {}
-    (x.length: void);
-    // error, it\'s a number
-    (y.length: void);
-    // error, it\'s a number
-    (z.length: void);
-
-    // error, it\'s a number
-    (x.name: void);
-    // error, it\'s a string
-    (y.name: void);
-    // error, it\'s a string
+    (x.length: void); // error, it\'s a number
+    (y.length: void); // error, it\'s a number
+    (z.length: void); // error, it\'s a number
+    (x.name: void); // error, it\'s a string
+    (y.name: void); // error, it\'s a string
     (z.name: void); // error, it\'s a string
   },
   function(y: () => void, z: Function) {
     function x() {}
-    x.length = \"foo\";
-    // error, it\'s a number
-    y.length = \"foo\";
-    // error, it\'s a number
-    z.length = \"foo\";
-
-    // error, it\'s a number
-    x.name = 123;
-    // error, it\'s a string
-    y.name = 123;
-    // error, it\'s a string
-    z.name = 123;
-
-    // error, it\'s a string
+    x.length = \"foo\"; // error, it\'s a number
+    y.length = \"foo\"; // error, it\'s a number
+    z.length = \"foo\"; // error, it\'s a number
+    x.name = 123; // error, it\'s a string
+    y.name = 123; // error, it\'s a string
+    z.name = 123; // error, it\'s a string
     // Non-(Function.prototype) properties on a \`Function\` type should be \`any\`
     (z.foo: number);
     (z.foo: string);

--- a/tests/flow/generators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/generators/__snapshots__/jsfmt.spec.js.snap
@@ -131,8 +131,7 @@ for (var x of examples.delegate_yield_iterable([])) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class GeneratorExamples {
   *stmt_yield(): Generator<number, void, void> {
-    yield 0;
-    // ok
+    yield 0; // ok
     yield \"\"; // error: string ~> number
   }
 
@@ -157,8 +156,7 @@ class GeneratorExamples {
   }
 
   *infer_stmt() {
-    var x: boolean = yield 0;
-    // error: number ~> boolean
+    var x: boolean = yield 0; // error: number ~> boolean
     return \"\";
   }
 
@@ -230,11 +228,8 @@ var examples = new GeneratorExamples();
 
 for (var x of examples.infer_stmt()) {
   (x: string);
-}
-
-// error: number ~> string
-var infer_stmt_next = examples.infer_stmt().next(0).value;
-// error: number ~> boolean
+} // error: number ~> string
+var infer_stmt_next = examples.infer_stmt().next(0).value; // error: number ~> boolean
 if (typeof infer_stmt_next === \"undefined\") {
 } else if (typeof infer_stmt_next === \"number\") {
 } else {
@@ -259,9 +254,7 @@ for (var x of examples.delegate_yield_generator()) {
   (x: number); // error: string ~> number
 }
 
-examples.delegate_next_iterable([]).next(\"\");
-
-// error: Iterator has no next value
+examples.delegate_next_iterable([]).next(\"\"); // error: Iterator has no next value
 for (var x of examples.delegate_yield_iterable([])) {
   (x: string); // error: number ~> string
 }
@@ -294,8 +287,7 @@ if (typeof infer_stmt_next === \"undefined\") {
 
 class GeneratorExamples<X> {
   *infer_stmt() {
-    var x: boolean = yield 0;
-    // error: number ~> boolean
+    var x: boolean = yield 0; // error: number ~> boolean
     return \"\";
   }
 }
@@ -304,12 +296,8 @@ var examples = new GeneratorExamples();
 
 for (var x of examples.infer_stmt()) {
   (x: string);
-}
-
-// error: number ~> string
-var infer_stmt_next = examples.infer_stmt().next(0).value;
-
-// error: number ~> boolean
+} // error: number ~> string
+var infer_stmt_next = examples.infer_stmt().next(0).value; // error: number ~> boolean
 if (typeof infer_stmt_next === \"undefined\") {
 } else if (typeof infer_stmt_next === \"number\") {
 } else {
@@ -450,8 +438,7 @@ if (multiple_return_result.done) {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function* stmt_yield(): Generator<number, void, void> {
-  yield 0;
-  // ok
+  yield 0; // ok
   yield \"\"; // error: string ~> number
 }
 
@@ -481,10 +468,8 @@ function* infer_stmt() {
 }
 for (var x of infer_stmt()) {
   (x: string);
-}
-// error: number ~> string
-var infer_stmt_next = infer_stmt().next(0).value;
-// error: number ~> boolean
+} // error: number ~> string
+var infer_stmt_next = infer_stmt().next(0).value; // error: number ~> boolean
 if (typeof infer_stmt_next === \"undefined\") {
 } else if (typeof infer_stmt_next === \"number\") {
 } else {
@@ -547,9 +532,7 @@ function* delegate_return_generator() {
 function* delegate_next_iterable(xs: Array<number>) {
   yield* xs;
 }
-delegate_next_iterable([]).next(\"\");
-
-// error: Iterator has no next value
+delegate_next_iterable([]).next(\"\"); // error: Iterator has no next value
 function* delegate_yield_iterable(xs: Array<number>) {
   yield* xs;
 }

--- a/tests/flow/generics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/generics/__snapshots__/jsfmt.spec.js.snap
@@ -71,15 +71,12 @@ var n: number = o.u;
 class E<X> extends C<X> {
   //x:X;
   set(x: X): X {
-    /*return x;*/
-    this.x = x;
-    return /*this.x; */
-    this.get();
+    /*return x;*/ this.x = x;
+    return /*this.x; */ this.get();
   }
 }
 
-var e = new E();
-// error: too few arguments to inherited constructor
+var e = new E(); // error: too few arguments to inherited constructor
 var x: string = e.set(0);
 
 class F<X> {}
@@ -95,12 +92,10 @@ var h1 = new H();
 h1.foo([\"...\"]);
 var h2: F<Array<Array<Array<number>>>> = h1;
 
-var obj: Object<string, string> = {};
-// error, arity 0
+var obj: Object<string, string> = {}; // error, arity 0
 var fn: Function<string> = function() {
   return \"foo\";
-};
-// error, arity 0
+}; // error, arity 0
 var fn: function<string> = function() {
   return \"foo\";
 }; // error, arity 0

--- a/tests/flow/get-def2/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/get-def2/__snapshots__/jsfmt.spec.js.snap
@@ -43,20 +43,14 @@ var Parent = require(\"./Parent\");
 // Hops through destructuring
 let ParentFoo;
 ({ ParentFoo } = Parent);
-ParentFoo;
-
-// Points to lval in line above this
+ParentFoo; // Points to lval in line above this
 // Follows assignment on simple/\"non-destructuring\" patterns
 let ParentFoo2;
 ParentFoo2 = Parent;
-ParentFoo2;
-
-// Points to LHS of line above this
+ParentFoo2; // Points to LHS of line above this
 // Follows assignment with declaration
 let ParentFoo3 = Parent;
-ParentFoo3;
-
-// Points to LHS of line above this
+ParentFoo3; // Points to LHS of line above this
 // Follows non-destructured property access of \`require(\'Parent\')\`
 let foo = require(\"./Parent\").ParentFoo.foo;
 foo;

--- a/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
@@ -96,9 +96,7 @@ class Foo {
   get propWithMismatchingGetterAndSetter(): number {
     return 4;
   }
-  set propWithMismatchingGetterAndSetter(x: string) {}
-
-  // doesn\'t match getter (OK)
+  set propWithMismatchingGetterAndSetter(x: string) {} // doesn\'t match getter (OK)
   propOverriddenWithGetter: number;
   get propOverriddenWithGetter() {
     return \"hello\";
@@ -114,26 +112,17 @@ var foo = new Foo();
 var testGetterNoError1: number = foo.goodGetterNoAnnotation;
 var testGetterNoError2: number = foo.goodGetterWithAnnotation;
 
-var testGetterWithError1: string = foo.goodGetterNoAnnotation;
-// Error number ~> string
-var testGetterWithError2: string = foo.goodGetterWithAnnotation;
-
-// Error number ~> string
+var testGetterWithError1: string = foo.goodGetterNoAnnotation; // Error number ~> string
+var testGetterWithError2: string = foo.goodGetterWithAnnotation; // Error number ~> string
 // Test setting properties with getters
 foo.goodSetterNoAnnotation = 123;
 foo.goodSetterWithAnnotation = 123;
 
 // TODO: Why does no annotation mean no error?
-foo.goodSetterNoAnnotation = \"hello\";
-// Error string ~> number
-foo.goodSetterWithAnnotation = \"hello\";
-
-// Error string ~> number
-var testSubtypingGetterAndSetter: number = foo.propWithSubtypingGetterAndSetter;
-
-// Error ?number ~> number
-var testPropOverridenWithGetter: number = foo.propOverriddenWithGetter;
-// Error string ~> number
+foo.goodSetterNoAnnotation = \"hello\"; // Error string ~> number
+foo.goodSetterWithAnnotation = \"hello\"; // Error string ~> number
+var testSubtypingGetterAndSetter: number = foo.propWithSubtypingGetterAndSetter; // Error ?number ~> number
+var testPropOverridenWithGetter: number = foo.propOverriddenWithGetter; // Error string ~> number
 foo.propOverriddenWithSetter = 123; // Error number ~> string
 "
 `;
@@ -230,11 +219,9 @@ var obj = {
   // The getter and setter need not have the same type
   get propWithSubtypingGetterAndSetter(): ?number {
     return 4;
-  },
-  // OK
+  }, // OK
   set propWithSubtypingGetterAndSetter(x: number) {},
-  set propWithSubtypingGetterAndSetterReordered(x: number) {},
-  // OK
+  set propWithSubtypingGetterAndSetterReordered(x: number) {}, // OK
   get propWithSubtypingGetterAndSetterReordered(): ?number {
     return 4;
   },
@@ -252,29 +239,19 @@ var obj = {
 var testGetterNoError1: number = obj.goodGetterNoAnnotation;
 var testGetterNoError2: number = obj.goodGetterWithAnnotation;
 
-var testGetterWithError1: string = obj.goodGetterNoAnnotation;
-// Error number ~> string
-var testGetterWithError2: string = obj.goodGetterWithAnnotation;
-
-// Error number ~> string
+var testGetterWithError1: string = obj.goodGetterNoAnnotation; // Error number ~> string
+var testGetterWithError2: string = obj.goodGetterWithAnnotation; // Error number ~> string
 // Test setting properties with getters
 obj.goodSetterNoAnnotation = 123;
 obj.goodSetterWithAnnotation = 123;
 
-obj.goodSetterNoAnnotation = \"hello\";
-// Error string ~> number
-obj.goodSetterWithAnnotation = \"hello\";
-
-// Error string ~> number
-var testSubtypingGetterAndSetter: number = obj.propWithSubtypingGetterAndSetter;
-
-// Error ?number ~> number
+obj.goodSetterNoAnnotation = \"hello\"; // Error string ~> number
+obj.goodSetterWithAnnotation = \"hello\"; // Error string ~> number
+var testSubtypingGetterAndSetter: number = obj.propWithSubtypingGetterAndSetter; // Error ?number ~> number
 // When building this feature, it was tempting to flow the setter into the
 // getter and then use either the getter or setter as the type of the property.
 // This example shows the danger of using the getter\'s type
-obj.exampleOfOrderOfGetterAndSetter = new C();
-
-// Error C ~> B
+obj.exampleOfOrderOfGetterAndSetter = new C(); // Error C ~> B
 // And this example shows the danger of using the setter\'s type.
 var testExampleOrOrderOfGetterAndSetterReordered: number = obj.exampleOfOrderOfGetterAndSetterReordered; // Error A ~> B
 "

--- a/tests/flow/import_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/import_type/__snapshots__/jsfmt.spec.js.snap
@@ -270,11 +270,8 @@ import type ClassFoo1 from \"./ExportDefault_Class\";
 import { foo1Inst } from \"./ExportDefault_Class\";
 
 var a1: ClassFoo1 = foo1Inst;
-var a2: number = foo1Inst;
-// Error: ClassFoo1 ~> number
-new ClassFoo1();
-
-// Error: ClassFoo1 is not a value-identifier
+var a2: number = foo1Inst; // Error: ClassFoo1 ~> number
+new ClassFoo1(); // Error: ClassFoo1 is not a value-identifier
 ///////////////////////////////////////////////
 // == Importing Class Type (Named Export) == //
 ///////////////////////////////////////////////
@@ -282,20 +279,15 @@ import type { ClassFoo2 } from \"./ExportNamed_Class\";
 import { foo2Inst } from \"./ExportNamed_Class\";
 
 var b1: ClassFoo2 = foo2Inst;
-var b2: number = foo2Inst;
-// Error: ClassFoo2 ~> number
-new ClassFoo2();
-
-// Error: ClassFoo2 is not a value-identifier
+var b2: number = foo2Inst; // Error: ClassFoo2 ~> number
+new ClassFoo2(); // Error: ClassFoo2 is not a value-identifier
 /////////////////////////////////////////////////////
 // == Importing Class Type (CJS Default Export) == //
 /////////////////////////////////////////////////////
 import type ClassFoo3T from \"./ExportCJSDefault_Class\";
 import ClassFoo3 from \"./ExportCJSDefault_Class\";
 var c1: ClassFoo3T = new ClassFoo3();
-new ClassFoo3T();
-
-// Error: ClassFoo3 is not a value-identifier
+new ClassFoo3T(); // Error: ClassFoo3 is not a value-identifier
 ///////////////////////////////////////////////////
 // == Importing Class Type (CJS Named Export) == //
 ///////////////////////////////////////////////////
@@ -303,25 +295,18 @@ import type { ClassFoo4, ClassFoo5 } from \"./ExportCJSNamed_Class\";
 import { foo4Inst, foo5Inst } from \"./ExportCJSNamed_Class\";
 
 var d1: ClassFoo4 = foo4Inst;
-var d2: number = foo4Inst;
-// Error: ClassFoo4 ~> number
-new ClassFoo4();
-// Error: ClassFoo4 is not a value-identifier
+var d2: number = foo4Inst; // Error: ClassFoo4 ~> number
+new ClassFoo4(); // Error: ClassFoo4 is not a value-identifier
 // TODO: this errors correctly, but the message is just \'can\'t resolve name\'
-var d3: typeof ClassFoo5 = foo5Inst;
-
-// Error: Can\'t typeof a type alias
+var d3: typeof ClassFoo5 = foo5Inst; // Error: Can\'t typeof a type alias
 ////////////////////////////////////////////
 // == Import Type Alias (Named Export) == //
 ////////////////////////////////////////////
 import type { AliasFoo3 } from \"./ExportNamed_Alias\";
 import { givesAFoo3Obj } from \"./ExportNamed_Alias\";
 var e1: AliasFoo3 = givesAFoo3Obj();
-var e2: number = givesAFoo3Obj();
-// Error: AliasFoo3 ~> number
-var e3: typeof AliasFoo3 = givesAFoo3Obj();
-
-// Error: Can\'t typeof a type alias
+var e2: number = givesAFoo3Obj(); // Error: AliasFoo3 ~> number
+var e3: typeof AliasFoo3 = givesAFoo3Obj(); // Error: Can\'t typeof a type alias
 //////////////////////////////////////////////
 // == Import Type Alias (Default Export) == //
 //////////////////////////////////////////////
@@ -331,9 +316,7 @@ var e3: typeof AliasFoo3 = givesAFoo3Obj();
 ///////////////////////////////////////////////////////
 // == Import Type With Non-Alias Compatible Value == //
 ///////////////////////////////////////////////////////
-import type { numValue } from \"./ExportsANumber\";
-
-// Error: Cannot import-type a number value
+import type { numValue } from \"./ExportsANumber\"; // Error: Cannot import-type a number value
 ////////////////////////////////////////////////////////////////////////
 // == Regression Test: https://github.com/facebook/flow/issues/359 == //
 // Ensure that type bindings stay type bindings across function body  //

--- a/tests/flow/import_typeof/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/import_typeof/__snapshots__/jsfmt.spec.js.snap
@@ -301,11 +301,8 @@ import typeof ClassFoo1T from \"./ExportDefault_Class\";
 import ClassFoo1 from \"./ExportDefault_Class\";
 
 var a1: ClassFoo1T = ClassFoo1;
-var a2: ClassFoo1T = new ClassFoo1();
-// Error: ClassFoo1 (inst) ~> ClassFoo1 (class)
-new ClassFoo1T();
-
-// Error: ClassFoo1T is not bound to a value
+var a2: ClassFoo1T = new ClassFoo1(); // Error: ClassFoo1 (inst) ~> ClassFoo1 (class)
+new ClassFoo1T(); // Error: ClassFoo1T is not bound to a value
 /////////////////////////////////////////////////
 // == Importing Class Typeof (Named Export) == //
 /////////////////////////////////////////////////
@@ -313,11 +310,8 @@ import typeof { ClassFoo2 as ClassFoo2T } from \"./ExportNamed_Class\";
 import { ClassFoo2 } from \"./ExportNamed_Class\";
 
 var b1: ClassFoo2T = ClassFoo2;
-var b2: ClassFoo2T = new ClassFoo2();
-// Error: ClassFoo2 (inst) ~> ClassFoo2 (class)
-new ClassFoo2T();
-
-// Error: ClassFoo2T is not bound to a value
+var b2: ClassFoo2T = new ClassFoo2(); // Error: ClassFoo2 (inst) ~> ClassFoo2 (class)
+new ClassFoo2T(); // Error: ClassFoo2T is not bound to a value
 ///////////////////////////////////////////////////////
 // == Importing Class Typeof (CJS Default Export) == //
 ///////////////////////////////////////////////////////
@@ -325,9 +319,7 @@ import typeof ClassFoo3T from \"./ExportCJSDefault_Class\";
 import ClassFoo3 from \"./ExportCJSDefault_Class\";
 
 var c1: ClassFoo3T = ClassFoo3;
-var c2: ClassFoo3T = new ClassFoo3();
-
-// Error: ClassFoo3 (inst) ~> ClassFoo3 (class)
+var c2: ClassFoo3T = new ClassFoo3(); // Error: ClassFoo3 (inst) ~> ClassFoo3 (class)
 /////////////////////////////////////////////////////
 // == Importing Class Typeof (CJS Named Export) == //
 /////////////////////////////////////////////////////
@@ -335,15 +327,11 @@ import typeof { ClassFoo4 as ClassFoo4T } from \"./ExportCJSNamed_Class\";
 import { ClassFoo4 } from \"./ExportCJSNamed_Class\";
 
 var d1: ClassFoo4T = ClassFoo4;
-var d2: ClassFoo4T = new ClassFoo4();
-
-// Error: ClassFoo4 (inst) ~> ClassFoo4 (class)
+var d2: ClassFoo4T = new ClassFoo4(); // Error: ClassFoo4 (inst) ~> ClassFoo4 (class)
 //////////////////////////////////////////////
 // == Import Typeof Alias (Named Export) == //
 //////////////////////////////////////////////
-import typeof { AliasFoo3 } from \"./ExportNamed_Alias\";
-
-// Error: Can\'t \`import typeof\` type aliases!
+import typeof { AliasFoo3 } from \"./ExportNamed_Alias\"; // Error: Can\'t \`import typeof\` type aliases!
 ////////////////////////////////////////////////
 // == Import Typeof Alias (Default Export) == //
 ////////////////////////////////////////////////
@@ -356,36 +344,28 @@ import typeof { AliasFoo3 } from \"./ExportNamed_Alias\";
 import typeof num_default from \"./ExportDefault_Number\";
 
 var f1: num_default = 42;
-var f2: num_default = \"asdf\";
-
-// Error: string ~> number
+var f2: num_default = \"asdf\"; // Error: string ~> number
 /////////////////////////////////////////////////////////////
 // == Import Typeof With Non-Class Value (Named Export) == //
 /////////////////////////////////////////////////////////////
 import typeof { num as num_named } from \"./ExportNamed_Number\";
 
 var g1: num_named = 42;
-var g2: num_named = \"asdf\";
-
-// Error: string ~> number
+var g2: num_named = \"asdf\"; // Error: string ~> number
 ///////////////////////////////////////////////////////////////////
 // == Import Typeof With Non-Class Value (CJS Default Export) == //
 ///////////////////////////////////////////////////////////////////
 import typeof num_cjs_default from \"./ExportCJSDefault_Number\";
 
 var h1: num_cjs_default = 42;
-var h2: num_cjs_default = \"asdf\";
-
-// Error: string ~> number
+var h2: num_cjs_default = \"asdf\"; // Error: string ~> number
 /////////////////////////////////////////////////////////////////
 // == Import Typeof With Non-Class Value (CJS Named Export) == //
 /////////////////////////////////////////////////////////////////
 import typeof { num as num_cjs_named } from \"./ExportCJSNamed_Number\";
 
 var i1: num_cjs_named = 42;
-var i2: num_cjs_named = \"asdf\";
-
-// Error: string ~> number
+var i2: num_cjs_named = \"asdf\"; // Error: string ~> number
 ///////////////////////////////////////////////
 // == Import Typeof ModuleNamespaceObject == //
 ///////////////////////////////////////////////

--- a/tests/flow/init/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/init/__snapshots__/jsfmt.spec.js.snap
@@ -403,8 +403,7 @@ function if_else_partial_init(b) {
 
 // use of var before if gives undefined
 function if_pre_init(b) {
-  var y: number = x;
-  // error
+  var y: number = x; // error
   if (b) {
     var x: number = 0;
   }
@@ -489,8 +488,7 @@ function switch_scoped_init_1(i) {
 
 // ...but use of var before switch gives undefined
 function switch_scoped_init_2(i) {
-  var y: number = x;
-  // error
+  var y: number = x; // error
   switch (i) {
     case 0:
       var x: number = 0;
@@ -511,9 +509,8 @@ function switch_scoped_init_4(i) {
   switch (i) {
     case 0:
       var x: number = 0;
-    // error
     case 1:
-      var y: number = x;
+      var y: number = x; // error
   }
 }
 
@@ -527,8 +524,7 @@ function while_scoped_init(b) {
 
 // ...but use of var before while gives undefined
 function while_pre_init(b) {
-  var y: number = x;
-  // error
+  var y: number = x; // error
   while (b) {
     var x: number = 0;
   }
@@ -552,8 +548,7 @@ function do_while_scoped_init(b) {
 
 // ...but use before do-while gives undefined
 function do_while_pre_init(b) {
-  var y: number = x;
-  // error
+  var y: number = x; // error
   do {
     var x: number = 0;
   } while (b);
@@ -577,8 +572,7 @@ function for_scoped_init(b) {
 
 // ...but use before for gives undefined
 function for_pre_init(b) {
-  var y: number = x;
-  // error
+  var y: number = x; // error
   for (; b; ) {
     var x: number = 0;
   }
@@ -602,8 +596,7 @@ function for_in_scoped_init() {
 
 // ...but use before while gives undefined
 function for_in_pre_init() {
-  var y: number = x;
-  // error
+  var y: number = x; // error
   for (var p in { a: 1, b: 2 }) {
     var x: number = 0;
   }
@@ -627,8 +620,7 @@ function for_of_scoped_init() {
 
 // ...but use before while gives undefined
 function for_in_pre_init() {
-  var y: number = x;
-  // error
+  var y: number = x; // error
   for (var x of [1, 2, 3]) {
     var x: number = 0;
   }
@@ -818,10 +810,8 @@ function linear_deferred_init() {
 // use of let before init gives undefined
 function linear_pre_init() {
   let x: number;
-  let y: ?number = x;
-  // ok
-  let z: number = x;
-  // error
+  let y: ?number = x; // ok
+  let z: number = x; // error
   x = 0;
   let w: number = x; // ok
 }
@@ -886,9 +876,8 @@ function switch_scoped_init_2(i) {
   switch (i) {
     case 0:
       let x: number;
-    // error, skipped declaration
     case 1:
-      let y: number = x;
+      let y: number = x; // error, skipped declaration
   }
 }
 

--- a/tests/flow/interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/interface/__snapshots__/jsfmt.spec.js.snap
@@ -50,12 +50,9 @@ var x: string = new C().x;
 
 interface I { x: number }
 
-var i = new I();
-
-// error
+var i = new I(); // error
 function testInterfaceName(o: I) {
-  (o.name: string);
-  // error, name is static
+  (o.name: string); // error, name is static
   (o.constructor.name: string); // ok
 }
 "
@@ -90,25 +87,20 @@ interface I_ { x: number }
 interface J extends I, I_ {}
 interface K extends J {}
 
-var k: K = { x: \"\", y: \"\" };
-// error: x should be number
-(k.x: string);
-// error: x is number
+var k: K = { x: \"\", y: \"\" }; // error: x should be number
+(k.x: string); // error: x is number
 (k.y: string);
 
 declare class C { x: number }
-declare class D extends C, Other {}
-// error: multiple extends
+declare class D extends C, Other {} // error: multiple extends
 //declare class E implements I { } // parse error
 interface A<Y> { y: Y }
 interface A_<X> { x: X }
 interface B<Z> extends A<string>, A_<Z> { z: Z }
 interface E<Z> extends B<Z> {}
 
-var e: E<number> = { x: \"\", y: \"\", z: \"\" };
-// error: x and z should be numbers
-(e.x: string);
-// error: x is number
+var e: E<number> = { x: \"\", y: \"\", z: \"\" }; // error: x and z should be numbers
+(e.x: string); // error: x is number
 (e.y: string);
 (e.z: string); // error: z is number
 "
@@ -132,13 +124,9 @@ interface L extends J, K { y: string }
 
 function foo(l: L) {
   l.x;
-
   l.y;
-
   l.z;
-}
-
-// error: z not found in L
+} // error: z not found in L
 // interface + multiple inheritance is similar to object type + intersection
 type M = { y: string } & J & { z: boolean };
 
@@ -161,11 +149,9 @@ function foo(k: K) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface I { x: number, y: string }
 interface J { y: number }
-interface K extends I, J { x: string }
-// error: x is number in I
+interface K extends I, J { x: string } // error: x is number in I
 function foo(k: K) {
-  (k.x: number);
-  // error: x is string in K
+  (k.x: number); // error: x is string in K
   (k.y: number); // error: y is string in I
 }
 "
@@ -183,9 +169,7 @@ declare class C {
 new C().bar((x: string) => { }); // error, number ~/~> string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface I { foo(x: number): void }
-(function foo(x: number) {}: I);
-
-// error, property \`foo\` not found function
+(function foo(x: number) {}: I); // error, property \`foo\` not found function
 declare class C { bar(i: I): void, bar(f: (x: number) => void): void }
 
 new C().bar((x: string) => {}); // error, number ~/~> string

--- a/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -222,9 +222,7 @@ var b: B = a;
 
 // intersection of dictionary types:
 declare var c: C;
-var d: D = c;
-
-// ok
+var d: D = c; // ok
 // dict type mismatch
 type E = { [key: string]: string };
 var e: E = c; // error

--- a/tests/flow/iterable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/iterable/__snapshots__/jsfmt.spec.js.snap
@@ -157,8 +157,9 @@ function makeIterator(coin_flip: () => boolean): Iterator<string> {
     },
     next(): IteratorResult<string, void> {
       var done = coin_flip();
-      if (done) {
-        // Whoops, made a mistake and forgot to negate done
+      if (
+        done // Whoops, made a mistake and forgot to negate done
+      ) {
         return { done, value: \"still going...\" }; // Error string ~> void
       } else {
         return { done }; // Error void ~> string
@@ -263,9 +264,7 @@ exports[`test variance.js 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
 
-(([]: Array<string>): Iterable<?string>);
-
-// ok, Iterable<+T>
+(([]: Array<string>): Iterable<?string>); // ok, Iterable<+T>
 (([]: Array<string>).values(): Iterable<?string>); // ok, Iterator<+T>
 "
 `;

--- a/tests/flow/jsx_intrinsics.builtin/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/jsx_intrinsics.builtin/__snapshots__/jsfmt.spec.js.snap
@@ -30,9 +30,7 @@ class CustomComponent extends React.Component {
 }
 
 var a: React.Element<{ prop: string }> = <CustomComponent prop=\"asdf\" />;
-var b: React.Element<{ prop1: string }> = <CustomComponent prop=\"asdf\" />;
-
-// Error: Props<{prop}> ~> Props<{prop1}>
+var b: React.Element<{ prop1: string }> = <CustomComponent prop=\"asdf\" />; // Error: Props<{prop}> ~> Props<{prop1}>
 // Since intrinsics are typed as \`any\` out of the box, we can pass any
 // attributes to intrinsics!
 var c: React.Element<any> = <div not_a_real_attr=\"asdf\" />;
@@ -75,18 +73,11 @@ var Div = \"div\";
 var Bad = \"bad\";
 var Str: string = \"str\";
 
-<Div />;
-/* This is fine*/
-<Bad />;
-/* This is fine*/
-<Str />;
-
-// This is fine
-React.createElement(\"div\", {});
-// This is fine
-React.createElement(\"bad\", {});
-
-/* This is fine*/
+<Div />; /* This is fine*/
+<Bad />; /* This is fine*/
+<Str />; // This is fine
+React.createElement(\"div\", {}); // This is fine
+React.createElement(\"bad\", {}); /* This is fine*/
 <Div id={42} />; // This is fine
 "
 `;

--- a/tests/flow/jsx_intrinsics.custom/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/jsx_intrinsics.custom/__snapshots__/jsfmt.spec.js.snap
@@ -26,16 +26,13 @@ class CustomComponent extends React.Component {
 }
 
 var a: React.Element<{ prop: string }> = <CustomComponent prop=\"asdf\" />;
-var b: React.Element<{ prop1: string }> = <CustomComponent prop=\"asdf\" />;
-
-/* Error: Props<{prop}> ~> Props<{prop1}>*/
+var b: React.Element<{ prop1: string }> = (
+  <CustomComponent prop=\"asdf\" />
+); /* Error: Props<{prop}> ~> Props<{prop1}>*/
 <div id=\"asdf\" />;
-<div id={42} />;
-// Error: (\`id\` prop) number ~> string
+<div id={42} />; // Error: (\`id\` prop) number ~> string
 var c: React.Element<{ id: string }> = <div id=\"asdf\" />;
-var d: React.Element<{ id: number }> = (
-  <div id=\"asdf\" />
-); // Error: Props<{id:string}> ~> Props<{id:number}>
+var d: React.Element<{ id: number }> = <div id=\"asdf\" />; // Error: Props<{id:string}> ~> Props<{id:number}>
 "
 `;
 
@@ -67,20 +64,12 @@ var Div = \"div\";
 var Bad = \"bad\";
 var Str: string = \"str\";
 
-<Div />;
-/* This is fine*/
-<Bad />;
-/* Error: \'bad\' not in JSXIntrinsics*/
-<Str />;
-
-// Error: string ~> keys of JSXIntrinsics
-React.createElement(\"div\", {});
-// This is fine
-React.createElement(\"bad\", {});
-// Error: \'bad\' not in JSXIntrinsics
-React.createElement(Str, {});
-
-/* Error: string ~> keys of JSXIntrinsics*/
+<Div />; /* This is fine*/
+<Bad />; /* Error: \'bad\' not in JSXIntrinsics*/
+<Str />; // Error: string ~> keys of JSXIntrinsics
+React.createElement(\"div\", {}); // This is fine
+React.createElement(\"bad\", {}); // Error: \'bad\' not in JSXIntrinsics
+React.createElement(Str, {}); /* Error: string ~> keys of JSXIntrinsics*/
 /* TODO: Make this an error*/
 <Div id={42} />; // Not an error but should be eventually
 "

--- a/tests/flow/keys/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/keys/__snapshots__/jsfmt.spec.js.snap
@@ -48,55 +48,42 @@ function testKeysOfOtherObj(str: string, lit: \'hi\') {
 /* @flow */
 
 function testKeysOfObject(str: string, lit: \"hi\") {
-  (str: $Keys<Object>);
-  // Any string should be fine
+  (str: $Keys<Object>); // Any string should be fine
   if (str) {
     (str: $Keys<Object>); // No error, truthy string should be fine
   }
-  (\"hi\": $Keys<Object>);
-
-  // String literal should be fine
+  (\"hi\": $Keys<Object>); // String literal should be fine
   (123: $Keys<Object>); // Error: number -> keys of Object
 }
 
 type StrDict = { [key: string]: mixed };
 function testKeysOfStrDict(str: string, lit: \"hi\") {
-  (str: $Keys<StrDict>);
-  // Any string should be fine
+  (str: $Keys<StrDict>); // Any string should be fine
   if (str) {
     (str: $Keys<StrDict>); // No error, truthy string should be fine
   }
-  (\"hi\": $Keys<StrDict>);
-
-  // String literal should be fine
+  (\"hi\": $Keys<StrDict>); // String literal should be fine
   (123: $Keys<StrDict>); // Error: number -> keys of StrDict
 }
 
 type StrLitDict = { [key: \"hi\"]: mixed };
 function testKeysOfStrLitDict(str: string, lit: \"hi\") {
-  (str: $Keys<StrLitDict>);
-  // Error: Not all strings are allowed
+  (str: $Keys<StrLitDict>); // Error: Not all strings are allowed
   if (str) {
     (str: $Keys<StrLitDict>); // Error: Not all truthy strings are allowed
   }
-  (\"hi\": $Keys<StrLitDict>);
-  // The right string literal is allowed
-  (\"bye\": $Keys<StrLitDict>);
-
-  // Error: The wrong string literal is not allowed
+  (\"hi\": $Keys<StrLitDict>); // The right string literal is allowed
+  (\"bye\": $Keys<StrLitDict>); // Error: The wrong string literal is not allowed
   (123: $Keys<StrLitDict>); // Error: number -> keys of StrLitDict
 }
 
 type ObjLit = { hi: mixed };
 function testKeysOfOtherObj(str: string, lit: \"hi\") {
-  (str: $Keys<ObjLit>);
-  // Error: string -> keys of ObjLit
+  (str: $Keys<ObjLit>); // Error: string -> keys of ObjLit
   if (str) {
     (str: $Keys<ObjLit>); // Error: truthy string -> keys of ObjLit
   }
-  (\"hi\": $Keys<ObjLit>);
-
-  // String literal should be fine
+  (\"hi\": $Keys<ObjLit>); // String literal should be fine
   (123: $Keys<ObjLit>); // Error: number -> keys of ObjLit
 }
 "

--- a/tests/flow/last_duplicate_property_wins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/last_duplicate_property_wins/__snapshots__/jsfmt.spec.js.snap
@@ -51,16 +51,13 @@ class C {
   }
   foo(): string {
     return \"hello\";
-  }
-  // last wins
+  } // last wins
   x: number;
-  x: string;
-  // last wins
+  x: string; // last wins
   bar(): number {
     return 0;
   }
-  bar: string;
-  // field wins over method
+  bar: string; // field wins over method
   qux: number;
   qux(): string {
     return \"hello\";
@@ -68,15 +65,10 @@ class C {
 }
 
 // check
-(new C().foo(): boolean);
-// last wins
-(new C().x: boolean);
-// last wins
-(new C().bar: boolean);
-// last wins
-(new C().qux: boolean);
-
-// weird outlier where last doesn\'t win in classes
+(new C().foo(): boolean); // last wins
+(new C().x: boolean); // last wins
+(new C().bar: boolean); // last wins
+(new C().qux: boolean); // weird outlier where last doesn\'t win in classes
 // Objects
 const o = {
   foo(): number {
@@ -84,30 +76,23 @@ const o = {
   },
   foo(): string {
     return \"hello\";
-  },
-  // last wins
+  }, // last wins
   x: 42,
-  x: \"hello\",
-  // last wins
+  x: \"hello\", // last wins
   bar(): number {
     return 0;
   },
-  bar: \"hello\",
-  // last wins
+  bar: \"hello\", // last wins
   qux: 42,
-  // last wins
   qux(): string {
     return \"hello\";
-  }
+  } // last wins
 };
 
 // check
-(o.foo(): boolean);
-// last wins
-(o.x: boolean);
-// last wins
-(o.bar: boolean);
-// last wins
+(o.foo(): boolean); // last wins
+(o.x: boolean); // last wins
+(o.bar: boolean); // last wins
 (o.qux(): boolean); // last wins
 "
 `;

--- a/tests/flow/literal/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/literal/__snapshots__/jsfmt.spec.js.snap
@@ -39,25 +39,15 @@ var APIKeys = require(\"./enum\");
 // object that maps \"AGE\" to \"age\", \"NAME\" to \"name\"
 function foo(x: $Keys<typeof APIKeys>) {}
 foo(\"AGE\");
-foo(\"LOCATION\");
-
-// error
+foo(\"LOCATION\"); // error
 function bar(x: $Keys<{ age: number }>) {}
-bar(APIKeys.AGE);
-// not an error: APIKeys.AGE = \"age\"
-bar(APIKeys.NAME);
-
-// error: since \"NAME\" is not in the smaller enum
+bar(APIKeys.AGE); // not an error: APIKeys.AGE = \"age\"
+bar(APIKeys.NAME); // error: since \"NAME\" is not in the smaller enum
 var object = {};
-object[APIKeys.AGE] = 123;
-// i.e., object.age = 123
-object[APIKeys.NAME] = \"FOO\";
-
-// i.e., object.name = \"FOO\"
+object[APIKeys.AGE] = 123; // i.e., object.age = 123
+object[APIKeys.NAME] = \"FOO\"; // i.e., object.name = \"FOO\"
 var age: number = object[APIKeys.AGE];
-var name: number = object[APIKeys.NAME];
-
-// error: object.name is a string
+var name: number = object[APIKeys.NAME]; // error: object.name is a string
 var indices = { red: 0, green: 1, blue: 2 };
 var tuple = [42, \"hello\", false];
 var red: string = tuple[indices.red]; // error: tuple[0] is a number

--- a/tests/flow/locals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/locals/__snapshots__/jsfmt.spec.js.snap
@@ -66,12 +66,10 @@ function switch_scope(x: mixed) {
   switch (x) {
     case \"foo\":
       let a;
-      a = 0;
-      // doesn\'t add lower bound to outer a
+      a = 0; // doesn\'t add lower bound to outer a
       b = 0;
   }
-  (a: string);
-  // OK
+  (a: string); // OK
   (b: string); // error: number ~> string
 }
 
@@ -83,12 +81,10 @@ function try_scope_finally() {
     b = \"\";
   } finally {
     let a;
-    a = 0;
-    // doesn\'t add lower bound to outer a
+    a = 0; // doesn\'t add lower bound to outer a
     b = 0;
   }
-  (a: string);
-  // ok
+  (a: string); // ok
   (b: string); // error: number ~> string
 }
 
@@ -96,8 +92,7 @@ function for_scope() {
   let a = \"\";
   let b = \"\";
   for (let a; ; ) {
-    a = 0;
-    // doesn\'t add lower bound to outer a
+    a = 0; // doesn\'t add lower bound to outer a
     b = 0;
   }
   (a: string);
@@ -108,8 +103,7 @@ function for_in_scope(o: Object) {
   let a = 0;
   let b = 0;
   for (let a in o) {
-    a = \"\";
-    // doesn\'t add lower bound to outer a
+    a = \"\"; // doesn\'t add lower bound to outer a
     b = \"\";
   }
   (a: number);
@@ -120,8 +114,7 @@ function for_of_scope(xs: number[]) {
   let a = \"\";
   let b = \"\";
   for (let a of xs) {
-    a = 0;
-    // doesn\'t add lower bound to outer a
+    a = 0; // doesn\'t add lower bound to outer a
     b = 0;
   }
   (a: string);

--- a/tests/flow/logical/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/logical/__snapshots__/jsfmt.spec.js.snap
@@ -519,8 +519,7 @@ function logical19b(x: { y: string, z: boolean }): boolean {
 /**
  * A falsy variable on the left side of &&
  */
-function logical1a(): number {
-  // expected \`: boolean\`
+function logical1a(): number { // expected \`: boolean\`
   var x = false;
   return x && \"123\";
 }
@@ -536,8 +535,7 @@ function logical1b(): string {
 /**
  * A literal on the left side of &&
  */
-function logical2a(): number {
-  // expected \`: boolean\`
+function logical2a(): number { // expected \`: boolean\`
   return false && \"123\";
 }
 
@@ -614,8 +612,7 @@ function logical2k(x: Function): string {
 /**
  * An expression on the left side of &&
  */
-function logical3a(): string {
-  // expected \`: boolean\`
+function logical3a(): string { // expected \`: boolean\`
   var x: ?number = null;
   return x != null && x > 10;
 }
@@ -623,8 +620,7 @@ function logical3a(): string {
 /**
  * An expression on the left side of &&
  */
-function logical3b(): number {
-  // expected \`: boolean | number\`
+function logical3b(): number { // expected \`: boolean | number\`
   var x: ?number = null;
   return x != null && x;
 }
@@ -632,8 +628,7 @@ function logical3b(): number {
 /**
  * An expression on the left side of &&
  */
-function logical3c(): ?number {
-  // expected \`: boolean | ?number\`
+function logical3c(): ?number { // expected \`: boolean | ?number\`
   var x: ?number = null;
   return x != undefined && x;
 }
@@ -641,8 +636,9 @@ function logical3c(): ?number {
 /**
  * Maybe truthy returns both types
  */
-function logical4(x: boolean): string {
-  // expected \`: boolean | string\`
+function logical4(
+  x: boolean
+): string { // expected \`: boolean | string\`
   return x && \"123\";
 }
 
@@ -665,8 +661,7 @@ function logical5b(): number {
 /**
  * A truthy variable on the left side of ||
  */
-function logical5c(): string {
-  // expected \`: boolean\`
+function logical5c(): string { // expected \`: boolean\`
   var x = true;
   return x || 0;
 }
@@ -695,8 +690,7 @@ function logical6c(): number {
 /**
  * A literal on the left side of ||
  */
-function logical6d(): number {
-  // expected \`: boolean\`
+function logical6d(): number { // expected \`: boolean\`
   return true || \"123\";
 }
 
@@ -800,8 +794,7 @@ function logical8e(): string {
 /**
  * A composite || and &&
  */
-function logical8f(): string {
-  // expected \`: boolean\`
+function logical8f(): string { // expected \`: boolean\`
   var x = true;
   return x || 1 && \"foo\";
 }
@@ -809,8 +802,10 @@ function logical8f(): string {
 /**
  * A composite || and ||
  */
-function logical9a(x: number, y: string): number | string {
-  // expected \`: number | string | boolean\`
+function logical9a(
+  x: number,
+  y: string
+): number | string { // expected \`: number | string | boolean\`
   return x || y || false;
 }
 
@@ -831,24 +826,30 @@ function logical9c(x: number, y: boolean): string {
 /**
  * A composite && and &&
  */
-function logical10a(x: number, y: string): number | string {
-  // expected \`: number | string | boolean\`
+function logical10a(
+  x: number,
+  y: string
+): number | string { // expected \`: number | string | boolean\`
   return x && y && false;
 }
 
 /**
  * A composite && and &&
  */
-function logical10b(x: number, y: string): Array<any> {
-  // expected \`: boolean\`
+function logical10b(
+  x: number,
+  y: string
+): Array<any> { // expected \`: boolean\`
   return false && x && y;
 }
 
 /**
  * A composite && and &&
  */
-function logical10c(x: number, y: string): Array<any> {
-  // expected \`number | boolean\`
+function logical10c(
+  x: number,
+  y: string
+): Array<any> { // expected \`number | boolean\`
   return x && false && y;
 }
 

--- a/tests/flow/method_properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/method_properties/__snapshots__/jsfmt.spec.js.snap
@@ -49,9 +49,7 @@ C.bar.x;
 
 import { Foo } from \"./exports_optional_prop\";
 const foo = new Foo();
-(foo.bar(): string);
-
-// error, could be undefined
+(foo.bar(): string); // error, could be undefined
 function f(x) {
   (x.bar(): string); // error. caused by \`f(foo)\`; annotate x to track it down.
 }

--- a/tests/flow/missing_annotation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/missing_annotation/__snapshots__/jsfmt.spec.js.snap
@@ -91,16 +91,19 @@ module.exports = Foo, Bar;
 /* @flow */
 
 var Foo = {
-  a: function(arg) {
-    // missing arg annotation
+  a: function(
+    arg // missing arg annotation
+  ) {
     return arg;
   },
-  b: function(arg) {
-    // missing arg annotation
+  b: function(
+    arg // missing arg annotation
+  ) {
     return { bar: arg };
   },
-  c: function(arg: string) {
-    // no return annotation required
+  c: function(
+    arg: string // no return annotation required
+  ) {
     return { bar: arg };
   },
   d: function(arg: string): { bar: string } {
@@ -110,31 +113,29 @@ var Foo = {
   // observed return type (e.g. param types in a function type) must come
   // from annotations
   e: function(arg: string) {
-    return function(x) {
-      // missing param annotation
+    return function(
+      x // missing param annotation
+    ) {
       return x;
     };
   },
   // ...if the return type is annotated explicitly, this is unnecessary
   f: function(arg: string): (x: number) => number {
-    return function(x) {
-      // no error
+    return function(
+      x // no error
+    ) {
       return x;
     };
   }
 };
 
 var Bar = {
-  a: Foo.a(\"Foo\"),
-  // no annotation required
+  a: Foo.a(\"Foo\"), // no annotation required
   // object property types are inferred, so make sure that this doesn\'t cause
   // us to also infer the parameter\'s type.
-  b: Foo.b(\"bar\"),
-  // no annotation required
-  c: Foo.c(\"bar\"),
-  // no annotation required
-  // no annotation required
-  d: Foo.d(\"bar\")
+  b: Foo.b(\"bar\"), // no annotation required
+  c: Foo.c(\"bar\"), // no annotation required
+  d: Foo.d(\"bar\") // no annotation required
 };
 
 module.exports = Foo, Bar;

--- a/tests/flow/modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/modules/__snapshots__/jsfmt.spec.js.snap
@@ -47,7 +47,6 @@ function g(x: string) {}
 //function f(x:number) { g(x); return x; }
 function f(x: number): number {
   g(x);
-
   return x;
 }
 

--- a/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
@@ -10,15 +10,10 @@ bar(app.props.children); // No error, App doesn\'t specify propTypes so anything
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var app = require(\"JSX\");
 
-app.setProps({ y: 42 });
-// error, y:number but foo expects string in App.react
-app.setState({ z: 42 });
-
-// error, z:number but foo expects string in App.react
+app.setProps({ y: 42 }); // error, y:number but foo expects string in App.react
+app.setState({ z: 42 }); // error, z:number but foo expects string in App.react
 function bar(x: number) {}
-bar(
-  app.props.children
-); // No error, App doesn\'t specify propTypes so anything goes
+bar(app.props.children); // No error, App doesn\'t specify propTypes so anything goes
 "
 `;
 
@@ -168,8 +163,7 @@ var D = React.createClass({
 });
 
 <D
-  namee=\"foo\"
-  /* error (as usual)*/
+  namee=\"foo\" /* error (as usual)*/
   titlee=\"bar\" /* OK (error ignored when spread is used)*/
 />;
 "

--- a/tests/flow/name_prop/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/name_prop/__snapshots__/jsfmt.spec.js.snap
@@ -12,15 +12,11 @@ var test6: number = a.constructor.name; // Error string ~> number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class A {}
 
-var test1 = A.bar;
-// Error bar doesn\'t exist
+var test1 = A.bar; // Error bar doesn\'t exist
 var test2: string = A.name;
-var test3: number = A.name;
-
-// Error string ~> number
+var test3: number = A.name; // Error string ~> number
 var a = new A();
-var test4 = a.constructor.bar;
-// Error bar doesn\'t exist
+var test4 = a.constructor.bar; // Error bar doesn\'t exist
 var test5: string = a.constructor.name;
 var test6: number = a.constructor.name; // Error string ~> number
 "

--- a/tests/flow/namespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/namespace/__snapshots__/jsfmt.spec.js.snap
@@ -28,8 +28,7 @@ var s2:Seq = [[\"\"]];
 
 module.exports = { foo: (\"\": number) };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/*@flow*/
-// import type { T } from \'...\'
+/*@flow*/ // import type { T } from \'...\'
 type T = (x: number) => void;
 var f: T = function(x: string): void {};
 

--- a/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
@@ -175,27 +175,30 @@ type T1 = {};
 type T2 = { x: number };
 type T3 = { x: number, y: number };
 
-class C1 extends React.Component<T1, T2, any> {}
+class C1
+  extends React.Component<T1, T2, any> {} // error
 
-class C2 extends React.Component<void, T2, any> {}
+class C2
+  extends React.Component<void, T2, any> {} // OK
 
 // no need to add type arguments to React.Component
-class C3 extends React.Component {
-  // OK
+class C3
+  extends React.Component { // OK
   static defaultProps: T1;
   props: T2;
 }
 
-class C4 extends React.Component {
-  // OK, recommended
+class C4
+  extends React.Component { // OK, recommended
   // no need to declare defaultProps unless necessary
   props: T2;
 }
 
-class C5 extends React.Component<T2, T3, any> {}
+class C5
+  extends React.Component<T2, T3, any> {} // error
 
-class C6 extends React.Component {
-  // OK, recommended
+class C6
+  extends React.Component { // OK, recommended
   static defaultProps: T2;
   props: T3;
 }
@@ -349,8 +352,7 @@ var FooLegacy = React.createClass({
   }
 });
 
-FooLegacy.defaultProps = 0;
-// TODO: should be error
+FooLegacy.defaultProps = 0; // TODO: should be error
 var foo_legacy: $jsx<number> = <FooLegacy />;
 
 FooLegacy.bar();
@@ -394,8 +396,7 @@ class HelloMessage extends React.Component {
   props: { name: string };
 }
 
-<HelloMessage name={007} />;
-/* number ~/~> string error*/
+<HelloMessage name={007} />; /* number ~/~> string error*/
 <HelloMessage name=\"Bond\" />; // ok
 "
 `;
@@ -506,9 +507,7 @@ var C = React.createClass({
   }
 });
 
-<C statistics={[{}, { label: \"\", value: undefined }]} />;
-
-// error (label is required, value not required)
+<C statistics={[{}, { label: \"\", value: undefined }]} />; // error (label is required, value not required)
 var props: Array<{ label: string, value?: number }> = [
   {},
   { label: \"\", value: undefined }
@@ -552,17 +551,13 @@ var TestProps = React.createClass({
     return { x: \"\", y: 0 };
   },
   test: function() {
-    var a: number = this.props.x;
-    // error
-    var b: string = this.props.y;
-    // error
+    var a: number = this.props.x; // error
+    var b: string = this.props.y; // error
     var c: string = this.props.z; // error
   }
 });
 
-var element = <TestProps x={false} y={false} z={false} />;
-
-// 3 errors
+var element = <TestProps x={false} y={false} z={false} />; // 3 errors
 (element: $jsx<*>);
 (element: $jsx<TestProps>);
 var FooProps = React.createClass({
@@ -870,8 +865,7 @@ type FooState = { key: ?Object };
 var Comp = React.createClass({
   getInitialState: function(): FooState {
     return {
-      // this used to cause a missing annotation error
-      key: null
+      key: null // this used to cause a missing annotation error
     };
   }
 });
@@ -906,12 +900,9 @@ var TestState = React.createClass({
     return { x: \"\" };
   },
   test: function() {
-    var a: number = this.state.x;
-
-    // error
+    var a: number = this.state.x; // error
     this.setState({
-      // error
-      x: false
+      x: false // error
     });
   }
 });

--- a/tests/flow/node_tests/assert/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/assert/__snapshots__/jsfmt.spec.js.snap
@@ -8,8 +8,7 @@ assert.ok(true) // ok
 /* @flow */
 
 var assert = require(\"assert\");
-assert(true);
-// ok
+assert(true); // ok
 assert.ok(true); // ok
 "
 `;

--- a/tests/flow/node_tests/child_process/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/child_process/__snapshots__/jsfmt.spec.js.snap
@@ -110,16 +110,11 @@ var execSync = require(\'child_process\').execSync;
 
 var execSync = require(\"child_process\").execSync;
 
-(execSync(\"ls\"): Buffer);
-// returns Buffer
-(execSync(\"ls\", { encoding: \"buffer\" }): Buffer);
-// returns Buffer
-(execSync(\"ls\", { encoding: \"utf8\" }): string);
-// returns string
-execSync(\"ls\", { timeout: \"250\" });
-// error, no signatures match
-execSync(\"ls\", { stdio: \"inherit\" });
-// error, no signatures match
+(execSync(\"ls\"): Buffer); // returns Buffer
+(execSync(\"ls\", { encoding: \"buffer\" }): Buffer); // returns Buffer
+(execSync(\"ls\", { encoding: \"utf8\" }): string); // returns string
+execSync(\"ls\", { timeout: \"250\" }); // error, no signatures match
+execSync(\"ls\", { stdio: \"inherit\" }); // error, no signatures match
 execSync(\"ls\", { stdio: [\"inherit\"] }); // error, no signatures match
 "
 `;

--- a/tests/flow/node_tests/crypto/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/crypto/__snapshots__/jsfmt.spec.js.snap
@@ -53,8 +53,7 @@ let tests = [
     });
 
     hmac.write(\"some data to hash\");
-    hmac.write(123);
-    // 2 errors: not a string or a Buffer
+    hmac.write(123); // 2 errors: not a string or a Buffer
     hmac.end();
   },
   // Hmac supports update and digest functions too
@@ -63,19 +62,15 @@ let tests = [
 
     hmac.update(\"some data to hash\");
     hmac.update(\"foo\", \"utf8\");
-    hmac.update(\"foo\", \"bogus\");
-    // 1 error
+    hmac.update(\"foo\", \"bogus\"); // 1 error
     hmac.update(buf);
-    hmac.update(buf, \"utf8\");
-
-    // 1 error: no encoding when passing a buffer
+    hmac.update(buf, \"utf8\"); // 1 error: no encoding when passing a buffer
     // it\'s also chainable
     (hmac.update(\"some data to hash\").update(buf).digest(): Buffer);
 
     (hmac.digest(\"hex\"): string);
     (hmac.digest(): Buffer);
-    (hmac.digest(\"hex\"): void);
-    // 1 error
+    (hmac.digest(\"hex\"): void); // 1 error
     (hmac.digest(): void); // 1 error
   }
 ];

--- a/tests/flow/node_tests/fs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/fs/__snapshots__/jsfmt.spec.js.snap
@@ -54,17 +54,11 @@ fs.readFile(\"file.exp\", {}, (_, data) => {
 
 /* readFileSync */
 (fs.readFileSync(\"file.exp\"): Buffer);
-(fs.readFileSync(\"file.exp\"): string);
-
-// error
+(fs.readFileSync(\"file.exp\"): string); // error
 (fs.readFileSync(\"file.exp\", \"blah\"): string);
-(fs.readFileSync(\"file.exp\", \"blah\"): Buffer);
-
-// error
+(fs.readFileSync(\"file.exp\", \"blah\"): Buffer); // error
 (fs.readFileSync(\"file.exp\", { encoding: \"blah\" }): string);
-(fs.readFileSync(\"file.exp\", { encoding: \"blah\" }): Buffer);
-
-// error
+(fs.readFileSync(\"file.exp\", { encoding: \"blah\" }): Buffer); // error
 (fs.readFileSync(\"file.exp\", {}): Buffer);
 (fs.readFileSync(\"file.exp\", {}): string); // error
 "

--- a/tests/flow/node_tests/json_file/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/json_file/__snapshots__/jsfmt.spec.js.snap
@@ -26,36 +26,21 @@ let data4 = require(\'./json_array\');
 // @flow
 
 let data = require(\"./package/index.json\");
-(data.foo: void);
-// error, should be object literal
-(data.foo.bar: void);
-// error, should be boolean
-(data.abc: boolean);
-
-// error, should be ?string
+(data.foo: void); // error, should be object literal
+(data.foo.bar: void); // error, should be boolean
+(data.abc: boolean); // error, should be ?string
 let data2 = require(\"./package\");
-(data2.baz: void);
-
-// error, should be string
+(data2.baz: void); // error, should be string
 let data3 = require(\"./package2\");
-(data3.foo: void);
-
-// error, should be number (not string! index.js wins)
+(data3.foo: void); // error, should be number (not string! index.js wins)
 let data4 = require(\"./json_array\");
 (data4: Array<number>);
-(data4: void);
-
-// error, should be Array<number>
-(require(\"./json_string\"): void);
-// error, should be string
-(require(\"./json_number\"): void);
-// error, should be number
-(require(\"./json_true\"): void);
-// error, should be true
-(require(\"./json_false\"): void);
-// error, should be false
-(require(\"./json_null\"): void);
-// error, should be null
+(data4: void); // error, should be Array<number>
+(require(\"./json_string\"): void); // error, should be string
+(require(\"./json_number\"): void); // error, should be number
+(require(\"./json_true\"): void); // error, should be true
+(require(\"./json_false\"): void); // error, should be false
+(require(\"./json_null\"): void); // error, should be null
 (require(\"./json_negative_number\"): -1); // ok
 "
 `;

--- a/tests/flow/node_tests/os/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/os/__snapshots__/jsfmt.spec.js.snap
@@ -21,17 +21,12 @@ var os = require(\"os\");
 
 var u1 = os.userInfo();
 (u1.username: string);
-(u1.username: Buffer);
-
-// error
+(u1.username: Buffer); // error
 var u2 = os.userInfo({ encoding: \"utf8\" });
 (u2.username: string);
-(u2.username: Buffer);
-
-// error
+(u2.username: Buffer); // error
 var u3 = os.userInfo({ encoding: \"buffer\" });
-(u3.username: string);
-// error
+(u3.username: string); // error
 (u3.username: Buffer);
 "
 `;

--- a/tests/flow/nullable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/nullable/__snapshots__/jsfmt.spec.js.snap
@@ -8,8 +8,7 @@ exports[`test maybe.js 1`] = `
 // @flow
 
 // unwrapping nested maybes should work
-((\"foo\": ??string): ?string);
-// ok
+((\"foo\": ??string): ?string); // ok
 ((123: ??number): ?string); // error (only num ~> string)
 "
 `;
@@ -46,13 +45,9 @@ function qux(x: string) {}
 
 function corge(x: number) {}
 
-var x = bar();
-// x: ?string
-if (x != null) qux(x);
-// x: ?string | null
-if (x != null) corge(x);
-
-// x: ?string | null
+var x = bar(); // x: ?string
+if (x != null) qux(x); // x: ?string | null
+if (x != null) corge(x); // x: ?string | null
 function grault() {
   x = null;
 }

--- a/tests/flow/object-method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object-method/__snapshots__/jsfmt.spec.js.snap
@@ -82,8 +82,7 @@ var a = { p: 0, f };
 
 var b = { f };
 
-a.f();
-// okey-dokie
+a.f(); // okey-dokie
 b.f(); // error, property \`p\` not found
 "
 `;
@@ -115,14 +114,11 @@ function foo() {
 }
 
 function bar(f: () => void) {
-  f();
-  // passing global object as \`this\`
+  f(); // passing global object as \`this\`
   ({ f }).f(); // passing container object as \`this\`
 }
 
-bar(foo);
-
-// error, since \`this\` is used non-trivially in \`foo\`
+bar(foo); // error, since \`this\` is used non-trivially in \`foo\`
 function qux(o: { f(): void }) {
   o.f(); // passing o as \`this\`
 }

--- a/tests/flow/object_api/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_api/__snapshots__/jsfmt.spec.js.snap
@@ -20,8 +20,7 @@ module.exports = b;
 
 var a = require(\"./a\");
 var b = Object.assign({ bar() {}, ...{} }, a);
-b.a();
-// works here
+b.a(); // works here
 module.exports = b;
 "
 `;
@@ -65,9 +64,7 @@ var export_ = Object.assign({}, {
 var decl_export_: { foo: any, bar: any } = Object.assign({}, export_);
 
 let anyObj: Object = {};
-Object.assign(anyObj, anyObj);
-
-// makes sure this terminates
+Object.assign(anyObj, anyObj); // makes sure this terminates
 module.exports = export_;
 "
 `;
@@ -178,9 +175,7 @@ class Bar extends Foo {
 
 var sealed = { one: \"one\", two: \"two\" };
 (Object.keys(sealed): Array<\"one\" | \"two\">);
-(Object.keys(sealed): void);
-
-// error, Array<string>
+(Object.keys(sealed): void); // error, Array<string>
 var unsealed = {};
 Object.keys(unsealed).forEach(k => {
   (k: number); // error: number ~> string
@@ -192,17 +187,13 @@ Object.keys(dict).forEach(k => {
 });
 
 var any: Object = {};
-(Object.keys(any): Array<number>);
-
-// error, Array<string>
+(Object.keys(any): Array<number>); // error, Array<string>
 class Foo {
   prop: string;
   foo() {}
 }
 // constructor and foo not enumerable
-(Object.keys(new Foo()): Array<\"error\">);
-
-// error: prop ~> error
+(Object.keys(new Foo()): Array<\"error\">); // error: prop ~> error
 class Bar extends Foo {
   bar_prop: string;
   bar() {}
@@ -423,9 +414,7 @@ var y = new Foo();
 //
 // call
 takesAString(a.toString());
-d.toString();
-
-// ok, even though dict specifies strings, this is a function
+d.toString(); // ok, even though dict specifies strings, this is a function
 // get
 var aToString: () => string = a.toString;
 var aToString2 = a.toString;
@@ -443,28 +432,21 @@ c.toString = function(): number {
 var cToString: () => number = c.toString;
 
 // ... on a built-in instance
-var xToString: number = x.toString;
-// error
-var xToString2: () => number = x.toString;
-// error
+var xToString: number = x.toString; // error
+var xToString2: () => number = x.toString; // error
 takesAString(x.toString());
 
 // ... on an instance
-var yToString: number = y.toString;
-// error
+var yToString: number = y.toString; // error
 takesAString(y.toString());
 
 // ... on a primitive
 (123).toString();
 (123).toString;
-(123).toString = function() {};
-// error
+(123).toString = function() {}; // error
 (123).toString(2);
-(123).toString(\"foo\");
-// error
-(123).toString(null);
-
-// error
+(123).toString(\"foo\"); // error
+(123).toString(null); // error
 //
 // hasOwnProperty
 //
@@ -482,15 +464,12 @@ b.hasOwnProperty = function() {
 };
 
 // ... on a built-in instance
-var xHasOwnProperty: number = x.hasOwnProperty;
-// error
-var xHasOwnProperty2: (prop: string) => number = x.hasOwnProperty;
-// error
+var xHasOwnProperty: number = x.hasOwnProperty; // error
+var xHasOwnProperty2: (prop: string) => number = x.hasOwnProperty; // error
 takesABool(x.hasOwnProperty(\"foo\"));
 
 // ... on an instance
-var yHasOwnProperty: number = y.hasOwnProperty;
-// error
+var yHasOwnProperty: number = y.hasOwnProperty; // error
 takesABool(y.hasOwnProperty(\"foo\"));
 
 //
@@ -510,15 +489,12 @@ b.propertyIsEnumerable = function() {
 };
 
 // ... on a built-in instance
-var xPropertyIsEnumerable: number = x.propertyIsEnumerable;
-// error
-var xPropertyIsEnumerable2: (prop: string) => number = x.propertyIsEnumerable;
-// error
+var xPropertyIsEnumerable: number = x.propertyIsEnumerable; // error
+var xPropertyIsEnumerable2: (prop: string) => number = x.propertyIsEnumerable; // error
 takesABool(x.propertyIsEnumerable(\"foo\"));
 
 // ... on an instance
-var yPropertyIsEnumerable: number = y.propertyIsEnumerable;
-// error
+var yPropertyIsEnumerable: number = y.propertyIsEnumerable; // error
 takesABool(y.propertyIsEnumerable(\"foo\"));
 
 //
@@ -538,13 +514,11 @@ b.valueOf = function() {
 };
 
 // ... on a built-in instance
-var xValueOf: number = x.valueOf;
-// error
+var xValueOf: number = x.valueOf; // error
 takesANumber(x.valueOf());
 
 // ... on an instance
-var yValueOf: number = y.valueOf;
-// error
+var yValueOf: number = y.valueOf; // error
 takesAnObject(y.valueOf());
 
 // ... on a literal
@@ -569,15 +543,12 @@ b.toLocaleString = function() {
 };
 
 // ... on a built-in instance
-var xToLocaleString: number = x.toLocaleString;
-// error
-var xToLocaleString2: () => number = x.toLocaleString;
-// error
+var xToLocaleString: number = x.toLocaleString; // error
+var xToLocaleString2: () => number = x.toLocaleString; // error
 takesAString(x.toLocaleString());
 
 // ... on an instance
-var yToLocaleString: number = y.toLocaleString;
-// error
+var yToLocaleString: number = y.toLocaleString; // error
 takesAString(y.toLocaleString());
 
 //

--- a/tests/flow/object_assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_assign/__snapshots__/jsfmt.spec.js.snap
@@ -83,11 +83,8 @@ var A = require(\"./A.js\");
 
 var good: number = A.Good.foo();
 
-var f = A.Bad.foo;
-// Property access is fine
-var bad_: number = f();
-
-// Calling the function is fine
+var f = A.Bad.foo; // Property access is fine
+var bad_: number = f(); // Calling the function is fine
 var bad: number = A.Bad.foo(); // Method call is not fine
 /*
 B.js|12 col 1 error|  call of method foo
@@ -166,8 +163,7 @@ class MyReactThing extends React.Component {
   }
 }
 
-<MyReactThing />;
-/* works*/
+<MyReactThing />; /* works*/
 <MyReactThing foo={undefined} />; // also works
 "
 `;

--- a/tests/flow/object_freeze/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_freeze/__snapshots__/jsfmt.spec.js.snap
@@ -23,25 +23,15 @@ var xx : { x: number } = Object.freeze({ x: \"error\" })
 /* @flow */
 
 var foo = Object.freeze({ bar: \"12345\" });
-foo.bar = \"23456\";
-
-// error
-Object.assign(foo, { bar: \"12345\" });
-
-// error
+foo.bar = \"23456\"; // error
+Object.assign(foo, { bar: \"12345\" }); // error
 var baz = { baz: 12345 };
 var bliffl = Object.freeze({ bar: \"12345\", ...baz });
-bliffl.bar = \"23456\";
-// error
-bliffl.baz = 3456;
-// error
-bliffl.corge;
-// error
-bliffl.constructor = baz;
-// error
-bliffl.toString = function() {};
-
-// error
+bliffl.bar = \"23456\"; // error
+bliffl.baz = 3456; // error
+bliffl.corge; // error
+bliffl.constructor = baz; // error
+bliffl.toString = function() {}; // error
 baz.baz = 0;
 
 var x: number = Object.freeze(123);

--- a/tests/flow/objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/objects/__snapshots__/jsfmt.spec.js.snap
@@ -28,17 +28,14 @@ var z = Object(123); // error (next line makes this not match any signatures)
 (Object(null): {});
 (Object(undefined): {});
 (Object(void 0): {});
-(Object(undefined): Number);
-
-// error
+(Object(undefined): Number); // error
 var x = Object(null);
 x.foo = \"bar\";
 
 var y = Object(\"123\");
 (y.charAt(0): string);
 
-var z = Object(123);
-// error (next line makes this not match any signatures)
+var z = Object(123); // error (next line makes this not match any signatures)
 (z.charAt(0): string);
 "
 `;
@@ -66,31 +63,18 @@ y[\'bar\'] = \'abc\'; // error, property not found
 /* @flow */
 
 var x: { \"123\": string, bar: string } = { \"123\": \"val\", bar: \"bar\" };
-(x.foo: string);
-// error, key doesn\'t exist
-(x[\"foo\"]: string);
-// error, key doesn\'t exist
-(x[123]: boolean);
-// TODO: use the number\'s value to error here
-(x.bar: boolean);
-// error, string !~> boolean
-(x[\"123\"]: boolean);
-// error, string !~> boolean
-x[\"123\"] = false;
-// error, boolean !~> string
-x[123] = false;
-// TODO: use the number\'s value to error here
-x[\"foo\" + \"bar\"] = \"derp\";
-// ok since we can\'t tell
-(x[\`foo\`]: string);
-
-// error, key doesn\'t exist
+(x.foo: string); // error, key doesn\'t exist
+(x[\"foo\"]: string); // error, key doesn\'t exist
+(x[123]: boolean); // TODO: use the number\'s value to error here
+(x.bar: boolean); // error, string !~> boolean
+(x[\"123\"]: boolean); // error, string !~> boolean
+x[\"123\"] = false; // error, boolean !~> string
+x[123] = false; // TODO: use the number\'s value to error here
+x[\"foo\" + \"bar\"] = \"derp\"; // ok since we can\'t tell
+(x[\`foo\`]: string); // error, key doesn\'t exist
 var y: { foo: string } = { foo: \"bar\" };
-y[\"foo\"] = 123;
-// error, number !~> string
-y[\"bar\"] = \"abc\";
-
-// error, property not found
+y[\"foo\"] = 123; // error, number !~> string
+y[\"bar\"] = \"abc\"; // error, property not found
 (y[\"hasOwnProperty\"]: string); // error, prototype method is not a string
 "
 `;

--- a/tests/flow/objmap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/objmap/__snapshots__/jsfmt.spec.js.snap
@@ -23,14 +23,10 @@ declare function keyMirror<O>(o: O): $ObjMapi<O, <K>(k: K) => K>;
 
 var o = keyMirror({ FOO: null, BAR: null });
 
-(o.FOO: \"FOO\");
-// ok
-(o.FOO: \"BAR\");
-
-// error, \'FOO\' incompatible with \'BAR\'
+(o.FOO: \"FOO\"); // ok
+(o.FOO: \"BAR\"); // error, \'FOO\' incompatible with \'BAR\'
 promiseAllByKey({ foo: Promise.resolve(0), bar: \"bar\" }).then(o => {
-  (o.foo: string);
-  // error, number ~> string
+  (o.foo: string); // error, number ~> string
   (o.bar: \"bar\"); // ok
 });
 "

--- a/tests/flow/optional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/optional/__snapshots__/jsfmt.spec.js.snap
@@ -173,7 +173,6 @@ foo();
 
 function qux(x = \"hello\", ...y): string {
   foo(x);
-
   return y[0];
 }
 
@@ -296,9 +295,7 @@ function bar(x = \"bar\"): string {
 bar(undefined); // ok
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function foo(x?: number) {}
-foo(undefined);
-
-// ok
+foo(undefined); // ok
 function bar(x = \"bar\"): string {
   return x;
 }
@@ -327,14 +324,9 @@ function foo(x?: number, ...y: Array<string>): [?number, Array<string>] {
   return [x, y];
 }
 
-foo();
-// OK
-foo(123), // OK
-foo(123, \"hello\");
-
-// OK
-foo(true);
-// ERROR boolean ~> number
+foo(); // OK
+foo(123), foo(123, \"hello\"); // OK // OK
+foo(true); // ERROR boolean ~> number
 foo(123, true); // ERROR boolean ~> string
 "
 `;

--- a/tests/flow/optional_props/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/optional_props/__snapshots__/jsfmt.spec.js.snap
@@ -13,17 +13,12 @@ bar({});
 bar({foo: \"\"});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var x: {} = { foo: 0 };
-var y: { foo?: string } = x;
-
-// OK in TypeScript, not OK in Flow
+var y: { foo?: string } = x; // OK in TypeScript, not OK in Flow
 var z: string = y.foo || \"\";
 
 var o = {};
-y = o;
-// OK; we know that narrowing could not have happened
-o.foo = 0;
-
-// future widening is constrained
+y = o; // OK; we know that narrowing could not have happened
+o.foo = 0; // future widening is constrained
 function bar(config: { foo?: number }) {}
 bar({});
 bar({ foo: \"\" });
@@ -46,24 +41,14 @@ var e: { foo?: ?string } = { foo: undefined }; // This is fine
 var f: { foo?: ?string } = { foo: null }; // Also fine
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var a: { foo?: string } = {};
-a.foo = undefined;
-// This is not an error
-a.foo = null;
-
-// But this is an error
+a.foo = undefined; // This is not an error
+a.foo = null; // But this is an error
 var b: { foo?: ?string } = {};
-b.foo = undefined;
-// This is fine
-b.foo = null;
-
-// Also fine
-var c: { foo?: string } = { foo: undefined };
-// This is not an error
-var d: { foo?: string } = { foo: null };
-
-// But this is an error
-var e: { foo?: ?string } = { foo: undefined };
-// This is fine
+b.foo = undefined; // This is fine
+b.foo = null; // Also fine
+var c: { foo?: string } = { foo: undefined }; // This is not an error
+var d: { foo?: string } = { foo: null }; // But this is an error
+var e: { foo?: ?string } = { foo: undefined }; // This is fine
 var f: { foo?: ?string } = { foo: null }; // Also fine
 "
 `;

--- a/tests/flow/overload/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/overload/__snapshots__/jsfmt.spec.js.snap
@@ -71,20 +71,12 @@ declare class C {
 
 var a = new C();
 
-a.foo(0);
-// ok
-a.foo(\"hey\");
-// ok
-a.foo(true);
-
-// error, function cannot be called on intersection type
-a.bar({ a: 0 });
-// ok
-a.bar({ a: \"hey\" });
-// ok
-a.bar({ a: true });
-
-// error, function cannot be called on intersection type
+a.foo(0); // ok
+a.foo(\"hey\"); // ok
+a.foo(true); // error, function cannot be called on intersection type
+a.bar({ a: 0 }); // ok
+a.bar({ a: \"hey\" }); // ok
+a.bar({ a: true }); // error, function cannot be called on intersection type
 declare var x: { a: boolean } & { b: string };
 
 a.bar(x); // error with nested intersection info (outer for bar, inner for x)
@@ -133,8 +125,7 @@ var foo = new Foo;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class Foo { bar(x: \"hmm\"): number, bar(x: string): string }
 var foo = new Foo();
-(foo.bar(\"hmm\"): number);
-// OK
+(foo.bar(\"hmm\"): number); // OK
 (foo.bar(\"hmmm\"): number); // error
 "
 `;
@@ -169,17 +160,13 @@ h(x_h.p); // ok
 declare function f(x: string): void;
 declare function f(x: number): void;
 declare var x_f: string | number;
-f(x_f);
-
-// ok
+f(x_f); // ok
 // maybe
 declare function g(x: null): void;
 declare function g(x: void): void;
 declare function g(x: string): void;
 declare var x_g: ?string;
-g(x_g);
-
-// ok
+g(x_g); // ok
 // optional
 declare function h(x: void): void;
 declare function h(x: string): void;

--- a/tests/flow/parse_error_haste/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/parse_error_haste/__snapshots__/jsfmt.spec.js.snap
@@ -18,11 +18,8 @@ var C = require(\"./ParseError\"); // Flow file
  */
 
 // non-flow files should not show parse errors
-var A = require(\"Foo\");
-// non-Flow file @providesModule Foo
-var B = require(\"./NoProvides\");
-
-// non-Flow file
+var A = require(\"Foo\"); // non-Flow file @providesModule Foo
+var B = require(\"./NoProvides\"); // non-Flow file
 var C = require(\"./ParseError\"); // Flow file
 "
 `;

--- a/tests/flow/parse_error_node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/parse_error_node/__snapshots__/jsfmt.spec.js.snap
@@ -17,9 +17,7 @@ var B = require(\"./ParseError\");        // Flow file
  */
 
 // non-flow files should not give parse errors
-var A = require(\"./Imported\");
-
-// non-Flow file @providesModule Foo
+var A = require(\"./Imported\"); // non-Flow file @providesModule Foo
 var B = require(\"./ParseError\"); // Flow file
 "
 `;

--- a/tests/flow/poly/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/poly/__snapshots__/jsfmt.spec.js.snap
@@ -12,18 +12,15 @@ function bar(): A<*> { // error, * can\'t be {} and {x: string} at the same time
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class A<X> {}
-new A();
-// OK, implicitly inferred type args
-class B extends A {}
-
-// OK, same as above
-function foo(b): A<any> {
-  // ok but unsafe, caller may assume any type arg
+new A(); // OK, implicitly inferred type args
+class B extends A {} // OK, same as above
+function foo(
+  b
+): A<any> { // ok but unsafe, caller may assume any type arg
   return b ? (new A(): A<number>) : (new A(): A<string>);
 }
 
-function bar(): A<*> {
-  // error, * can\'t be {} and {x: string} at the same time
+function bar(): A<*> { // error, * can\'t be {} and {x: string} at the same time
   return (new A(): A<{}>) || (new A(): A<{ x: string }>);
 }
 "
@@ -69,8 +66,7 @@ var a: C<*> = new C();
 
 a.meth(new Middle());
 a.meth(new Child());
-a.meth(42);
-// Error: number ~> Middle
+a.meth(42); // Error: number ~> Middle
 a.meth(new Base()); // Error: Base ~> Middle
 "
 `;
@@ -188,16 +184,13 @@ class C {
 class D extends C {
   foo(x: number): number {
     return x;
-  }
-  // error (specialization, see below)
+  } // error (specialization, see below)
   foo_(x: number): number {
     return x;
-  }
-  // OK, but only because the overridden foo accepts no more than number and returns exactly number
+  } // OK, but only because the overridden foo accepts no more than number and returns exactly number
   bar<X>(x: X): X {
     return x;
-  }
-  // OK
+  } // OK
   qux<X>(x: X): X {
     return x;
   } // OK (generalization)

--- a/tests/flow/predicates-abstract/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/predicates-abstract/__snapshots__/jsfmt.spec.js.snap
@@ -68,8 +68,7 @@ type E = { kind: \"E\", y: boolean };
 
 declare var ab: Array<A | B | C>;
 
-(my_filter(ab, (x): %checks => x.kind === \"A\"): Array<A>);
-// OK
+(my_filter(ab, (x): %checks => x.kind === \"A\"): Array<A>); // OK
 (my_filter(ab, (x): %checks => x.kind !== \"A\"): Array<B | C>); // OK
 "
 `;
@@ -258,8 +257,7 @@ type E = { kind: \"E\", y: boolean };
 
 declare var ab: Array<A | B | C>;
 
-(my_filter(ab, (x): %checks => x.kind === \"A\"): Array<B>);
-// ERROR
+(my_filter(ab, (x): %checks => x.kind === \"A\"): Array<B>); // ERROR
 (my_filter(ab, (x): %checks => x.kind !== \"A\"): Array<A | C>); // ERROR
 "
 `;
@@ -316,8 +314,7 @@ function is_string_and_number(x, y): %checks {
 declare function refine<T, P: $Pred<1>>(v: T, cb: P): $Refine<T, P, 2>;
 
 declare var a: mixed;
-var b = refine(a, is_string);
-// ERROR: index out of bounds
+var b = refine(a, is_string); // ERROR: index out of bounds
 (b: string);
 
 // Sanity check B: refine2 expects a function that accepts 3 arguments but
@@ -341,8 +338,7 @@ function is_string_and_number(x, y): %checks {
 }
 
 // Sanity check C: expecting a predicate function but passed a non-predicate one
-var e = refine(a, is_string_regular);
-// ERROR: is_string_regular is not a
+var e = refine(a, is_string_regular); // ERROR: is_string_regular is not a
 // predicate function
 (e: number);
 

--- a/tests/flow/predicates-declared/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/predicates-declared/__snapshots__/jsfmt.spec.js.snap
@@ -445,8 +445,9 @@ function foo(x: string | Array<string>): string {
 // Sanity check:
 // - predicate functions cannot have bodies (can only be declarations)
 
-function pred(x: mixed): boolean %checks(typeof x === \"string\") {
-  // error: cannot use pred type here
+function pred(
+  x: mixed
+): boolean %checks(typeof x === \"string\") { // error: cannot use pred type here
   return typeof x === \"string\";
 }
 

--- a/tests/flow/predicates-parsing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/predicates-parsing/__snapshots__/jsfmt.spec.js.snap
@@ -37,8 +37,9 @@ var a2 = (x: mixed): %checks (x !== null) => {        // Error: body form
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // @flow
 
-var a2 = (x: mixed): %checks(x !== null) => {
-  // Error: body form
+var a2 = (
+  x: mixed // Error: body form
+): %checks(x !== null) => {
   var x = 1;
   return x;
 };

--- a/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
@@ -47,18 +47,13 @@ declare var pnum: Promise<number>;
 Promise.all([
   pstr,
   pnum,
-  // non-Promise values passed through
-  true
+  true // non-Promise values passed through
 ]).then(xs => {
   // tuple information is preserved
   let [a, b, c] = xs;
-  (a: number);
-  // Error: string ~> number
-  (b: boolean);
-  // Error: number ~> boolean
-  (c: string);
-
-  // Error: boolean ~> string
+  (a: number); // Error: string ~> number
+  (b: boolean); // Error: number ~> boolean
+  (c: string); // Error: boolean ~> string
   // array element type is (string | number | boolean)
   xs.forEach(x => {
     (x: void); // Errors: string ~> void, number ~> void, boolean ~> void
@@ -66,13 +61,9 @@ Promise.all([
 });
 
 // First argument is required
-Promise.all();
-
-// Error: expected array instead of undefined (too few arguments)
+Promise.all(); // Error: expected array instead of undefined (too few arguments)
 // Mis-typed arg
-Promise.all(0);
-
-// Error: expected array instead of number
+Promise.all(0); // Error: expected array instead of number
 // Promise.all is a function
 (Promise.all: Function);
 
@@ -695,9 +686,7 @@ exports[`test resolve_void.js 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // @flow
 
-(Promise.resolve(): Promise<number>);
-
-// error
+(Promise.resolve(): Promise<number>); // error
 (Promise.resolve(undefined): Promise<number>); // error
 "
 `;

--- a/tests/flow/react_functional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react_functional/__snapshots__/jsfmt.spec.js.snap
@@ -16,18 +16,12 @@ var Z = 0;
 import React from \"react\";
 
 function F(props: { foo: string }) {}
-<F />;
-/* error: missing \`foo\`*/
-<F foo={0} />;
-/* error: number ~> string*/
-<F foo=\"\" />;
-
-// ok
+<F />; /* error: missing \`foo\`*/
+<F foo={0} />; /* error: number ~> string*/
+<F foo=\"\" />; // ok
 // props subtyping is property-wise covariant
 function G(props: { foo: string | numner }) {}
-<G foo=\"\" />;
-
-// ok
+<G foo=\"\" />; // ok
 var Z = 0;
 <Z />; // error, expected React component
 "

--- a/tests/flow/rec/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/rec/__snapshots__/jsfmt.spec.js.snap
@@ -92,27 +92,16 @@ pstar = (new P: P<P<number>>); // OK
 class P<X> {
   x: X;
 }
-
 // this is like Promise
-type Pstar<X> = X | Pstar<P<X>>;
-
-// this is like Promise*
+type Pstar<X> = X | Pstar<P<X>>; // this is like Promise*
 var p: P<number> = new P();
-(p.x: string);
-
-// error
-var pstar: Pstar<number> = 0;
-// OK
-(pstar: number);
-// error, but limit potentially unbounded number of errors!
+(p.x: string); // error
+var pstar: Pstar<number> = 0; // OK
+(pstar: number); // error, but limit potentially unbounded number of errors!
 // e.g., P<number> ~/~ number, P<P<number>> ~/~ number, ...
-pstar = p;
-// OK
-(pstar.x: string);
-
-// error
-pstar = (new P(): P<P<number>>);
-// OK
+pstar = p; // OK
+(pstar.x: string); // error
+pstar = (new P(): P<P<number>>); // OK
 (pstar.x: string); // error
 "
 `;

--- a/tests/flow/record/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/record/__snapshots__/jsfmt.spec.js.snap
@@ -28,26 +28,16 @@ type Key1 = \"foo\" | \"bar\";
 // make an enum type with known key set
 var o1: { [key: Key1]: number } = {
   foo: 0,
-  // error: string ~/~ number
-  bar: \"\"
+  bar: \"\" // error: string ~/~ number
 };
-o1.foo;
-// OK
-o1.qux;
-// error: qux not found
-o1.toString();
-
-// ok
+o1.foo; // OK
+o1.qux; // error: qux not found
+o1.toString(); // ok
 type R = { foo: any, bar: any };
-type Key2 = $Keys<R>;
-// another way to make an enum type, with unknown key set
-var o2: { [key: Key2]: number } = { foo: 0 };
-// OK to leave out bar
-o2.bar;
-// OK to access bar
-o2.qux;
-
-// error: qux not found
+type Key2 = $Keys<R>; // another way to make an enum type, with unknown key set
+var o2: { [key: Key2]: number } = { foo: 0 }; // OK to leave out bar
+o2.bar; // OK to access bar
+o2.qux; // error: qux not found
 class C<X> {
   x: $Subtype<{ [key: $Keys<X>]: any }>; // object with larger key set than X\'s
 }

--- a/tests/flow/refi/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refi/__snapshots__/jsfmt.spec.js.snap
@@ -534,8 +534,7 @@ var tests = [
   },
   function(x: mixed) {
     if (typeof x.bar === \"string\") {
-    }
-    // error, so \`x.bar\` refinement is empty
+    } // error, so \`x.bar\` refinement is empty
     (x: string & number);
   },
   // --- nested conditionals ---
@@ -574,8 +573,7 @@ var tests = [
   function() {
     var x: { p: ?string } = { p: \"xxx\" };
     if (x.p != null) {
-      var { p } = x;
-      // TODO: annot checked against type of x
+      var { p } = x; // TODO: annot checked against type of x
       (p: string); // ok
     }
   }
@@ -631,10 +629,9 @@ function block_scope(x: string | number) {
 
 function switch_scope(x: string | number) {
   switch (x) {
-    // doesn\'t refine outer x
     default:
       let x;
-      x = \"\";
+      x = \"\"; // doesn\'t refine outer x
   }
   (x: string); // error: number ~> string
 }
@@ -1187,10 +1184,8 @@ function exhaustion3(x): number {
 // @flow
 function foo(a, b, c) {
   switch (c) {
-    case a.x.y:
-    // OK
-    case b.x.y:
-      // OK
+    case a.x.y: // OK
+    case b.x.y: // OK
       return;
     default:
       return;
@@ -1201,8 +1196,7 @@ function foo(a, b, c) {
 function exhaustion1(x): number {
   var foo;
   switch (x) {
-    case 0:
-    // falls through
+    case 0: // falls through
     case 1:
       foo = 3;
       break;
@@ -1240,8 +1234,7 @@ function exhaustion2(x, y): number {
 function exhaustion3(x): number {
   let foo = null;
   switch (x) {
-    case 0:
-    // falls through
+    case 0: // falls through
     case 1:
       foo = 3;
       break;

--- a/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
@@ -44,15 +44,17 @@ function foo(x: ?number) {
 type Bar = { parent: ?Bar, doStuff(): void };
 
 function bar0(x: Bar) {
-  while (x = x.parent) {
-    // can\'t assign x to ?Bar
+  while (
+    x = x.parent // can\'t assign x to ?Bar
+  ) {
     x.doStuff();
   }
 }
 
 function bar1(x: ?Bar) {
-  while (x = x.parent) {
-    // x.parent might be null
+  while (
+    x = x.parent // x.parent might be null
+  ) {
     x.doStuff();
   }
 }
@@ -287,8 +289,7 @@ type NonNullType = { kind: \"NonNullType\", type: Name | ListType | BadType };
 type BadType = {};
 
 function getTypeASTName(typeAST: Type): string {
-  if (!typeAST.type) throw new Error(\"Must be wrapping type\");
-  // OK
+  if (!typeAST.type) throw new Error(\"Must be wrapping type\"); // OK
   return getTypeASTName(typeAST.type); // error, BadType not a subtype of Type
 }
 
@@ -372,15 +373,13 @@ let tests = [
 let tests = [
   function(x: string, y: number) {
     if (x == y) {
-    }
-    // error, string & number are not comparable (unsafe casting)
+    } // error, string & number are not comparable (unsafe casting)
     if (x === y) {
     } // no error, to match \`let z = (x === y)\` which is allowed
   },
   function(x: string) {
     if (x == undefined) {
-    }
-    // ok
+    } // ok
     if (x == void 0) {
     } // ok
   },
@@ -390,8 +389,7 @@ let tests = [
   },
   function(x: { y: \"foo\" } | { y: \"bar\" }) {
     if (x.y == 123) {
-    }
-    // error
+    } // error
     if (x.y === 123) {
     } // ok
   }
@@ -487,8 +485,7 @@ function bar(x:Object) {
 /* @flow */
 
 function foo(x: { y?: () => void }) {
-  x.y();
-  // error: could be undefined
+  x.y(); // error: could be undefined
   if (x.hasOwnProperty(\"y\")) {
     x.y(); // error: still could be undefined
   }
@@ -498,8 +495,7 @@ function foo(x: { y?: () => void }) {
 }
 
 function bar(x: Object) {
-  x.y();
-  // treated as \`any\`, so allowed
+  x.y(); // treated as \`any\`, so allowed
   if (x.hasOwnProperty(\"y\")) {
     x.y(); // still treated as \`any\`, so allowed
   }
@@ -603,33 +599,26 @@ type Obj = { p: number | string };
 function f() {}
 
 function def_assign_function_havoc(obj: Obj) {
-  obj.p = 10;
-  // (obj.p : number)
-  f();
-  // clears refi
+  obj.p = 10; // (obj.p : number)
+  f(); // clears refi
   var x: number = obj.p; // error, obj.p : number | string
 }
 
 function def_assign_setprop_havoc(obj: Obj, obj2: Obj) {
-  obj.p = 10;
-  // (obj.p : number)
-  obj2.p = \"hey\";
-  // clears refi
+  obj.p = 10; // (obj.p : number)
+  obj2.p = \"hey\"; // clears refi
   var x: number = obj.p; // error, obj.p : number | string
 }
 
 function def_assign_index_havoc(obj: Obj, obj2: Obj) {
-  obj.p = 10;
-  // (obj.p : number)
-  obj2[\"p\"] = \"hey\";
-  // clears refi
+  obj.p = 10; // (obj.p : number)
+  obj2[\"p\"] = \"hey\"; // clears refi
   var x: number = obj.p; // error, obj.p : number | string
 }
 
 function def_assign_within_if(b: boolean, obj: Obj) {
   if (b) {
-    obj.p = 10;
-    // (obj.p : number)
+    obj.p = 10; // (obj.p : number)
     var x: number = obj.p; // ok by def assign
   }
   var y: number = obj.p; // error, obj.p : number | string
@@ -637,8 +626,7 @@ function def_assign_within_if(b: boolean, obj: Obj) {
 
 function def_assign_within_while(b: boolean, obj: Obj) {
   while (b) {
-    obj.p = 10;
-    // (obj.p : number)
+    obj.p = 10; // (obj.p : number)
     var x: number = obj.p; // ok by def assign
   }
   var y: number = obj.p; // error, obj.p : number | string
@@ -646,31 +634,26 @@ function def_assign_within_while(b: boolean, obj: Obj) {
 
 function def_assign_within_do(b: boolean, obj: Obj) {
   do {
-    obj.p = 10;
-    // (obj.p : number)
+    obj.p = 10; // (obj.p : number)
     var x: number = obj.p; // ok by def assign
   } while (b);
   var y: number = obj.p; // no error, loop runs at least once
 }
 
 function def_assign_within_try(b: boolean, obj: Obj) {
-  obj.p = 10;
-  // (obj.p : number)
+  obj.p = 10; // (obj.p : number)
   try {
-    f();
-    // clears refi and might throw
+    f(); // clears refi and might throw
     obj.p = \"hey\";
   } catch (e) {
-    f();
-    // clears refi and might throw
+    f(); // clears refi and might throw
     obj.p = \"hey\";
   } finally {
     // NOTE: the values understood to flow to obj.p at this point
     // include the number 42 written downstream;
     // so if we did y:string, we would get at least a spurious error
     // (among other reasonable errors caused by values written upstream)
-    var y: number = obj.p;
-    // error, string ~/~ number
+    var y: number = obj.p; // error, string ~/~ number
     obj.p = 42;
   }
   var z: string = obj.p; // error, number ~/~ string
@@ -678,8 +661,7 @@ function def_assign_within_try(b: boolean, obj: Obj) {
 
 function def_assign_within_for(b: boolean, obj: Obj) {
   for (; b; ) {
-    obj.p = 10;
-    // (obj.p : number)
+    obj.p = 10; // (obj.p : number)
     var x: number = obj.p; // ok by def assign
   }
   var z: number = obj.p; // error, (number | string) ~/~ number
@@ -689,10 +671,8 @@ function def_assign_within_for(b: boolean, obj: Obj) {
 type Obj2 = { q: number | string };
 
 function def_assign_setprop_nohavoc(obj: Obj, obj2: Obj2) {
-  obj.p = 10;
-  // (obj.p : number)
-  obj2.q = \"hey\";
-  // doesn\'t clear refi of .p
+  obj.p = 10; // (obj.p : number)
+  obj2.q = \"hey\"; // doesn\'t clear refi of .p
   var x: number = obj.p; // still ok
 }
 "
@@ -764,15 +744,17 @@ function foo8(o: { p: mixed }) {
 // @flow
 
 function foo1(o: { x: number }) {
-  if (o.p1) {
-    // OK, this is an idiomatic way of testing property existence
+  if (
+    o.p1 // OK, this is an idiomatic way of testing property existence
+  ) {
     o.x;
   }
 }
 
 function foo2(o: { x: number }) {
-  if (o.p2) {
-    // OK
+  if (
+    o.p2 // OK
+  ) {
     o.p2.x; // error, since o.p2\'s type is unknown (e.g., could be \`number\`)
   }
 }
@@ -782,8 +764,9 @@ function foo3(o: { x: number }) {
 }
 
 function foo4(o: $Exact<{ x: number }>) {
-  if (o.p4) {
-    // OK
+  if (
+    o.p4 // OK
+  ) {
     o.p4.x; // currently OK, should be unreachable
   } else {
     o.p4.x; // error
@@ -808,22 +791,18 @@ function foo6(o: mixed) {
 
 function foo7(o: mixed) {
   if (typeof o.bar === \"string\") {
-  }
-  // error
+  } // error
   if (o && typeof o.bar === \"string\") {
-  }
-  // ok
+  } // ok
   if (o != null && typeof o.bar === \"string\") {
-  }
-  // ok
+  } // ok
   if (o !== null && o !== undefined && typeof o.bar === \"string\") {
   } // ok
 }
 
 function foo8(o: { p: mixed }) {
   if (o.p && o.p.q) {
-  }
-  // this is ok because o.p is truthy, so o.p.q is safe
+  } // this is ok because o.p is truthy, so o.p.q is safe
   if (o.p && o.p.q && o.p.q.r) {
   }
 }
@@ -960,8 +939,7 @@ function takesString(x: string) {}
 
 function num(x: mixed) {
   if (typeof x === \"number\") {
-    takesString(x);
-    // error
+    takesString(x); // error
     (!x: false); // error: we don\'t know the truthiness of x
   }
   if (typeof x === \"number\" && x) {
@@ -974,8 +952,7 @@ function num(x: mixed) {
 
 function str(x: mixed) {
   if (typeof x === \"string\") {
-    takesNumber(x);
-    // error
+    takesNumber(x); // error
     (!x: false); // error: we don\'t know the truthiness of x
   }
   if (typeof x === \"string\" && x) {
@@ -988,8 +965,7 @@ function str(x: mixed) {
 
 function bool(x: mixed) {
   if (typeof x === \"boolean\") {
-    takesString(x);
-    // error
+    takesString(x); // error
     (x: true); // error: we don\'t know the truthiness of x
   }
   if (typeof x === \"boolean\" && x) {
@@ -1409,11 +1385,15 @@ let tests = [
     }
   },
   function(num: number, obj: { foo: number }) {
-    if (num === obj.bar) { // ok, typos allowed in conditionals
+    if (
+      num === obj.bar // ok, typos allowed in conditionals
+    ) {
     }
   },
   function(num: number, obj: { [key: string]: number }) {
-    if (num === obj.bar) { // ok
+    if (
+      num === obj.bar // ok
+    ) {
     }
   },
   function(n: number): Mode {
@@ -1988,11 +1968,15 @@ let tests = [
     }
   },
   function(str: string, obj: { foo: string }) {
-    if (str === obj.bar) { // ok, typos allowed in conditionals
+    if (
+      str === obj.bar // ok, typos allowed in conditionals
+    ) {
     }
   },
   function(str: string, obj: { [key: string]: string }) {
-    if (str === obj.bar) { // ok
+    if (
+      str === obj.bar // ok
+    ) {
     }
   },
   function(str: string): Mode {
@@ -2081,8 +2065,9 @@ class A {
 
 class B {
   test(): string {
-    if (super.prop) {
-      // super.prop doesn\'t exist
+    if (
+      super.prop // super.prop doesn\'t exist
+    ) {
       return super.prop; // error, unknown type passed to string expected
     }
     return \"B\";
@@ -2163,9 +2148,8 @@ function foo(text: string | number): string {
   switch (typeof text) {
     case \"string\":
       return text;
-    // error, should return string
     case \"number\":
-      return text;
+      return text; // error, should return string
     default:
       return \"wat\";
   }
@@ -2181,9 +2165,9 @@ function bar(text: string | number): string {
 function baz1(text: string | number): string {
   switch (typeof text) {
     case \"number\":
-    // error, [0] on number
     case \"string\":
       return text[0];
+    // error, [0] on number
     default:
       return \"wat\";
   }
@@ -2191,9 +2175,8 @@ function baz1(text: string | number): string {
 function baz2(text: string | number): string {
   switch (typeof text) {
     case \"string\":
-    // error, [0] on number
     case \"number\":
-      return text[0];
+      return text[0]; // error, [0] on number
     default:
       return \"wat\";
   }
@@ -2203,9 +2186,7 @@ function corge(text: string | number | Array<string>): string {
     case \"object\":
       return text[0];
     case \"string\":
-    case // using ++ since it isn\'t valid on arrays or strings.
-    // should only error for string since Array was filtered out.
-    \"number\":
+    case \"number\": // using ++ since it isn\'t valid on arrays or strings. // should only error for string since Array was filtered out.
       return text++ + \"\";
     default:
       return \"wat\";
@@ -2464,8 +2445,7 @@ function getTypeASTName(typeAST: Type): string {
 
 // example 2
 import type { ASTNode } from \"./ast_node\";
-var Node = require(\"./node1\");
-// Node = \"Node1\"
+var Node = require(\"./node1\"); // Node = \"Node1\"
 function foo(x: ASTNode) {
   if (x.kind === Node) {
     return x.prop1.charAt(0); // typeAST: Node1, but x.prop1 may be undefined
@@ -2484,7 +2464,7 @@ type Breakfast = Apple | Orange | Broccoli | Carrot;
 function bar(x: Breakfast) {
   if (x.kind === \"Fruit\") {
     (x.taste: \"Good\");
-  } // error, Apple.taste = Bad else
+  } else // error, Apple.taste = Bad
     (x.raw: \"No\"); // error, Carrot.raw = Maybe
 }
 
@@ -2525,9 +2505,8 @@ function kind(x: A | B | C): number {
       return x.A;
     case EnumKind.B:
       return x.B;
-    // error, x: C and property A not found in type C
     default:
-      return x.A;
+      return x.A; // error, x: C and property A not found in type C
   }
 }
 kind({ kind: EnumKind.A, A: 1 });
@@ -2543,8 +2522,9 @@ function nationality(x: Citizen | NonCitizen) {
 let tests = [
   // non-existent props
   function test7(x: A) {
-    if (x.kindTypo === 1) {
-      // typos are allowed to be tested
+    if (
+      x.kindTypo === 1 // typos are allowed to be tested
+    ) {
       (x.kindTypo: string); // typos can\'t be used, though
     }
   },
@@ -2558,8 +2538,7 @@ let tests = [
   // invalid RHS
   function(x: A) {
     if (x.kind === null.toString()) {
-    }
-    // error, method on null
+    } // error, method on null
     if (({ kind: 1 }).kind === null.toString()) {
     } // error, method on null
   },
@@ -2575,50 +2554,53 @@ let tests = [
   ) {
     if (x.length === 0) {
     }
-    if (x.legnth === 0) {
-      // typos are allowed to be tested
-      (x.legnth: number);
-      // inside the block, it\'s a number
+    if (
+      x.legnth === 0 // typos are allowed to be tested
+    ) {
+      (x.legnth: number); // inside the block, it\'s a number
       (x.legnth: string); // error: number literal 0 !~> string
     }
     if (y.length === 0) {
     }
-    if (y.legnth === 0) {
-      // typos are allowed to be tested
-      (y.legnth: number);
-      // inside the block, it\'s a number
+    if (
+      y.legnth === 0 // typos are allowed to be tested
+    ) {
+      (y.legnth: number); // inside the block, it\'s a number
       (y.legnth: string); // error: number literal 0 !~> string
     }
     if (z.toString === 0) {
     }
-    if (z.toStirng === 0) {
-      // typos are allowed to be tested
-      (z.toStirng: number);
-      // inside the block, it\'s a number
+    if (
+      z.toStirng === 0 // typos are allowed to be tested
+    ) {
+      (z.toStirng: number); // inside the block, it\'s a number
       (z.toStirng: string); // error: number literal 0 !~> string
     }
     if (q.valueOf === 0) {
     }
-    if (q.valeuOf === 0) {
-      // typos are allowed to be tested
-      (q.valeuOf: number);
-      // inside the block, it\'s a number
+    if (
+      q.valeuOf === 0 // typos are allowed to be tested
+    ) {
+      (q.valeuOf: number); // inside the block, it\'s a number
       (q.valeuOf: string); // error: number literal 0 !~> string
     }
-    if (r.toStirng === 0) {
-      // typos are allowed to be tested
+    if (
+      r.toStirng === 0 // typos are allowed to be tested
+    ) {
       (r.toStirng: empty); // props on AnyObjT are \`any\`
     }
     if (s.call === 0) {
     }
-    if (s.calll === 0) {
-      // typos are allowed to be tested
+    if (
+      s.calll === 0 // typos are allowed to be tested
+    ) {
       (t.calll: empty); // ok, props on functions are \`any\` :/
     }
     if (t.call === 0) {
     }
-    if (t.calll === 0) {
-      // typos are allowed to be tested
+    if (
+      t.calll === 0 // typos are allowed to be tested
+    ) {
       (t.calll: empty); // ok, props on functions are \`any\` :/
     }
   },
@@ -2664,12 +2646,10 @@ let tests = [
   // type mismatch, but one is not a literal
   function(x: { foo: number, y: string } | { foo: \"foo\", z: string }) {
     if (x.foo === 123) {
-      (x.y: string);
-      // ok, because 123 !== \'foo\'
+      (x.y: string); // ok, because 123 !== \'foo\'
       x.z; // error
     } else {
-      x.y;
-      // error: x.foo could be a string
+      x.y; // error: x.foo could be a string
       x.z; // error: could still be either case (if foo was a different number)
     }
 
@@ -2684,12 +2664,10 @@ let tests = [
   // type mismatch, neither is a literal
   function(x: { foo: number, y: string } | { foo: string, z: string }) {
     if (x.foo === 123) {
-      (x.y: string);
-      // ok, because 123 !== string
+      (x.y: string); // ok, because 123 !== string
       x.z; // error
     } else {
-      x.y;
-      // error: x.foo could be a string
+      x.y; // error: x.foo could be a string
       x.z; // error: could still be either case (if foo was a different number)
     }
 
@@ -2697,8 +2675,7 @@ let tests = [
       (x.z: string);
       x.y; // error
     } else {
-      x.y;
-      // error: x.foo could be a different string
+      x.y; // error: x.foo could be a different string
       x.z; // error: x.foo could be a number
     }
   },
@@ -2708,8 +2685,7 @@ let tests = [
     num: number
   ) {
     if (x.foo === num) {
-      x.y;
-      // error: flow isn\'t smart enough to figure this out yet
+      x.y; // error: flow isn\'t smart enough to figure this out yet
       x.z; // error
     }
   }
@@ -2852,11 +2828,9 @@ function fn0() {
   BAZ.stuff(123); // error, refinement is gone
 }
 function fn1() {
-  BAZ.stuff;
-  // error, could be undefined
+  BAZ.stuff; // error, could be undefined
   if (typeof BAZ !== \"undefined\" && typeof BAZ.stuff === \"function\") {
-    BAZ.stuff(123);
-    // ok
+    BAZ.stuff(123); // ok
     BAZ.stuff(123); // error, refinement is gone
   }
 }
@@ -2876,8 +2850,9 @@ function anyobj(x: number | Object): number {
 }
 
 function testInvalidValue(x: mixed) {
-  if (typeof x === \"foo\") {
-    // error
+  if (
+    typeof x === \"foo\" // error
+  ) {
     return 0;
   }
 }
@@ -2889,8 +2864,9 @@ function testTemplateLiteral(x: string | number) {
 }
 
 function testInvalidTemplateLiteral(x: string | number) {
-  if (typeof x === \`foo\`) {
-    // error
+  if (
+    typeof x === \`foo\` // error
+  ) {
     return 0;
   }
 }

--- a/tests/flow/require/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/require/__snapshots__/jsfmt.spec.js.snap
@@ -153,19 +153,13 @@ require(\"./D\");
 // E exports an object with a numVal property
 var E = require(\"./E\");
 var e_1: number = E.numberValue;
-E.stringValue;
-
-// Error: The E exports obj has no \'stringValue\' property
+E.stringValue; // Error: The E exports obj has no \'stringValue\' property
 // We require that the param passed to require() be a string literal to support
 // guaranteed static extraction
 var a = \"./E\";
-require(a);
-// Error: Param must be string literal
-require(\`./E\`);
-// template literals are ok...
-require(\`\${\"./E\"}\`);
-
-// error: but only if they have no expressions
+require(a); // Error: Param must be string literal
+require(\`./E\`); // template literals are ok...
+require(\`\${\"./E\"}\`); // error: but only if they have no expressions
 // require.call is allowed but circumverts Flow\'s static analysis
 require.call(null, \"DoesNotExist\");
 "

--- a/tests/flow/requireLazy/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/requireLazy/__snapshots__/jsfmt.spec.js.snap
@@ -69,25 +69,19 @@ requireLazy([\'A\']); // Error: No calback expression
 requireLazy([\"A\", \"B\"], function(A, B) {
   var num1: number = A.numberValueA;
   var str1: string = A.stringValueA;
-  var num2: number = A.stringValueA;
-  // Error: string ~> number
-  var str2: string = A.numberValueA;
-
-  // Error: number ~> string
+  var num2: number = A.stringValueA; // Error: string ~> number
+  var str2: string = A.numberValueA; // Error: number ~> string
   var num3: number = B.numberValueB;
   var str3: string = B.stringValueB;
-  var num4: number = B.stringValueB;
-  // Error: string ~> number
+  var num4: number = B.stringValueB; // Error: string ~> number
   var str4: string = B.numberValueB; // Error: number ~> string
 });
 
 var notA: Object = A;
 var notB: Object = B;
 
-requireLazy();
-// Error: No args
-requireLazy([nope], function() {});
-// Error: Non-stringliteral args
+requireLazy(); // Error: No args
+requireLazy([nope], function() {}); // Error: Non-stringliteral args
 requireLazy([\"A\"]); // Error: No calback expression
 "
 `;

--- a/tests/flow/return_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/return_new/__snapshots__/jsfmt.spec.js.snap
@@ -15,19 +15,13 @@ var a: A = new B(); // OK (returns new A)
 function Foo() {
   return {};
 }
-var foo: number = new Foo();
-
-// error (returns object literal above)
+var foo: number = new Foo(); // error (returns object literal above)
 function Bar() {
   return 0;
 }
-var bar: number = new Bar();
-
-// error (returns new object)
+var bar: number = new Bar(); // error (returns new object)
 function Qux() {}
-var qux: number = new Qux();
-
-// error (returns new object)
+var qux: number = new Qux(); // error (returns new object)
 class A {}
 function B() {
   return new A();
@@ -50,18 +44,13 @@ d.x = \"\"; // error, string ~/~ number (but property x is found)
 module.exports = D;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class D {
-  constructor(): { x: number },
-  // OK
+  constructor(): { x: number }, // OK
   y: any
 }
 
 var d = new D();
-d.x = \"\";
-
-// error, string ~/~ number (but property x is found)
-(new D(): D);
-
-// error, new D is an object, D not in proto chain
+d.x = \"\"; // error, string ~/~ number (but property x is found)
+(new D(): D); // error, new D is an object, D not in proto chain
 module.exports = D;
 "
 `;

--- a/tests/flow/sealed/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/sealed/__snapshots__/jsfmt.spec.js.snap
@@ -58,9 +58,7 @@ Foo.prototype = {
   }
 };
 
-var export_o: { x: any } = o;
-
-// awkward type cast
+var export_o: { x: any } = o; // awkward type cast
 module.exports = export_o;
 "
 `;
@@ -86,8 +84,7 @@ var x: string = o.x;
 var Bar = require(\"./function\");
 var a = new Bar(234);
 a.x = 123;
-a.y = \"abc\";
-// error, needs to be declared in Bar\'s constructor
+a.y = \"abc\"; // error, needs to be declared in Bar\'s constructor
 (a.getX(): number);
 (a.getY(): string);
 "

--- a/tests/flow/sealed_objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/sealed_objects/__snapshots__/jsfmt.spec.js.snap
@@ -20,29 +20,17 @@ var s6: string = o6.y; // ok  (indexers make object types extensible)
 var o7: { x: number; y?: string; } = ({ x: 0, y: 0 }: { x: number; [_:any]:number}); // error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var o1 = { x: 0 };
-var s1: string = o1.y;
-
-// error
+var s1: string = o1.y; // error
 var o2: { x: number, y?: string } = { x: 0 };
-var s2: string = o2.y || \"\";
-
-// ok
+var s2: string = o2.y || \"\"; // ok
 var o3: { x: number, y?: string } = ({ x: 0, y: 0 }: { x: number });
-var s3: string = o3.y || \"\";
-
-// error
+var s3: string = o3.y || \"\"; // error
 var o4: { x: number, y?: string } = ({ x: 0 }: { [_: any]: any, x: number });
-var s4: string = o4.y || \"\";
-
-// ok
+var s4: string = o4.y || \"\"; // ok
 var o5 = { x: 0, ...{} };
-var s5: string = o5.y;
-
-// ok (spreads make object types extensible)
+var s5: string = o5.y; // ok (spreads make object types extensible)
 var o6: { [_: any]: any, x: number } = { x: 0 };
-var s6: string = o6.y;
-
-// ok  (indexers make object types extensible)
+var s6: string = o6.y; // ok  (indexers make object types extensible)
 var o7: { x: number, y?: string } = ({ x: 0, y: 0 }: {
   [_: any]: number,
   x: number

--- a/tests/flow/singleton/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/singleton/__snapshots__/jsfmt.spec.js.snap
@@ -44,17 +44,13 @@ function veryOptimistic(isThisAwesome: true): boolean {
 }
 
 var x: boolean = veryOptimistic(true);
-var y: boolean = veryOptimistic(false);
-
-// error
+var y: boolean = veryOptimistic(false); // error
 function veryPessimistic(isThisAwesome: true): boolean {
   return !isThisAwesome; // test bool conversion
 }
 
 var x: boolean = veryPessimistic(true);
-var y: boolean = veryPessimistic(false);
-
-// error
+var y: boolean = veryPessimistic(false); // error
 type MyOwnBooleanLOL = true | false;
 
 function bar(x: MyOwnBooleanLOL): false {
@@ -67,9 +63,7 @@ function bar(x: MyOwnBooleanLOL): false {
 
 bar(true);
 bar(false);
-bar(1);
-
-// error
+bar(1); // error
 function alwaysFalsy(x: boolean): false {
   if (x) {
     return !x;
@@ -112,9 +106,7 @@ function highlander(howMany: 1): number {
 }
 
 highlander(1);
-highlander(2);
-
-// error
+highlander(2); // error
 type Foo = 1 | 2;
 
 function bar(num: Foo): number {
@@ -123,9 +115,7 @@ function bar(num: Foo): number {
 
 bar(1);
 bar(2);
-bar(3);
-
-// error
+bar(3); // error
 type ComparatorResult = -1 | 0 | 1;
 function sort(fn: (x: any, y: any) => ComparatorResult) {}
 sort((x, y) => -1);

--- a/tests/flow/spread/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/spread/__snapshots__/jsfmt.spec.js.snap
@@ -169,8 +169,7 @@ function test(
   kinds: { [key: string]: string }
 ): Array<{ kind: ?string }> {
   return map(kinds, value => {
-    (value: string);
-    // OK
+    (value: string); // OK
     return { ...x, kind: value };
   });
 }
@@ -204,8 +203,7 @@ o = { ...o };
 (o: { foo: string });
 
 var p = { foo: \"bar\" };
-(p: { foo: string, abc: string });
-// error, p doesn\'t have \`abc\` yet
+(p: { foo: string, abc: string }); // error, p doesn\'t have \`abc\` yet
 p = { ...p, abc: \"def\" };
 (p: { foo: string, abc: string });
 

--- a/tests/flow/structural_subtyping/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/structural_subtyping/__snapshots__/jsfmt.spec.js.snap
@@ -20,8 +20,7 @@ interface IHasLength { length: number }
 
 var lengthTest1: IHasLength = [];
 var lengthTest2: IHasLength = \"hello\";
-var lengthTest3: IHasLength = 123;
-// number doesn\'t have length
+var lengthTest3: IHasLength = 123; // number doesn\'t have length
 var lengthTest4: IHasLength = true; // bool doesn\'t have length
 "
 `;
@@ -66,8 +65,7 @@ interface IHasXNumber { x: number }
 interface IHasYString { y: string }
 
 var testInstance1: IHasXString = new ClassWithXString();
-var testInstance2: IHasXNumber = new ClassWithXString();
-// Error wrong type
+var testInstance2: IHasXNumber = new ClassWithXString(); // Error wrong type
 var testInstance3: IHasYString = new ClassWithXString(); // Error missing prop
 "
 `;
@@ -101,10 +99,8 @@ function propTest6(y: {[key: string]: number}) {
 interface IHasXString { x: string }
 
 var propTest1: IHasXString = { x: \"hello\" };
-var propTest2: IHasXString = { x: 123 };
-// Error string != number
-var propTest3: IHasXString = {};
-// Property not found
+var propTest2: IHasXString = { x: 123 }; // Error string != number
+var propTest3: IHasXString = {}; // Property not found
 var propTest4: IHasXString = ({}: Object);
 
 function propTest5(y: { [key: string]: string }) {
@@ -137,9 +133,7 @@ interface HasOptional { a: string, b?: number }
 
 var test1: HasOptional = { a: \"hello\" };
 
-var test2: HasOptional = {};
-
-// Error: missing property a
+var test2: HasOptional = {}; // Error: missing property a
 var test3: HasOptional = { a: \"hello\", b: true }; // Error: boolean ~> number
 "
 `;

--- a/tests/flow/super/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/super/__snapshots__/jsfmt.spec.js.snap
@@ -170,8 +170,7 @@ class C extends A {}
 class D extends A {
   y: number;
   constructor() {
-    this.y;
-    // error (no super call)
+    this.y; // error (no super call)
     this.x; // error (no super call)
   }
 }
@@ -180,22 +179,19 @@ class E extends A {
   y: number;
   constructor() {
     super();
-    this.y;
-    // OK
+    this.y; // OK
     this.x; // OK
   }
 }
 
 function leak(f) {
-  f.y;
-  // error
+  f.y; // error
   f.x; // error
 }
 class F extends A {
   y: number;
   constructor() {
-    leak(this);
-    // error (no super call yet)
+    leak(this); // error (no super call yet)
     super();
     this.y;
     this.x;
@@ -213,8 +209,7 @@ class H extends A {
   constructor() {
     if (Math.random() < 0.5) super();
     else super();
-    this.y;
-    // OK
+    this.y; // OK
     this.x; // OK
   }
 }
@@ -261,8 +256,7 @@ class K extends K_ {
   constructor() {
     super(() => {
       if (_this) _this.foo();
-    });
-    // OK
+    }); // OK
     var _this = this;
     this.closure_leaking_this();
   }
@@ -372,8 +366,7 @@ class B extends A {
   }
 
   static anotherStatic() {
-    (super.staticMethod(\"foo\"): number);
-    // error, string !~> number
+    (super.staticMethod(\"foo\"): number); // error, string !~> number
     super.doesntExist(); // error, A doesn\'t have a doesntExist method
   }
 

--- a/tests/flow/suppress/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/suppress/__snapshots__/jsfmt.spec.js.snap
@@ -25,29 +25,19 @@ var test5: string = 123; // This error should be suppressed
 var test6: string = 123;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // $FlowFixMe
-var test1: string = 123;
-
-// This error should be suppressed
+var test1: string = 123; // This error should be suppressed
 // $FlowIssue
-var test2: string = 123;
-
-// This error should be suppressed
+var test2: string = 123; // This error should be suppressed
 function getNum() {
   return 123;
 }
 
 // $FlowFixMe This was the second loc in the error
-var test3: string = getNum();
-
-// This error should be suppressed
+var test3: string = getNum(); // This error should be suppressed
 // $FlowFixMe Error unused suppression
-var test4: string = 123;
-
-// This error is NOT suppressed
+var test4: string = 123; // This error is NOT suppressed
 // $FlowFixMe Indentation shouldn\'t matter
-var test5: string = 123;
-
-// This error should be suppressed
+var test5: string = 123; // This error should be suppressed
 /*
  * $FlowNewLine
  */

--- a/tests/flow/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/switch/__snapshots__/jsfmt.spec.js.snap
@@ -190,14 +190,10 @@ function foo(x: mixed): string {
   }
 
   // a is now string | number
-  (a: string);
-  // error, string | number ~/> string
-  (a: number);
-
-  // error, string | number ~/> number
+  (a: string); // error, string | number ~/> string
+  (a: number); // error, string | number ~/> number
   // b is now number
-  (b: number);
-  // ok
+  (b: number); // ok
   return b; // error, number ~/> string
 }
 
@@ -216,17 +212,11 @@ function baz(x: mixed): number {
   }
 
   // a is now string | number
-  (a: string);
-  // error, string | number ~/> string
-  (a: number);
-
-  // error, string | number ~/> number
+  (a: string); // error, string | number ~/> string
+  (a: number); // error, string | number ~/> number
   // b is now string | number
-  (b: string);
-  // error, string | number ~/> string
-  (b: number);
-
-  // error, string | number ~/> number
+  (b: string); // error, string | number ~/> string
+  (b: number); // error, string | number ~/> number
   return a + b; // error, string ~/> number
 }
 "
@@ -348,8 +338,8 @@ function f2(i) {
     default:
       x = 1;
       break;
-    // does not fall through default
     case 2:
+    // does not fall through default
   }
 
   var y: number = x; // error, number | uninitialized ~/> number

--- a/tests/flow/taint/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/taint/__snapshots__/jsfmt.spec.js.snap
@@ -98,8 +98,7 @@ let tests = [
   // setting a property
   function(x: $Tainted<string>, y: string) {
     let obj: Object = {};
-    obj.foo = x;
-    // error, taint ~> any
+    obj.foo = x; // error, taint ~> any
     obj[y] = x; // error, taint ~> any
   },
   // getting a property
@@ -110,9 +109,7 @@ let tests = [
   // calling a method
   function(x: $Tainted<string>) {
     let obj: Object = {};
-    obj.foo(x);
-
-    // error, taint ~> any
+    obj.foo(x); // error, taint ~> any
     let foo = obj.foo;
     foo(x); // error, taint ~> any
   }
@@ -266,8 +263,7 @@ class A {
 
 class A {
   f(x: $Tainted<FakeLocation>) {
-    fakeDocument.location = x;
-    // error
+    fakeDocument.location = x; // error
     doStuff(x); // ok
   }
   f1(x: $Tainted<FakeLocation>) {

--- a/tests/flow/template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/template/__snapshots__/jsfmt.spec.js.snap
@@ -33,45 +33,30 @@ let tests = [
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @flow */
 
-(\`foo\`: string);
-// ok
-(\`bar\`: \"bar\");
-// ok
-(\`baz\`: number);
-
-// error
-\`foo \${123} bar\`;
-// ok, number can be appended to string
-\`foo \${{ bar: 123 }} baz\`;
-
-// error, object can\'t be appended
+(\`foo\`: string); // ok
+(\`bar\`: \"bar\"); // ok
+(\`baz\`: number); // error
+\`foo \${123} bar\`; // ok, number can be appended to string
+\`foo \${{ bar: 123 }} baz\`; // error, object can\'t be appended
 let tests = [
   function(x: string) {
-    \`foo \${x}\`;
-    // ok
-    \`\${x} bar\`;
-    // ok
+    \`foo \${x}\`; // ok
+    \`\${x} bar\`; // ok
     \`foo \${\"bar\"} \${x}\`; // ok
   },
   function(x: number) {
-    \`foo \${x}\`;
-    // ok
-    \`\${x} bar\`;
-    // ok
+    \`foo \${x}\`; // ok
+    \`\${x} bar\`; // ok
     \`foo \${\"bar\"} \${x}\`; // ok
   },
   function(x: boolean) {
-    \`foo \${x}\`;
-    // error
-    \`\${x} bar\`;
-    // error
+    \`foo \${x}\`; // error
+    \`\${x} bar\`; // error
     \`foo \${\"bar\"} \${x}\`; // error
   },
   function(x: mixed) {
-    \`foo \${x}\`;
-    // error
-    \`\${x} bar\`;
-    // error
+    \`foo \${x}\`; // error
+    \`\${x} bar\`; // error
     \`foo \${\"bar\"} \${x}\`; // error
   }
 ];

--- a/tests/flow/this/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this/__snapshots__/jsfmt.spec.js.snap
@@ -71,27 +71,18 @@ F.prototype.m = function() {
 
 function foo(p: string) {}
 
-var o1 = new F();
-// sets o1.x to 0
+var o1 = new F(); // sets o1.x to 0
 o1.x = \"\";
-foo(o1.x);
-
-// ok by definite assignment
+foo(o1.x); // ok by definite assignment
 var o2 = new F();
 o1.y = 0;
 o2.y = \"\";
-foo(o2.y);
-
-// setting o1.y to 0 has no effect on o2.y
+foo(o2.y); // setting o1.y to 0 has no effect on o2.y
 var o3 = new F();
-o3.m();
-// sets o3.y to 0
+o3.m(); // sets o3.y to 0
 o3.y = \"\";
-foo(o3.y);
-// ok by definite assignment
-foo(o2.y);
-
-// setting o3.y to 0 has no effect on o2.y
+foo(o3.y); // ok by definite assignment
+foo(o2.y); // setting o3.y to 0 has no effect on o2.y
 /*
  * this bindings:
  */
@@ -100,25 +91,18 @@ function f1(): number {
   return this.x;
 }
 
-var f1_1 = f1.bind({ x: 0 })();
-// ok
-var f1_2: string = f1.bind({ x: 0 })();
-// error, number -> string
-var f1_3 = f1.bind({ x: \"\" })();
-// error, string -> number
+var f1_1 = f1.bind({ x: 0 })(); // ok
+var f1_2: string = f1.bind({ x: 0 })(); // error, number -> string
+var f1_3 = f1.bind({ x: \"\" })(); // error, string -> number
 // TODO make this error blame the call site, rather than the function body
-var f1_4 = f1();
-
-// error, (global object).x
+var f1_4 = f1(); // error, (global object).x
 /* arrow functions bind this at point of definition */
 /* top level arrow functions bind this to global object */
 var a1 = () => {
   return this.x;
 };
 
-var ax = a1();
-
-// error, (this:mixed).x
+var ax = a1(); // error, (this:mixed).x
 /* nested arrows bind enclosing this (which may itself rebind) */
 function f2(): number {
   var a2 = () => {
@@ -127,16 +111,11 @@ function f2(): number {
   return a2();
 }
 
-var f2_1 = f2.bind({ x: 0 })();
-// ok
-var f2_2: string = f2.bind({ x: 0 })();
-// error, number -> string
-var f2_3 = f2.bind({ x: \"\" })();
-// error, string -> number
+var f2_1 = f2.bind({ x: 0 })(); // ok
+var f2_2: string = f2.bind({ x: 0 })(); // error, number -> string
+var f2_3 = f2.bind({ x: \"\" })(); // error, string -> number
 // TODO make this error blame the call site, rather than the function body
-var f2_4 = f2();
-
-// error, (global object).x
+var f2_4 = f2(); // error, (global object).x
 (this: void);
 
 module.exports = true;
@@ -184,25 +163,18 @@ class C {
 }
 var c = new C();
 var f = c.foo();
-var i = f();
-// OK
-(i: C);
-
-// OK
+var i = f(); // OK
+(i: C); // OK
 class D extends C {}
 var d = new D();
 var g = d.foo();
-var j = g();
-// OK
-(j: D);
-
-// error, since return type of bar is C, not the type of \`this\`
+var j = g(); // OK
+(j: D); // error, since return type of bar is C, not the type of \`this\`
 class E {
   foo(x: number) {}
 }
 class F extends E {
-  foo() {
-    // OK to override with generalization
+  foo() { // OK to override with generalization
     (() => {
       super.foo(\"\"); // find super method, error due to incorrect arg
     })();

--- a/tests/flow/this_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this_type/__snapshots__/jsfmt.spec.js.snap
@@ -86,9 +86,7 @@ class D extends C {}
 
 var d = new D();
 (d: C).next = new C();
-(d.next: D);
-
-// sneaky
+(d.next: D); // sneaky
 class A {
   foo<X: this>(that: X) {} // error: can\'t hide contravariance using a bound
 }
@@ -242,24 +240,17 @@ class B1 extends A1 {
   } // error
 }
 
-(new B1().bar(): B1);
-
-// OK
+(new B1().bar(): B1); // OK
 class B3<X> extends A3<X> {
   foo(): B3<X> {
     return new B3();
   } // error
 }
 
-(new B3().bar(): B3<*>);
-// OK
-(new B3().qux(0): string);
-
-// error
-(new B3().bar(): A2<*>);
-// OK
-((new B3().bar(): B3<string>): A2<number>);
-// error
+(new B3().bar(): B3<*>); // OK
+(new B3().qux(0): string); // error
+(new B3().bar(): A2<*>); // OK
+((new B3().bar(): B3<string>): A2<number>); // error
 ((new B3(): A2<number>).qux(0): string); // error
 "
 `;
@@ -327,13 +318,11 @@ exports[`test self.js 1`] = `
 class A {
   foo() {
     return this;
-  }
-  // return of foo is not annotated to get around
+  } // return of foo is not annotated to get around
   // substituting this below
   bar(): this {
     return new A().foo();
-  }
-  // same as returning : A, so error
+  } // same as returning : A, so error
   qux(): this {
     return this.bar();
   } // OK (don\'t cascade errors)
@@ -363,8 +352,7 @@ class B extends A { } // inherits statics method too, with \`this\` bound to the
 // supporting \`this\` type in statics
 
 class A {
-  static make(): this {
-    // factory method, whose return type \`this\` (still)
+  static make(): this { // factory method, whose return type \`this\` (still)
     // describes instances of A or subclasses of A: the
     // meaning of the \`this\` type is not changed simply by
     // switching into a static context
@@ -372,15 +360,10 @@ class A {
     // the class, instead of instances of the class
   }
 }
-class B extends A {}
-
-// inherits statics method too, with \`this\` bound to the class
-(A.make(): A);
-// OK
-(B.make(): B);
-// OK
-(B.make(): A);
-// OK
+class B extends A {} // inherits statics method too, with \`this\` bound to the class
+(A.make(): A); // OK
+(B.make(): B); // OK
+(B.make(): A); // OK
 (A.make(): B); // error
 "
 `;
@@ -480,13 +463,10 @@ class Inherit extends Base {}
 class Override extends Base {
   foo() {
     return this;
-  }
-  // OK
+  } // OK
   qux() {
     return this;
-  }
-
-  // OK, too
+  } // OK, too
   bar() {
     return new Override();
   } // OK (cf. error below)
@@ -495,16 +475,13 @@ class Override extends Base {
 class InheritOverride extends Override {}
 
 (new Inherit().foo(): Base);
-(new Inherit().foo(): Inherit);
-// error (cf. OK below)
+(new Inherit().foo(): Inherit); // error (cf. OK below)
 ((new Inherit(): Base).foo(): Base);
 (new Override().foo(): Base);
-(new Override().foo(): Override);
-// OK
+(new Override().foo(): Override); // OK
 ((new Override(): Base).foo(): Base);
 
-(new InheritOverride().bar_caller(): InheritOverride);
-// error
+(new InheritOverride().bar_caller(): InheritOverride); // error
 // blame flips below
 // Examples with \`this\` types (compare with examples above)
 class Base2 {
@@ -531,20 +508,15 @@ class Inherit2 extends Base2 {}
 class Override2 extends Base2 {
   foo(): this {
     return this;
-  }
-  // OK
+  } // OK
   qux(): this {
     return this;
-  }
-
-  // OK, too
+  } // OK, too
   bar(): Override2 {
     return new Override2();
-  }
-  // error (cf. OK above)
+  } // error (cf. OK above)
   // see exploit below
-  corge(that: this) {}
-  // error
+  corge(that: this) {} // error
   // see exploit below
   grault(that: this) {} // error, too
 }
@@ -552,17 +524,13 @@ class Override2 extends Base2 {
 class InheritOverride2 extends Override2 {}
 
 (new Inherit2().foo(): Base2);
-(new Inherit2().foo(): Inherit2);
-// OK (cf. error above)
+(new Inherit2().foo(): Inherit2); // OK (cf. error above)
 ((new Inherit2(): Base2).foo(): Base2);
 (new Override2().foo(): Base2);
-(new Override2().foo(): Override2);
-// OK
+(new Override2().foo(): Override2); // OK
 ((new Override2(): Base2).foo(): Base2);
 
-(new InheritOverride2().bar_caller(): InheritOverride2);
-
-// exploits error above
+(new InheritOverride2().bar_caller(): InheritOverride2); // exploits error above
 (new Override2(): Base2).corge(new Base2()); // exploits error above
 "
 `;

--- a/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
@@ -35,10 +35,8 @@ declare class Baz<T> {
   x: T
 }
 
-(new Foo().x: number);
-// error: Qux wins
-(new Foo().y: string);
-// error: Bar wins
+(new Foo().x: number); // error: Qux wins
+(new Foo().y: string); // error: Bar wins
 (new Foo().z: number); // error: Qux wins
 "
 `;

--- a/tests/flow/try/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/try/__snapshots__/jsfmt.spec.js.snap
@@ -263,8 +263,7 @@ function f() {
   try {
     var x: number = 0;
   } catch (e) {
-    might_throw();
-    // ...but if so, suffix is not reached
+    might_throw(); // ...but if so, suffix is not reached
     var x: number = 0;
   }
   var y: number = x;
@@ -275,8 +274,7 @@ function f() {
   try {
   } catch (e) {
   } finally {
-    might_throw();
-    // ...but if so, suffix is not reached
+    might_throw(); // ...but if so, suffix is not reached
     var x: number = 0;
   }
   var y: number = x;
@@ -288,8 +286,7 @@ function f() {
     var x: number;
   } catch (e) {
   } finally {
-    might_throw();
-    // ...but if so, suffix is not reached
+    might_throw(); // ...but if so, suffix is not reached
     x = 0;
   }
   var y: number = x;
@@ -301,8 +298,7 @@ function f() {
   } catch (e) {
     var x: number;
   } finally {
-    might_throw();
-    // ...but if so, suffix is not reached
+    might_throw(); // ...but if so, suffix is not reached
     x = 0;
   }
   var y: number = x;
@@ -310,8 +306,7 @@ function f() {
 
 // error if used prior to init
 function f() {
-  var y: number = x;
-  // error
+  var y: number = x; // error
   try {
     var x: number = 0;
   } catch (e) {
@@ -547,8 +542,7 @@ function foo() {
     y = {};
   }
   // here via [try; finally] only.
-  x();
-  // string ~/> function call (no num or bool error)
+  x(); // string ~/> function call (no num or bool error)
   y(); // object ~/> function call (no uninitialized error)
 }
 
@@ -560,7 +554,9 @@ function bar(response) {
     throw new Error(\"...\");
   }
   // here via [try] only.
-  if (payload.error) { // ok
+  if (
+    payload.error // ok
+  ) {
     // ...
   }
 }

--- a/tests/flow/tuples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/tuples/__snapshots__/jsfmt.spec.js.snap
@@ -31,11 +31,8 @@ exports[`test optional.js 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // @flow
 
-([0, undefined]: [number, ?string]);
-// Ok, correct arity
-([0]: [number, ?string]);
-
-// Error, arity is enforced
+([0, undefined]: [number, ?string]); // Ok, correct arity
+([0]: [number, ?string]); // Error, arity is enforced
 ([]: [?number, string]); // error, since second element is not marked optional
 "
 `;
@@ -64,10 +61,8 @@ var e: [number, string,] = [123,\'duck\'];
 var f: [number, string] = [123, 456];
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var a: [] = [];
-var b: [] = [123];
-// Error - arity mismatch
-var c: [number] = [];
-// nope
+var b: [] = [123]; // Error - arity mismatch
+var c: [number] = []; // nope
 var d: [number, string] = [123, \"duck\"];
 var e: [number, string] = [123, \"duck\"];
 var f: [number, string] = [123, 456];

--- a/tests/flow/type-at-pos/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type-at-pos/__snapshots__/jsfmt.spec.js.snap
@@ -117,8 +117,7 @@ var on: O<number> = { x: 0 };
 on;
 
 type Mono = C<void>;
-var mn: Mono<number> = new C();
-// error: application of non-poly type
+var mn: Mono<number> = new C(); // error: application of non-poly type
 mn;
 "
 `;

--- a/tests/flow/type-destructors/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type-destructors/__snapshots__/jsfmt.spec.js.snap
@@ -22,10 +22,8 @@ function foo(x: ?string): $NonMaybeType<?string> {
 }
 
 //(foo(): string); // should not be necessary to expose the error above
-(0: $NonMaybeType<null>);
-// error
-(0: $NonMaybeType<?number>);
-// ok
+(0: $NonMaybeType<null>); // error
+(0: $NonMaybeType<?number>); // ok
 (0: $NonMaybeType<number | null>); // ok
 "
 `;
@@ -65,12 +63,8 @@ var x3: $PropertyType<{p:number}|{p:string},\'p\'> = true; // err, boolean ~> nu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var x0: $NonMaybeType<number | string> = 0;
 // ok, number ~> number|string
-var x1: $NonMaybeType<number | string> = true;
-// err, boolean ~> number|string
-var x2: $PropertyType<{ p: number } | { p: string }, \"p\"> = 0;
-// ok, number ~> number|string
-var x3: $PropertyType<
-  | { p: number }
-  | { p: string }, \"p\"> = true; // err, boolean ~> number|string
+var x1: $NonMaybeType<number | string> = true; // err, boolean ~> number|string
+var x2: $PropertyType<{ p: number } | { p: string }, \"p\"> = 0; // ok, number ~> number|string
+var x3: $PropertyType<{ p: number } | { p: string }, \"p\"> = true; // err, boolean ~> number|string
 "
 `;

--- a/tests/flow/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
@@ -93,9 +93,7 @@ class MyClass<T> {
   }
 }
 
-var c: MyClass = new MyClass(0);
-
-// no error
+var c: MyClass = new MyClass(0); // no error
 // no arity error in type annotation using polymorphic class with defaulting
 class MyClass2<T, U=string> {
   x: T;
@@ -106,30 +104,21 @@ class MyClass2<T, U=string> {
   }
 }
 
-var c2: MyClass2 = new MyClass2(0, \"\");
-
-// no error
+var c2: MyClass2 = new MyClass2(0, \"\"); // no error
 // no arity error in type annotation using polymorphic type alias
 type MyObject<T> = { x: T };
 
-var o: MyObject = { x: 0 };
-
-// no error
+var o: MyObject = { x: 0 }; // no error
 // arity error in type alias rhs
-type MySubobject = { y: number } & MyObject;
-
-// no error
+type MySubobject = { y: number } & MyObject; // no error
 // arity error in interface extends
 interface MyInterface<T> { x: T }
 
-interface MySubinterface extends MyInterface {
-  // no error
-  y: number
-}
+interface MySubinterface extends MyInterface { y: number } // no error
 
 // no arity error in extends of polymorphic class
-class MySubclass extends MyClass {
-  // ok, type arg inferred
+class MySubclass
+  extends MyClass { // ok, type arg inferred
   y: number;
   constructor(y: number) {
     super(y);

--- a/tests/flow/type_args_strict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_args_strict/__snapshots__/jsfmt.spec.js.snap
@@ -91,9 +91,7 @@ class MyClass<T> {
   }
 }
 
-var c: MyClass = new MyClass(0);
-
-// error, missing argument list (1)
+var c: MyClass = new MyClass(0); // error, missing argument list (1)
 // arity error in type annotation using polymorphic class with defaulting
 class MyClass2<T, U=string> {
   x: T;
@@ -104,30 +102,21 @@ class MyClass2<T, U=string> {
   }
 }
 
-var c2: MyClass2 = new MyClass2(0, \"\");
-
-// error, missing argument list (1-2)
+var c2: MyClass2 = new MyClass2(0, \"\"); // error, missing argument list (1-2)
 // arity error in type annotation using polymorphic type alias
 type MyObject<T> = { x: T };
 
-var o: MyObject = { x: 0 };
-
-// error, missing argument list
+var o: MyObject = { x: 0 }; // error, missing argument list
 // arity error in type alias rhs
-type MySubobject = { y: number } & MyObject;
-
-// error, missing argument list
+type MySubobject = { y: number } & MyObject; // error, missing argument list
 // arity error in interface extends
 interface MyInterface<T> { x: T }
 
-interface MySubinterface extends MyInterface {
-  // error, missing argument list
-  y: number
-}
+interface MySubinterface extends MyInterface { y: number } // error, missing argument list
 
 // *no* arity error in extends of polymorphic class
-class MySubclass extends MyClass {
-  // ok, type arg inferred
+class MySubclass
+  extends MyClass { // ok, type arg inferred
   y: number;
   constructor(y: number) {
     super(y);

--- a/tests/flow/type_param_defaults/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_param_defaults/__snapshots__/jsfmt.spec.js.snap
@@ -83,70 +83,42 @@ var b_default: B<> = new B(\"hello\");
 
 var b_star: B<*> = new B(123);
 
-(b_number.p: boolean);
-// Error number ~> boolean
-(b_void.p: boolean);
-// Error void ~> boolean
-(b_default.p: boolean);
-
-// Error string ~> boolean
-(b_star.p: boolean);
-
-// Error number ~> boolean
+(b_number.p: boolean); // Error number ~> boolean
+(b_void.p: boolean); // Error void ~> boolean
+(b_default.p: boolean); // Error string ~> boolean
+(b_star.p: boolean); // Error number ~> boolean
 class C<T: ?string=string> extends A<T> {}
 
-var c_number: C<number> = new C(123);
-// Error number ~> ?string
+var c_number: C<number> = new C(123); // Error number ~> ?string
 var c_void: C<void> = new C();
 var c_default: C<> = new C(\"hello\");
 var c_star: C<*> = new C(\"hello\");
 
-(c_void.p: boolean);
-// Error void ~> boolean
-(c_default.p: boolean);
-// Error string ~> boolean
-(c_star.p: boolean);
-
-// Error string ~> boolean
+(c_void.p: boolean); // Error void ~> boolean
+(c_default.p: boolean); // Error string ~> boolean
+(c_star.p: boolean); // Error string ~> boolean
 class D<S, T=string> extends A<T> {}
 var d_number: D<mixed, number> = new D(123);
 var d_void: D<mixed, void> = new D();
 var d_default: D<mixed> = new D(\"hello\");
-var d_too_few_args: D<> = new D(\"hello\");
-// Error too few tparams
-var d_too_many: D<mixed, string, string> = new D(\"hello\");
-// Error too many tparams
-var d_star: D<*> = new D(10);
-
-// error, number ~> string
-(d_number.p: boolean);
-// Error number ~> boolean
-(d_void.p: boolean);
-// Error void ~> boolean
-(d_default.p: boolean);
-// Error string ~> boolean
-(d_star.p: boolean);
-
-// Error number ~> boolean
-class E<S: string, T: number=S> {}
-// Error: string ~> number
-class F<S: string, T: S=number> {}
-
-// Error: number ~> string
+var d_too_few_args: D<> = new D(\"hello\"); // Error too few tparams
+var d_too_many: D<mixed, string, string> = new D(\"hello\"); // Error too many tparams
+var d_star: D<*> = new D(10); // error, number ~> string
+(d_number.p: boolean); // Error number ~> boolean
+(d_void.p: boolean); // Error void ~> boolean
+(d_default.p: boolean); // Error string ~> boolean
+(d_star.p: boolean); // Error number ~> boolean
+class E<S: string, T: number=S> {} // Error: string ~> number
+class F<S: string, T: S=number> {} // Error: number ~> string
 class G<S: string, T=S> extends A<T> {}
 
 var g_default: G<string> = new G(\"hello\");
 
-(g_default.p: boolean);
-
-// Error string ~> boolean
-class H<S=T, T=string> {}
-
-// Error - can\'t refer to T before it\'s defined
+(g_default.p: boolean); // Error string ~> boolean
+class H<S=T, T=string> {} // Error - can\'t refer to T before it\'s defined
 class I<T: ?string=*> extends A<T> {}
 
-var i_number: I<number> = new I(123);
-// Error number ~> ?string
+var i_number: I<number> = new I(123); // Error number ~> ?string
 var i_void: I<void> = new I();
 var i_default: I<> = new I(\"hello\");
 var i_star: I<*> = new I(\"hello\");

--- a/tests/flow/type_param_scope/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_param_scope/__snapshots__/jsfmt.spec.js.snap
@@ -10,8 +10,7 @@ exports[`test class.js 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class C<T> {
   a<A>(x: T, a: A) {
-    this.b(x);
-    // ok
+    this.b(x); // ok
     this.b(a); // error: A ~> incompatible instance of T
   }
 
@@ -37,16 +36,12 @@ f(0); // ok
 function f<T>(a: T) {
   function g<U>(b: U, c: T = a) {
     function h(d: U = b) {}
-    h();
-    // ok
-    h(b);
-    // ok
+    h(); // ok
+    h(b); // ok
     h(c); // err, T ~> U
   }
-  g(0);
-  // ok
-  g(0, a);
-  // ok
+  g(0); // ok
+  g(0, a); // ok
   g(0, 0); // error: number ~> T
 }
 f(0); // ok
@@ -148,13 +143,9 @@ class G<T> {
 }
 
 declare var g: G<number | string>;
-g.m(0);
-// ok
-g.m(true);
-// err, bool ~> number|string
-(g.m(\"\"): G<number>);
-
-// err, string ~> number
+g.m(0); // ok
+g.m(true); // err, bool ~> number|string
+(g.m(\"\"): G<number>); // err, string ~> number
 // Shadow bounds incompatible with parent
 class H<T> {
   x: T;

--- a/tests/flow/typeof/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/typeof/__snapshots__/jsfmt.spec.js.snap
@@ -143,9 +143,7 @@ var c: typeof MyClass2 = new MyClass2();
 //////////////////////////////////////
 var numValue: number = 42;
 var d: typeof numValue = 100;
-var e: typeof numValue = \"asdf\";
-
-// Error: string ~> number
+var e: typeof numValue = \"asdf\"; // Error: string ~> number
 /////////////////////////////////
 // == typeof <<type-alias>> == //
 /////////////////////////////////
@@ -155,9 +153,7 @@ type numberAlias = number;
 // a type, as an argument. However, the current error
 // is suboptimal - just \'cannot resolve name\'. TODO.
 //
-var f: typeof numberAlias = 42;
-
-// Error: \'typeof <<type-alias>>\' makes no sense...
+var f: typeof numberAlias = 42; // Error: \'typeof <<type-alias>>\' makes no sense...
 /**
  * Use of a non-class/non-function value in type annotation.
  * These provoke a specific error, not just the generic

--- a/tests/flow/unary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/unary/__snapshots__/jsfmt.spec.js.snap
@@ -91,10 +91,8 @@ let tests = [
     --y;
   },
   function(y: string) {
-    y++;
-    // error, we don\'t allow coercion here
-    (y: number);
-    // ok, y is a number now
+    y++; // error, we don\'t allow coercion here
+    (y: number); // ok, y is a number now
     y++; // error, but you still can\'t write a number to a string
   },
   function(y: string) {
@@ -108,8 +106,7 @@ let tests = [
   },
   function() {
     const y = 123;
-    y++;
-    // error, can\'t update const
+    y++; // error, can\'t update const
     y--; // error, can\'t update const
   },
   function(y: any) {

--- a/tests/flow/unchecked_node_module_vs_lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/unchecked_node_module_vs_lib/__snapshots__/jsfmt.spec.js.snap
@@ -37,22 +37,16 @@ var x3: string = buffer3.INSPECT_MAX_BYTES; // error, module not found
 // so we shouldn\'t pick up its boolean redefinition of INSPECT_MAX_BYTES
 //
 var buffer = require(\"buffer\");
-var b: boolean = buffer.INSPECT_MAX_BYTES;
-
-// error, number ~/> boolean
+var b: boolean = buffer.INSPECT_MAX_BYTES; // error, number ~/> boolean
 // node_modules/crypto/index.js is checked,
 // so we should pick up its boolean redefinition of DEFAULT_ENCODING
 //
 var crypto = require(\"crypto\");
-var b: boolean = crypto.DEFAULT_ENCODING;
-
-// no error, we\'ve overridden
+var b: boolean = crypto.DEFAULT_ENCODING; // no error, we\'ve overridden
 // names that are explicit paths shouldn\'t fall back to lib defs
 //
 var buffer2 = require(\"./buffer\");
-var x2: string = buffer2.INSPECT_MAX_BYTES;
-
-// error, module not found
+var x2: string = buffer2.INSPECT_MAX_BYTES; // error, module not found
 var buffer3 = require(\"./buffer.js\");
 var x3: string = buffer3.INSPECT_MAX_BYTES; // error, module not found
 "

--- a/tests/flow/undefined/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/undefined/__snapshots__/jsfmt.spec.js.snap
@@ -14,9 +14,7 @@ foo();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function doSomethingAsync(): Promise<void> {
   return new Promise((resolve, reject) => {
-    resolve();
-
-    // OK to leave out arg, same as resolve(undefined)
+    resolve(); // OK to leave out arg, same as resolve(undefined)
     var anotherVoidPromise: Promise<void> = Promise.resolve();
     resolve(anotherVoidPromise);
   });
@@ -94,17 +92,13 @@ let tests = [
   function(x: number) {
     var id;
     var name = id ? \"John\" : undefined;
-    (name: boolean);
-
-    // error, string or void
+    (name: boolean); // error, string or void
     const bar = [undefined, \"bar\"];
     (bar[x]: boolean); // error, string or void
   },
   function(x: number) {
     var undefined = \"foo\";
-    (undefined: string);
-
-    // ok
+    (undefined: string); // ok
     var x;
     if (x !== undefined) {
       x[0]; // should error, could be void

--- a/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
@@ -320,8 +320,7 @@ var C = require(\"test-lib\");
 
 // TODO: spurious error! (replacing C with number makes the error go away)
 // type Foo<X> = Array<C> | Array<?C>;
-type Foo<X: ?C> = Array<X>;
-// workaround
+type Foo<X: ?C> = Array<X>; // workaround
 var x: Array<C> = [];
 var y: Array<?C> = [];
 function foo<X>(x: Foo<X>) {}
@@ -330,9 +329,7 @@ foo(y);
 
 // TODO: spurious error! (replacing C with number makes the error go away)
 // type Bar = (() => C) | (() => string);
-type Bar = () => C | string;
-
-// workaround
+type Bar = () => C | string; // workaround
 function f() {
   return \"\";
 }
@@ -417,12 +414,9 @@ class C {}
 class D {}
 function CD(b) {
   var E = b ? C : D;
-  var c: C = new E();
-  // error, since E could be D, and D is not a subtype of C
-  function qux(e: E) {}
-  // this annotation is an error: is it C, or is it D?
-  function qux2(e: C | D) {}
-  // OK
+  var c: C = new E(); // error, since E could be D, and D is not a subtype of C
+  function qux(e: E) {} // this annotation is an error: is it C, or is it D?
+  function qux2(e: C | D) {} // OK
   qux2(new C());
 }
 

--- a/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -453,9 +453,7 @@ function obj(a: A1 | A2) {
   return a.x;
 }
 
-const obj_result = obj({ x: \"\" });
-
-// currently an error! (expect it to be OK)
+const obj_result = obj({ x: \"\" }); // currently an error! (expect it to be OK)
 // Type definitions used above are defined below, but in an order that
 // deliberately makes their full resolution as lazy as possible. The call above
 // blocks until A1 is partially resolved. Since the argument partially matches
@@ -1244,12 +1242,9 @@ function length(list: List) {
 }
 
 length({ kind: \"nil\" });
-length({ kind: \"cons\" });
-// missing \`next\`
+length({ kind: \"cons\" }); // missing \`next\`
 length({ kind: \"cons\", next: { kind: \"nil\" } });
-length({ kind: \"empty\" });
-
-// \`kind\` not found
+length({ kind: \"empty\" }); // \`kind\` not found
 type List = Nil | Cons;
 type Nil = { kind: \"nil\" };
 type Cons = { kind: \"cons\", next: List };
@@ -1644,8 +1639,7 @@ type NestedObj = {} & { dummy: SomeLibClass };
 type Obj = NestedObj & { x: string };
 
 function foo(obj: Obj) {
-  obj.x;
-  // should be OK
+  obj.x; // should be OK
   obj.x; // should also be OK (the check above shouldn\'t affect anything)
 }
 "

--- a/tests/flow/unreachable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/unreachable/__snapshots__/jsfmt.spec.js.snap
@@ -41,8 +41,7 @@ function test2() {
   return;
 
   function f() {
-    var x: typeof n = 0;
-    // no error, n is still number
+    var x: typeof n = 0; // no error, n is still number
     var y: string = n; // error, n is number (EmptyT would work)
   }
 }

--- a/tests/quotes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/quotes/__snapshots__/jsfmt.spec.js.snap
@@ -117,40 +117,28 @@ exports[`test strings.js 1`] = `
 // Emoji.
 \"🐶\"; // Empty string.
 \"\";
-
 \"\"; // Single double quote.
 \'\"\';
-
 \'\"\'; // Single single quote.
 \"\'\";
-
 \"\'\"; // Unnecessary escapes.
 \"\'\";
-
 \'\"\'; // One of each.
 \"\\\"\'\";
-
 \"\\\"\'\"; // One of each with unnecessary escapes.
 \"\\\"\'\";
-
 \"\\\"\'\"; // More double quotes than single quotes.
 \'\"\\\'\"\';
-
 \'\"\\\'\"\'; // More single quotes than double quotes.
 \"\\\"\'\'\";
-
 \"\\\"\'\'\"; // Two of each.
 \"\\\"\\\"\'\'\";
-
 \"\\\"\\\"\'\'\"; // Single backslash.
 \"\\\\\";
-
 \"\\\\\"; // Backslases.
 \"\\\"\\\\\\\"\\\\\\\\\\\" \'\'\\\\\'\\\\\'\\\\\\\\\'\";
-
 \'\\\'\\\\\\\'\\\\\\\\\\\' \"\"\\\\\"\\\\\"\\\\\\\\\"\'; // Somewhat more real-word example.
 \"He\'s sayin\': \\\"How\'s it goin\'?\\\" Don\'t ask me why.\";
-
 \"He\'s sayin\': \\\"How\'s it goin\'?\\\" Don\'t ask me why.\"; // Somewhat more real-word example 2.
 \'var backslash = \"\\\\\", doubleQuote = \\\'\"\\\';\';
 \'var backslash = \"\\\\\", doubleQuote = \\\'\"\\\';\';
@@ -246,40 +234,28 @@ exports[`test strings.js 2`] = `
 // Emoji.
 \'🐶\'; // Empty string.
 \'\';
-
 \'\'; // Single double quote.
 \'\"\';
-
 \'\"\'; // Single single quote.
 \"\'\";
-
 \"\'\"; // Unnecessary escapes.
 \"\'\";
-
 \'\"\'; // One of each.
 \'\"\\\'\';
-
 \'\"\\\'\'; // One of each with unnecessary escapes.
 \'\"\\\'\';
-
 \'\"\\\'\'; // More double quotes than single quotes.
 \'\"\\\'\"\';
-
 \'\"\\\'\"\'; // More single quotes than double quotes.
 \"\\\"\'\'\";
-
 \"\\\"\'\'\"; // Two of each.
 \'\"\"\\\'\\\'\';
-
 \'\"\"\\\'\\\'\'; // Single backslash.
 \'\\\\\';
-
 \'\\\\\'; // Backslases.
 \"\\\"\\\\\\\"\\\\\\\\\\\" \'\'\\\\\'\\\\\'\\\\\\\\\'\";
-
 \'\\\'\\\\\\\'\\\\\\\\\\\' \"\"\\\\\"\\\\\"\\\\\\\\\"\'; // Somewhat more real-word example.
 \"He\'s sayin\': \\\"How\'s it goin\'?\\\" Don\'t ask me why.\";
-
 \"He\'s sayin\': \\\"How\'s it goin\'?\\\" Don\'t ask me why.\"; // Somewhat more real-word example 2.
 \'var backslash = \"\\\\\", doubleQuote = \\\'\"\\\';\';
 \'var backslash = \"\\\\\", doubleQuote = \\\'\"\\\';\';


### PR DESCRIPTION
This is a significant improvement over the old comment algorithm. It still shares a lot of code, but it's a lot more straight-forward about how comments get attached.

First, before I describe the algorithm, here is a printed output from the prettier (all comments stayed where they were originally). There are still some issues (as seen in the comments snapshot) but this is much better.

```js
// @flow

function foo(first /* first */, /* second */ second) {
  var x = 5;
  // sfsff
}

function foo() {
  return /* x */ 1;
}

// yeah
global = 6;

const obj = {
  x: 1, // sdlfkjsdlkjf
  y: 2, // sdlkfjsldfj
  z: 3 // sdkfjsdlkfj
};

// The first time I wanted
// the first number
foo(
  // the second number
  1,
  2, // the second number
  3 // the third
);

/* yes */ function foo(sdfk /* foo */, /* dsfddf */ sdfsdf) {
  var x = 5;
}
```

The AST knows nothing about comments. We are given a full list of comments after parsing, and it's up to us to use the location information to figure out where to put them back in. (Some parsers try to eagerly annotate the AST with comment info, but we want our own algorithm and to work with all parsers.) That's what the `comments.attach` function does.

The attachment process goes like this: it takes each comment, traverses through the AST, and compares source location information. It will pinpoint the nodes that a comment sits between and annotate those nodes with the comment. This is complicated though, because if you naively did that, you'd print a comment twice when printing the node above and below a comment. Also, when printing a node that has a comment attached, where do you put the comment? Above or below?

Recast has a notion of "leading" and "trailing" comments which gives us that information. The attachment process figures out if it's leading or trailing comment, and attaches it to either the node before or after the comment.

Previously, it used the AST structure to infer the leading/trailing info, and in some ambiguous cases checks which side has whitespace. Meaning, where a comment sits structurally will determine it's fate. Comments are placed visually, however, not structurally, so this introduces a lot of problems. A well-known case is this:

```js
functionCall(
  arg1, // first arg
  arg2 // second arg
)
```

Because `// first arg` sits *after* the comma, the previous algorithm would attach it to `arg2` as a leading comment! `// second arg` is properly attached as trailing comment, but only because there are no args after it so no comma is required. We cannot determine leading/trailing info from the AST or syntax structure. We need to use the original source info to figure it out.

Here's the new algorithm that appears to work a lot better:

* If a comment has all whitespace before it on the same line, it's almost always a leading comment. Always prefer attaching it to the next node. The only time when we don't is when there is no following node within the structure, i.e.

```js
function foo() {
  var x = 1;
  // this is a trailing comment
}

var y = 2;
```

If we are too simple, we might end up attaching the comment to `var y = 2` and moving it down. So these kinds of comments *never* move across delimiters and do respect the AST structure.

* If a comment has any text before it on the same line, but only whitespace *after* it, it should *always* be a trailing comment.  This solves all those weird situations where you put a comment at the end of the line and there is syntax between the thing you're trying to comment on and the comment.

This *will* move across delimiters. It's always attached to the "global" previous node regardless of structure. That makes this work:

```js
function foo() { // a comment
}
```

And many other strange scenarios. (The trailing comment within object/array/function args would still work without that, because the "previous" node is still correctly calculated in a list.)

The main thing this heuristic solves is this case:

```js
functionCall(
  arg1, // first arg
  arg2 // second arg
)
```

Because even though `// first arg` is closer to `arg2` structurally, our new algorithm uncondtionally forces these kinds of comments to be attached to whatever is to the left of it. OMG this fixes so many things.

* The final case is when text exists both before *and* after a comment. This can only happen with `/* block comments */`. If this is the case, we fallback to the old algorithm and figure out whether to attach it to the previous or following nodes based on the structure (are there commas between them, etc.)

* (I edited this in, forgot about it) The last thing we need is the ability to *unconditionally* print text at the end of the line. It would be incredibly complex to try to print trailing comments at *just* the right time. It's much easier to introduce a new printer command, `lineSuffix`, which tells the low-level printer to always print a specific string when the line ends. This string is not taken into account in the measuring, so trailing comments will not force a break.

In my tests, this new algorithm is *much* better even if there are some places where it fails. The key, however, is that when it fails, it should *never* output invalid JS code. Here is an example of where it fails, but fails = outputs undesirable, but working code:

```js
foo()
  // Call bar
  .bar()
  // Call baz
  .baz()
```

The output:

```js
foo().// Call bar
bar().// Call baz
baz();
```

We need to solve a bunch of things with member expressions though, and @vjeux already has a PR to improve them. We can solve any failures cases as they come up, and some this are just not going to be optimal (I don't care about supporting certain super weird places to put comments)