### PR TITLE
Don't break up JSXOpeningElement if it only has a single text attribute

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1129,7 +1129,24 @@ function genericPrintNoParens(path, options, print) {
       const elem = printJSXElement(path, options, print);
       return maybeWrapJSXElementInParens(path, elem, options);
     }
-    case "JSXOpeningElement":
+    case "JSXOpeningElement": {
+      const n = path.getValue();
+
+      // don't break up opening elements with a single long text attribute
+      if (n.attributes.length === 1 &&
+          n.attributes[0].value &&
+          n.attributes[0].value.type === "Literal" &&
+          typeof n.attributes[0].value.value === "string"
+      ) {
+        return group(concat([
+          "<",
+          path.call(print, "name"),
+          " ",
+          concat(path.map(print, "attributes")),
+          n.selfClosing ? " />" : ">"
+        ]));
+      }
+
       return group(
         concat([
           "<",
@@ -1146,6 +1163,7 @@ function genericPrintNoParens(path, options, print) {
           n.selfClosing ? "/>" : ">"
         ])
       );
+    }
     case "JSXClosingElement":
       return concat([ "</", path.call(print, "name"), ">" ]);
     case "JSXText":

--- a/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
@@ -38,6 +38,15 @@ make_self_closing =
 
 leave_opening =
   <BaseForm url=\"/auth/google\" method=\"GET\" colour=\"blue\" size=\"large\" submitLabel=\"Sign in with Google\"> </BaseForm>
+
+long_string =
+  <div className=\"i use bootstrap and just put loooaads of classnames in here all the time\">hello world</div>
+
+long_string_with_extra_param =
+  <div className=\"i use bootstrap and just put loooaads of classnames in here all the time\" blah=\"3\">hello world</div>
+
+long_obj =
+  <div style={{ i: \'dont\', use: \'bootstrap\', and: \'instead\', use: \'massive\', objects }}>hello world</div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 long_closed = (
   <BaseForm
@@ -169,6 +178,35 @@ leave_opening = (
   >
     {\" \"}
   </BaseForm>
+);
+
+long_string = (
+  <div className=\"i use bootstrap and just put loooaads of classnames in here all the time\">
+    hello world
+  </div>
+);
+
+long_string_with_extra_param = (
+  <div
+    className=\"i use bootstrap and just put loooaads of classnames in here all the time\"
+    blah=\"3\"
+  >
+    hello world
+  </div>
+);
+
+long_obj = (
+  <div
+    style={{
+      i: \"dont\",
+      use: \"bootstrap\",
+      and: \"instead\",
+      use: \"massive\",
+      objects
+    }}
+  >
+    hello world
+  </div>
 );
 "
 `;

--- a/tests/jsx-split-attrs/test.js
+++ b/tests/jsx-split-attrs/test.js
@@ -37,3 +37,12 @@ make_self_closing =
 
 leave_opening =
   <BaseForm url="/auth/google" method="GET" colour="blue" size="large" submitLabel="Sign in with Google"> </BaseForm>
+
+long_string =
+  <div className="i use bootstrap and just put loooaads of classnames in here all the time">hello world</div>
+
+long_string_with_extra_param =
+  <div className="i use bootstrap and just put loooaads of classnames in here all the time" blah="3">hello world</div>
+
+long_obj =
+  <div style={{ i: 'dont', use: 'bootstrap', and: 'instead', use: 'massive', objects }}>hello world</div>


### PR DESCRIPTION
Addresses a pain point mentioned in https://github.com/jlongster/prettier/issues/467 according to an algorithm proposed by @vjeux in https://github.com/jlongster/prettier/issues/467#issuecomment-275230393

specifically, don't break opening elements such as 
```jsx
<div className="i use bootstrap and just put loooaads of classnames in here all the time">
  hello world
</div>
```