### PR TITLE
Stop using conditionalGroup inside of UnionTypeAnnotation

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1423,32 +1423,22 @@ function genericPrintNoParens(path, options, print) {
       const types = path.map(print, "types");
       const op = n.type === "IntersectionTypeAnnotation" ? "&" : "|";
 
-      return conditionalGroup([
-        // single-line variation
-        // A | B | C
-        concat([
-          indent(
-            options.tabWidth,
-            concat([
-              types[0],
-              indent(
-                options.tabWidth,
-                concat(types.slice(1).map(t => concat([ " ", op, line, t ])))
-              )
-            ])
-          )
-        ]),
-        // multi-line variation
-        // | A
-        // | B
-        // | C
-        concat([
-          indent(
-            options.tabWidth,
-            concat(types.map(t => concat([ line, op, " ", t ])))
-          )
-        ])
-      ]);
+      // single-line variation
+      // A | B | C
+
+      // multi-line variation
+      // | A
+      // | B
+      // | C
+      return group(
+        indent(
+          options.tabWidth,
+          concat([
+            ifBreak(concat([line, op, " "])),
+            join(concat([line, op, " "]), types)
+          ])
+        )
+      );
     }
     case "NullableTypeAnnotation":
       return concat([ "?", path.call(print, "typeAnnotation") ]);

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -147,10 +147,18 @@ throw new ProcessSystemError({
 
 // Adding a comment stops the pretty printing process and everything is
 // squished in a single line afterward
-export type BuckWebSocketMessage = {
+export type BuckWebSocketMessage =
+  | {
     // Not actually from Buck - this is to let the receiver know that the socket is connected.
     type: \"SocketConnected\"
-  } | { type: \"BuildProgressUpdated\", progressValue: number } | { type: \"BuildFinished\", exitCode: number } | { type: \"BuildStarted\" } | { type: \"ParseStarted\" } | { type: \"ParseFinished\" } | { type: \"RunStarted\" } | { type: \"RunComplete\" };
+  }
+  | { type: \"BuildProgressUpdated\", progressValue: number }
+  | { type: \"BuildFinished\", exitCode: number }
+  | { type: \"BuildStarted\" }
+  | { type: \"ParseStarted\" }
+  | { type: \"ParseFinished\" }
+  | { type: \"RunStarted\" }
+  | { type: \"RunComplete\" };
 
 // Missing one level of indentation because of the comment
 const rootEpic = (actions, store) =>
@@ -161,11 +169,13 @@ const rootEpic = (actions, store) =>
   });
 
 // Two extra levels of indentation because of the comment
-export type AsyncExecuteOptions = child_process$execFileOpts & {
-      // The contents to write to stdin.
-      stdin?: ?string,
-      dontLogInNuclide?: ?boolean
-    };
+export type AsyncExecuteOptions =
+  & child_process$execFileOpts
+  & {
+    // The contents to write to stdin.
+    stdin?: ?string,
+    dontLogInNuclide?: ?boolean
+  };
 
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(
@@ -336,10 +346,18 @@ throw new ProcessSystemError({
 
 // Adding a comment stops the pretty printing process and everything is
 // squished in a single line afterward
-export type BuckWebSocketMessage = {
+export type BuckWebSocketMessage =
+  | {
     // Not actually from Buck - this is to let the receiver know that the socket is connected.
     type: \"SocketConnected\"
-  } | { type: \"BuildProgressUpdated\", progressValue: number } | { type: \"BuildFinished\", exitCode: number } | { type: \"BuildStarted\" } | { type: \"ParseStarted\" } | { type: \"ParseFinished\" } | { type: \"RunStarted\" } | { type: \"RunComplete\" };
+  }
+  | { type: \"BuildProgressUpdated\", progressValue: number }
+  | { type: \"BuildFinished\", exitCode: number }
+  | { type: \"BuildStarted\" }
+  | { type: \"ParseStarted\" }
+  | { type: \"ParseFinished\" }
+  | { type: \"RunStarted\" }
+  | { type: \"RunComplete\" };
 
 // Missing one level of indentation because of the comment
 const rootEpic = (actions, store) =>
@@ -350,11 +368,13 @@ const rootEpic = (actions, store) =>
   });
 
 // Two extra levels of indentation because of the comment
-export type AsyncExecuteOptions = child_process$execFileOpts & {
-      // The contents to write to stdin.
-      stdin?: ?string,
-      dontLogInNuclide?: ?boolean
-    };
+export type AsyncExecuteOptions =
+  & child_process$execFileOpts
+  & {
+    // The contents to write to stdin.
+    stdin?: ?string,
+    dontLogInNuclide?: ?boolean
+  };
 
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(


### PR DESCRIPTION
It's actually not needed to use conditionalGroup as we can use `ifBreak` and `join` for it. I was going to do it just for cleanup and found out that it also fixed two of the bugs we have with comments. That's great :p

Fixes #485
Fixes #486