### PR TITLE
Proper support for dangling comments

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -352,25 +352,28 @@ function printTrailingComment(commentPath, print, options, parentNode) {
   ])
 }
 
-function printDanglingComment(commentPath, print, options) {
+function printDanglingComments(path, options, noIndent) {
   const text = options.originalText;
   const parts = [];
-  const comment = commentPath.getValue();
-  if (util.hasNewline(text, locStart(comment), { backwards: true })) {
-    parts.push(hardline);
-  }
-  parts.push(printComment(commentPath));
-  return concat(parts);
-}
+  const node = path.getValue();
 
-function printDanglingComments(path, print, options) {
-  const parts = [];
+  if(!node || !node.comments) {
+    return "";
+  }
+
   path.each(commentPath => {
     const comment = commentPath.getValue();
-    if (!comment.leading && !comment.trailing) {
-      parts.push(printDanglingComment(commentPath, print, options));
+    if(!comment.leading && !comment.trailing) {
+      if(util.hasNewline(text, locStart(comment), { backwards: true })) {
+        parts.push(hardline);
+      }
+      parts.push(printComment(commentPath));
     }
   }, "comments");
+
+  if(!noIndent) {
+    return indent(options.tabWidth, concat(parts));
+  }
   return concat(parts);
 }
 
@@ -416,17 +419,6 @@ function printComments(path, print, options) {
             parent
           )
         );
-      } else {
-        // Those two node types print their dangling comments themselves
-        if (value.type !== "Program" && value.type !== "BlockStatement") {
-          trailingParts.push(
-            printDanglingComment(
-              commentPath,
-              print,
-              options
-            )
-          );
-        }
       }
     },
     "comments"

--- a/src/printer.js
+++ b/src/printer.js
@@ -135,10 +135,10 @@ function genericPrintNoParens(path, options, print) {
         )
       );
 
-      if(n.comments) {
-        parts.push(comments.printDanglingComments(path, print, options));
-      }
 
+      parts.push(
+        comments.printDanglingComments(path, options, /* noIdent */ true)
+      );
       parts.push(hardline);
 
       return concat(parts);
@@ -510,15 +510,9 @@ function genericPrintNoParens(path, options, print) {
 
       if (hasContent) {
         parts.push(indent(options.tabWidth, concat([ hardline, naked ])));
-      } else if (n.comments) {
-        parts.push(
-          indent(
-            options.tabWidth,
-            comments.printDanglingComments(path, print, options)
-          )
-        );
       }
 
+      parts.push(comments.printDanglingComments(path, options));
       parts.push(hardline, "}");
 
       return concat(parts);
@@ -581,7 +575,11 @@ function genericPrintNoParens(path, options, print) {
       });
 
       if (props.length === 0) {
-        return "{}";
+        return concat([
+          "{",
+          comments.printDanglingComments(path, options),
+          "}"
+        ]);
       } else {
         return group(
           concat([
@@ -662,7 +660,11 @@ function genericPrintNoParens(path, options, print) {
     case "ArrayExpression":
     case "ArrayPattern":
       if (n.elements.length === 0) {
-        parts.push("[]");
+        parts.push(concat([
+          "[",
+          comments.printDanglingComments(path, options),
+          "]"
+        ]));
       } else {
         const lastElem = util.getLast(n.elements);
         const canHaveTrailingComma = !(lastElem &&
@@ -1169,7 +1171,7 @@ function genericPrintNoParens(path, options, print) {
     case "JSXText":
       throw new Error("JSXTest should be handled by JSXElement");
     case "JSXEmptyExpression":
-      return "";
+      return comments.printDanglingComments(path, options);
     case "TypeAnnotatedIdentifier":
       return concat([
         path.call(print, "annotation"),

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -188,7 +188,7 @@ takeUntil(
 
 /* Comments disappear inside of JSX*/
 <div>
-  {}
+  {/* Some comment */}
 </div>;
 
 /* Comments in JSX tag are placed in a non optimal way*/
@@ -377,7 +377,7 @@ takeUntil(
 
 // Comments disappear inside of JSX
 <div>
-  {}
+  {/* Some comment */}
 </div>;
 
 // Comments in JSX tag are placed in a non optimal way

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -24,6 +24,40 @@ exports[`test blank.js 2`] = `
 "
 `;
 
+exports[`test dangling.js 1`] = `
+"var x = {/* dangling */};
+var x = [/* dangling */];
+function x() {
+  /* dangling */
+}
+declare class Foo extends Qux<string> {/* dangling */}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var x = {/* dangling */};
+var x = [/* dangling */];
+function x() {
+  /* dangling */
+}
+declare class Foo extends Qux<string> {/* dangling */}
+"
+`;
+
+exports[`test dangling.js 2`] = `
+"var x = {/* dangling */};
+var x = [/* dangling */];
+function x() {
+  /* dangling */
+}
+declare class Foo extends Qux<string> {/* dangling */}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var x = {/* dangling */};
+var x = [/* dangling */];
+function x() {
+  /* dangling */
+}
+declare class Foo extends Qux<string> {/* dangling */}
+"
+`;
+
 exports[`test issues.js 1`] = `
 "// Does not need to break as it fits in 80 columns
 this.call(a, /* comment */ b);

--- a/tests/comments/dangling.js
+++ b/tests/comments/dangling.js
@@ -1,0 +1,6 @@
+var x = {/* dangling */};
+var x = [/* dangling */];
+function x() {
+  /* dangling */
+}
+declare class Foo extends Qux<string> {/* dangling */}

--- a/tests/flow/this_type/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this_type/lib/__snapshots__/jsfmt.spec.js.snap
@@ -30,8 +30,8 @@ declare module \"mini-immutable\" {
   declare class Map<K, V> {
     set(key: K, value: V): this /* more precise than Map<K,V> (see below)*/
   }
-  declare class OrderedMap<K, V> extends Map<K, V> {}
-  /* inherits set method returning OrderedMap<K,V> instead of Map<K,V>*/
+  declare class OrderedMap<K, V> extends Map<K, V> {
+    /* inherits set method returning OrderedMap<K,V> instead of Map<K,V>*/}
 }
 "
 `;

--- a/tests/flow/this_type/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this_type/lib/__snapshots__/jsfmt.spec.js.snap
@@ -31,6 +31,7 @@ declare module \"mini-immutable\" {
     set(key: K, value: V): this /* more precise than Map<K,V> (see below)*/
   }
   declare class OrderedMap<K, V> extends Map<K, V> {}
+  /* inherits set method returning OrderedMap<K,V> instead of Map<K,V>*/
 }
 "
 `;

--- a/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
@@ -21,6 +21,8 @@ declare class Baz<T> {
 ((new Foo).z: number); // error: Qux wins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class Foo extends Qux<string> {}
+/* KeyedCollection <: Collection*/
+/* ...KeyedIterable*/
 declare class Bar<T> extends Baz<T> {
   // KeyedIterable <: Iterable
   y: T

--- a/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
@@ -20,9 +20,9 @@ declare class Baz<T> {
 ((new Foo).y: string); // error: Bar wins
 ((new Foo).z: number); // error: Qux wins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-declare class Foo extends Qux<string> {}
-/* KeyedCollection <: Collection*/
-/* ...KeyedIterable*/
+declare class Foo extends Qux<string> {
+  /* KeyedCollection <: Collection*/
+  /* ...KeyedIterable*/}
 declare class Bar<T> extends Baz<T> {
   // KeyedIterable <: Iterable
   y: T


### PR DESCRIPTION
In one code path, the dangling comment case is not properly handled. So I added the dangling comment, but it turns out that we only print manually in two node types: Program and BlockStatement. I made the generic printComment function print it everywhere but those two nodes. I tried to get rid of those special cases but unfortunately we need them there otherwise they are not printed at the right place.

Fixes #20