### PR TITLE
Properly print comments for BinaryExpression

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2365,7 +2365,7 @@ function isBinaryish(node) {
 // precedence level and the AST is structured based on precedence
 // level, things are naturally broken up correctly, i.e. `&&` is
 // broken before `+`.
-function printBinaryishExpressions(path, parts, print) {
+function printBinaryishExpressions(path, parts, print, options, isNested) {
   let node = path.getValue();
 
   // We treat BinaryExpression and LogicalExpression nodes the same.
@@ -2384,12 +2384,25 @@ function printBinaryishExpressions(path, parts, print) {
     ) {
       // Flatten them out by recursively calling this function. The
       // printed values will all be appended to `parts`.
-      path.call(left => printBinaryishExpressions(left, parts, print), "left");
+      path.call(left => printBinaryishExpressions(left, parts, print, options, /* isNested */ true), "left");
     } else {
       parts.push(path.call(print, "left"));
     }
 
     parts.push(" ", node.operator, line, path.call(print, "right"));
+
+    // The root comments are already printed, but we need to manually print
+    // the other ones since we don't call the normal print on BinaryExpression,
+    // only for the left and right parts
+    if (isNested && node.comments) {
+      parts.push(
+        comments.printComments(
+          path,
+          p => "",
+          options
+        )
+      );
+    }
   } else {
     // Our stopping case. Simply print the node normally.
     parts.push(path.call(print));

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -170,10 +170,10 @@ export type AsyncExecuteOptions = child_process$execFileOpts & {
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(
   \"^\\\\s*\" + // beginning of the line
-    \"name\\\\s*=\\\\s*\" +
-    \"[\'\\\"]\" +
-    escapeStringRegExp(target.name) +
-    \"[\'\\\"]\" +
+    \"name\\\\s*=\\\\s*\" + // name =
+    \"[\'\\\"]\" + // opening quotation mark
+    escapeStringRegExp(target.name) + // target name
+    \"[\'\\\"]\" + // closing quotation mark
     \",?$\" // optional trailing comma
 );
 
@@ -359,10 +359,10 @@ export type AsyncExecuteOptions = child_process$execFileOpts & {
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(
   \"^\\\\s*\" + // beginning of the line
-    \"name\\\\s*=\\\\s*\" +
-    \"[\'\\\"]\" +
-    escapeStringRegExp(target.name) +
-    \"[\'\\\"]\" +
+    \"name\\\\s*=\\\\s*\" + // name =
+    \"[\'\\\"]\" + // opening quotation mark
+    escapeStringRegExp(target.name) + // target name
+    \"[\'\\\"]\" + // closing quotation mark
     \",?$\" // optional trailing comma
 );
 


### PR DESCRIPTION
We don't call the generic print on the BinaryExpression itself, so we need to manually print those comments. It's going to be useful for my work on the MemberExpression :)