### PR TITLE
Remove extra group when printing object values

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -635,13 +635,9 @@ function genericPrintNoParens(path, options, print) {
         } else {
           parts.push(
             concat([
-              group(
-                concat([
-                  ":",
-                  ifBreak(" (", " "),
-                  indent(options.tabWidth, concat([softline, printedValue]))
-                ])
-              ),
+              ":",
+              ifBreak(" (", " "),
+              indent(options.tabWidth, concat([softline, printedValue])),
               softline,
               ifBreak(")")
             ])

--- a/tests/object_colon_bug/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object_colon_bug/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,14 @@
+exports[`test bug.js 1`] = `
+"const foo = {
+  bar: props.bar ? props.bar : noop,
+  baz: props.baz
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const foo = {
+  bar: (
+    props.bar ? props.bar : noop
+  ),
+  baz: props.baz
+};
+"
+`;

--- a/tests/object_colon_bug/bug.js
+++ b/tests/object_colon_bug/bug.js
@@ -1,0 +1,4 @@
+const foo = {
+  bar: props.bar ? props.bar : noop,
+  baz: props.baz
+}

--- a/tests/object_colon_bug/jsfmt.spec.js
+++ b/tests/object_colon_bug/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, {printWidth: 35});


### PR DESCRIPTION
It turns out that in an unlikely turn of event, the inner group can be inline and not print the opening paren but the outer group breaks and outputs the closing paren which generates invalid JavaScript.

I tried removing the group altogether and no tests failed, so I'm assuming the group wasn't needed in the first place. If it was, we should add tests to cover this.

Fixes #501