### PR TITLE
Don't print trailing commas for object destructuring and rest

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -582,6 +582,10 @@ function genericPrintNoParens(path, options, print) {
         );
       });
 
+      const lastElem = util.getLast(n.properties);
+      const canHaveTrailingComma = !(lastElem &&
+        lastElem.type === "RestProperty");
+
       if (props.length === 0) {
         return concat([
           "{",
@@ -599,7 +603,7 @@ function genericPrintNoParens(path, options, print) {
                 join(concat([separator, line]), props)
               ])
             ),
-            ifBreak(options.trailingComma ? "," : ""),
+            ifBreak(canHaveTrailingComma && options.trailingComma ? "," : ""),
             options.bracketSpacing ? line : softline,
             rightBrace,
             path.call(print, "typeAnnotation")

--- a/tests/rest/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/rest/__snapshots__/jsfmt.spec.js.snap
@@ -16,6 +16,8 @@ declare class C { f(...superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSu
 [superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,,];
 
 [veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong, ...a] = [];
+var {veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong, ...a} = {};
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class C {
   f(
@@ -44,5 +46,9 @@ declare class C {
   veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong,
   ...a
 ] = [];
+var {
+  veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong,
+  ...a
+} = {};
 "
 `;

--- a/tests/rest/trailing-commas.js
+++ b/tests/rest/trailing-commas.js
@@ -15,3 +15,5 @@ declare class C { f(...superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSu
 [superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,,];
 
 [veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong, ...a] = [];
+var {veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong, ...a} = {};
+


### PR DESCRIPTION
Fixes #507