### PR TITLE
[JSX] Put `}` on the same level of indent as `{`

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1110,7 +1110,16 @@ function genericPrintNoParens(path, options, print) {
             n.expression.type === "LogicalExpression");
 
       if (shouldInline) {
-        return concat(["{", path.call(print, "expression"), "}"]);
+        const shouldPutBracketOnNextLine =
+          n.expression.type === "LogicalExpression" ||
+          n.expression.type === "ConditionalExpression";
+
+        return concat([
+          "{",
+          path.call(print, "expression"),
+          shouldPutBracketOnNextLine ? softline : "",
+          "}"
+        ]);
       }
 
       return group(

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -200,7 +200,8 @@ const renderTernary = props => (
         >
           Hello world
         </BaseForm>
-      : \"hello \" + \"howdy! \"}
+      : \"hello \" + \"howdy! \"
+    }
     {props.showTheThing
       ? <BaseForm
           url=\"/auth/google\"
@@ -211,7 +212,8 @@ const renderTernary = props => (
         >
           Hello world
         </BaseForm>
-      : null}
+      : null
+    }
     {props.showTheThing
       ? null
       : <BaseForm
@@ -222,7 +224,8 @@ const renderTernary = props => (
           submitLabel=\"Sign in with Google\"
         >
           Hello world
-        </BaseForm>}
+        </BaseForm>
+    }
     {props.showTheOtherThing ? <div>I am here</div> : <div attr=\"blah\" />}
     {props.showTheOtherThing ? <div>I am here!!</div> : null}
   </BaseForm>

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -164,7 +164,8 @@ exports[`test hug.js 1`] = `
             getComponent={routeES6Modules[route.value]}
           />
         ))}
-      </div>}
+      </div>
+  }
 </div>;
 
 <div>
@@ -178,7 +179,8 @@ exports[`test hug.js 1`] = `
           getComponent={routeES6Modules[route.value]}
         />
       ))}
-    </div>}
+    </div>
+  }
 </div>;
 "
 `;


### PR DESCRIPTION
If the children are going to have a level of indentation, we should put a soft empty line. This way the `}` is going to be at the same level of indentation as `{`. Sadly, I don't think there's a way to express this with the IR, but since we're only inline so few nodes, I just put the two that will have this behavior.