### PR TITLE
Print \x and \u escapes in strings and regexes lowercase

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1231,7 +1231,10 @@ function genericPrintNoParens(path, options, print) {
     case "ClassExpression":
       return concat(printClass(path, options, print));
     case "TemplateElement":
-      return join(literalline, n.value.raw.split("\n"));
+      return join(
+        literalline,
+        n.value.raw.split("\n").map(line => normalizeEscapes(line))
+      );
     case "TemplateLiteral":
       var expressions = path.map(print, "expressions");
 

--- a/tests/literal/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/literal/__snapshots__/jsfmt.spec.js.snap
@@ -116,3 +116,48 @@ function test5(): string {
 0.1e-10;
 "
 `;
+
+exports[`test regex.js 1`] = `
+"// Normalization of \\x and \\u escapes:
+
+// Basic case.
+/a\\xAaAb\\uB1cDE/gim;
+
+// ES2015 unicode escapes.
+/\\u{1Fa3}/u;
+/\\u{00000000A0}/u;
+
+// Leaves what looks like a ES2015 unicode escape alone if not using the /u flag.
+/\\u{1Fa3}/;
+
+// Leaves what looks like escapes but aren\'t alone.
+/\\xA\\u00BG/;
+
+// Leaves other escapes alone.
+/\\B\\S/;
+
+// Handles escaped backslashes.
+/\\\\xAB\\\\\\xAB\\\\\\\\xAB\\B\\\\\\B\\uAbCd/;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Normalization of \\x and \\u escapes:
+
+// Basic case.
+/a\\xaaAb\\ub1cdE/gim;
+
+// ES2015 unicode escapes.
+/\\u{1fa3}/u;
+/\\u{00000000a0}/u;
+
+// Leaves what looks like a ES2015 unicode escape alone if not using the /u flag.
+/\\u{1Fa3}/;
+
+// Leaves what looks like escapes but aren\'t alone.
+/\\xA\\u00BG/;
+
+// Leaves other escapes alone.
+/\\B\\S/;
+
+// Handles escaped backslashes.
+/\\\\xAB\\\\\\xab\\\\\\\\xAB\\B\\\\\\B\\uabcd/;
+"
+`;

--- a/tests/literal/regex.js
+++ b/tests/literal/regex.js
@@ -1,0 +1,20 @@
+// Normalization of \x and \u escapes:
+
+// Basic case.
+/a\xAaAb\uB1cDE/gim;
+
+// ES2015 unicode escapes.
+/\u{1Fa3}/u;
+/\u{00000000A0}/u;
+
+// Leaves what looks like a ES2015 unicode escape alone if not using the /u flag.
+/\u{1Fa3}/;
+
+// Leaves what looks like escapes but aren't alone.
+/\xA\u00BG/;
+
+// Leaves other escapes alone.
+/\B\S/;
+
+// Handles escaped backslashes.
+/\\xAB\\\xAB\\\\xAB\B\\\B\uAbCd/;

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -24,6 +24,21 @@ exports[`test strings.js 1`] = `
 
   \'\\uD801\\uDC28\',
 ];
+
+// Normalization of \\x and \\u escapes:
+
+// Basic case.
+\"a\\xAaAb\\uB1cDE\"
+
+// ES2015 unicode escapes.
+\"\\u{1Fa3}\"
+\"\\u{00000000A0}\"
+
+// Leaves other escapes alone.
+\"\\B\\S\"
+
+// Handles escaped backslashes.
+\"\\\\xAB\\\\\\xAB\\\\\\\\xAB\\B\\\\\\B\\u1234\"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [
   \"abc\",
@@ -42,6 +57,11 @@ exports[`test strings.js 1`] = `
   \"\\0\",
   \"🐶\",
   \'\\uD801\\uDC28\'
-];
+]; // Normalization of \\x and \\u escapes: // Basic case.
+\"a\\xaaAb\\ub1cdE\"; // ES2015 unicode escapes.
+\"\\u{1fa3}\";
+\"\\u{00000000a0}\"; // Leaves other escapes alone.
+\"\\B\\S\"; // Handles escaped backslashes.
+\"\\\\xAB\\\\\\xab\\\\\\\\xAB\\B\\\\\\B\\u1234\";
 "
 `;

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -28,17 +28,25 @@ exports[`test strings.js 1`] = `
 // Normalization of \\x and \\u escapes:
 
 // Basic case.
-\"a\\xAaAb\\uB1cDE\"
+\"a\\xAaAb\\uB1cDE\";
+\`a\\xAaAb\\uB1cDE\`;
 
 // ES2015 unicode escapes.
-\"\\u{1Fa3}\"
-\"\\u{00000000A0}\"
+\"\\u{1Fa3}\";
+\`\\u{1Fa3}\`;
+\"\\u{00000000A0}\";
+\`\\u{00000000A0}\`;
 
 // Leaves other escapes alone.
-\"\\B\\S\"
+\"\\B\\S\";
+\`\\B\\S\`;
 
 // Handles escaped backslashes.
-\"\\\\xAB\\\\\\xAB\\\\\\\\xAB\\B\\\\\\B\\u1234\"
+\"\\\\xAB\\\\\\xAB\\\\\\\\xAB\\B\\\\\\B\\u1234\";
+\`\\\\xAB\\\\\\xAB\\\\\\\\xAB\\B\\\\\\B\\u1234\`;
+
+// Mix of everything.
+\"\\xF0\"\`a\\uaBcD\${\'\\xFdE\'}\\\\\\u{00AbCdE}\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [
   \"abc\",
@@ -58,10 +66,16 @@ exports[`test strings.js 1`] = `
   \"🐶\",
   \'\\uD801\\uDC28\'
 ]; // Normalization of \\x and \\u escapes: // Basic case.
-\"a\\xaaAb\\ub1cdE\"; // ES2015 unicode escapes.
+\"a\\xaaAb\\ub1cdE\";
+\`a\\xaaAb\\ub1cdE\`; // ES2015 unicode escapes.
 \"\\u{1fa3}\";
-\"\\u{00000000a0}\"; // Leaves other escapes alone.
-\"\\B\\S\"; // Handles escaped backslashes.
+\`\\u{1fa3}\`;
+\"\\u{00000000a0}\";
+\`\\u{00000000a0}\`; // Leaves other escapes alone.
+\"\\B\\S\";
+\`\\B\\S\`; // Handles escaped backslashes.
 \"\\\\xAB\\\\\\xab\\\\\\\\xAB\\B\\\\\\B\\u1234\";
+\`\\\\xAB\\\\\\xab\\\\\\\\xAB\\B\\\\\\B\\u1234\`; // Mix of everything.
+\"\\xf0\"\`a\\uabcd\${\"\\xfdE\"}\\\\\\u{00abcde}\`;
 "
 `;

--- a/tests/strings/strings.js
+++ b/tests/strings/strings.js
@@ -27,14 +27,22 @@
 // Normalization of \x and \u escapes:
 
 // Basic case.
-"a\xAaAb\uB1cDE"
+"a\xAaAb\uB1cDE";
+`a\xAaAb\uB1cDE`;
 
 // ES2015 unicode escapes.
-"\u{1Fa3}"
-"\u{00000000A0}"
+"\u{1Fa3}";
+`\u{1Fa3}`;
+"\u{00000000A0}";
+`\u{00000000A0}`;
 
 // Leaves other escapes alone.
-"\B\S"
+"\B\S";
+`\B\S`;
 
 // Handles escaped backslashes.
-"\\xAB\\\xAB\\\\xAB\B\\\B\u1234"
+"\\xAB\\\xAB\\\\xAB\B\\\B\u1234";
+`\\xAB\\\xAB\\\\xAB\B\\\B\u1234`;
+
+// Mix of everything.
+"\xF0"`a\uaBcD${'\xFdE'}\\\u{00AbCdE}`;

--- a/tests/strings/strings.js
+++ b/tests/strings/strings.js
@@ -23,3 +23,18 @@
 
   '\uD801\uDC28',
 ];
+
+// Normalization of \x and \u escapes:
+
+// Basic case.
+"a\xAaAb\uB1cDE"
+
+// ES2015 unicode escapes.
+"\u{1Fa3}"
+"\u{00000000A0}"
+
+// Leaves other escapes alone.
+"\B\S"
+
+// Handles escaped backslashes.
+"\\xAB\\\xAB\\\\xAB\B\\\B\u1234"


### PR DESCRIPTION
I went with lowercase since with did so for hex numbers in #498. Tell me if you'd rather want uppercase.

Feel free to close this if prettier shouldn't care. :)
