### PR TITLE
Add 0.14.1 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.14.1
+
+[link](https://github.com/jlongster/prettier/compare/0.14.0...0.14.1)
+
+* Fix range for object newline detection (#520)
+  * a bugfix for "Keep expanded objects expanded" (#495)
+
 # 0.14.0
 
 [link](https://github.com/jlongster/prettier/compare/0.13.0...0.14.0)


### PR DESCRIPTION
Also, the tag for 0.14.1 hasn't been pushed to the repository, so the "changes" link is invalid – currently, you'd need https://github.com/jlongster/prettier/compare/0.14.0...efc3ee0488f72ddecda6c3605061327b737f1c22.