### PR TITLE
Update `bracketSpacing` comment to say it's about {}

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ prettier.format(source, {
   // Controls the printing of trailing commas wherever possible
   trailingComma: false,
 
-  // Controls the printing of spaces inside array and objects
+  // Controls the printing of spaces inside object literals
   bracketSpacing: true,
 
   // Which parser to use. Valid options are 'flow' and 'babylon'


### PR DESCRIPTION
Before e13bb7dbba5b9b725338f19cc196f75201b9fc82 `bracketSpacing` used to be about both `[]` and `{}` but now it's only about `{}`.