### PR TITLE
Fix closing call expression commented out

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1708,17 +1708,18 @@ function printArgumentsList(path, options, print) {
   // This is just an optimization; I think we could return the
   // conditional group for all function calls, but it's more expensive
   // so only do it for specific forms.
-  const groupLastArg = lastArg.type === "ObjectExpression" ||
-    lastArg.type === "ArrayExpression" ||
-    lastArg.type === "FunctionExpression" ||
-    lastArg.type === "ArrowFunctionExpression" &&
-      (lastArg.body.type === "BlockStatement" ||
-        lastArg.body.type === "ArrowFunctionExpression" ||
-        lastArg.body.type === "ObjectExpression" ||
-        lastArg.body.type === "ArrayExpression" ||
-        lastArg.body.type === "CallExpression" ||
-        lastArg.body.type === "JSXElement") ||
-    lastArg.type === "NewExpression";
+  const groupLastArg = (!lastArg.comments || !lastArg.comments.length) &&
+    (lastArg.type === "ObjectExpression" ||
+      lastArg.type === "ArrayExpression" ||
+      lastArg.type === "FunctionExpression" ||
+      lastArg.type === "ArrowFunctionExpression" &&
+        (lastArg.body.type === "BlockStatement" ||
+          lastArg.body.type === "ArrowFunctionExpression" ||
+          lastArg.body.type === "ObjectExpression" ||
+          lastArg.body.type === "ArrayExpression" ||
+          lastArg.body.type === "CallExpression" ||
+          lastArg.body.type === "JSXElement") ||
+      lastArg.type === "NewExpression");
 
   if (groupLastArg) {
     const shouldBreak = printed.slice(0, -1).some(willBreak);

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -161,6 +161,11 @@ else {
 
 // The comment makes the line break in a weird way
 const result = asyncExecute(\'non_existing_command\', /* args */ []);
+
+// The closing paren is printed on the same line as the comment
+foo({}
+  // Hi
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Does not need to break as it fits in 80 columns
 this.call(a, /* comment */ b);
@@ -270,6 +275,12 @@ if (1) {
 
 // The comment makes the line break in a weird way
 const result = asyncExecute(\"non_existing_command\", /* args */ []);
+
+// The closing paren is printed on the same line as the comment
+foo(
+  {}
+  // Hi
+);
 "
 `;
 
@@ -376,6 +387,11 @@ else {
 
 // The comment makes the line break in a weird way
 const result = asyncExecute(\'non_existing_command\', /* args */ []);
+
+// The closing paren is printed on the same line as the comment
+foo({}
+  // Hi
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Does not need to break as it fits in 80 columns
 this.call(a, /* comment */ b);
@@ -485,5 +501,11 @@ if (1) {
 
 // The comment makes the line break in a weird way
 const result = asyncExecute(\"non_existing_command\", /* args */ []);
+
+// The closing paren is printed on the same line as the comment
+foo(
+  {}
+  // Hi
+);
 "
 `;

--- a/tests/comments/issues.js
+++ b/tests/comments/issues.js
@@ -101,10 +101,7 @@ else {
 // The comment makes the line break in a weird way
 const result = asyncExecute('non_existing_command', /* args */ []);
 
-// Commments in call expression cause a syntax error
-foo(
-  // Hi!
-);
-foo({},
+// The closing paren is printed on the same line as the comment
+foo({}
   // Hi
 );

--- a/tests/comments/issues.js
+++ b/tests/comments/issues.js
@@ -100,3 +100,8 @@ else {
 
 // The comment makes the line break in a weird way
 const result = asyncExecute('non_existing_command', /* args */ []);
+
+// Commments in call expression cause a syntax error
+foo(
+  // Hi!
+);

--- a/tests/comments/issues.js
+++ b/tests/comments/issues.js
@@ -105,3 +105,6 @@ const result = asyncExecute('non_existing_command', /* args */ []);
 foo(
   // Hi!
 );
+foo({},
+  // Hi
+);


### PR DESCRIPTION
```js
foo({}
  // Hi
);
```

prints

```js
foo({}
  // Hi);
```

Edit: change from a test failure PR to a fix PR