### PR TITLE
Preserve next line with trailing comment

### DIFF
--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -256,6 +256,7 @@ const regex = new RegExp(
 
 // The comment is moved and doesn\'t trigger the eslint rule anymore
 import path from \"path\"; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
+
 // Comments disappear in-between MemberExpressions
 Observable.of(process).// Don\'t complete until we say so!
 merge(Observable.never()).// Get the errors.
@@ -482,6 +483,7 @@ const regex = new RegExp(
 
 // The comment is moved and doesn\'t trigger the eslint rule anymore
 import path from \"path\"; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
+
 // Comments disappear in-between MemberExpressions
 Observable.of(process).// Don\'t complete until we say so!
 merge(Observable.never()).// Get the errors.

--- a/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
@@ -149,6 +149,7 @@ function foo() {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let myClassInstance: MyClass = null;
+
 // forward ref ok, null ~> class error
 
 function bar(): MyClass {
@@ -156,6 +157,7 @@ function bar(): MyClass {
 }
 
 class MyClass {} // looked up above
+
 function foo() {
   let myClassInstance: MyClass = mk(); // ok (no confusion across scopes)
   function mk() {

--- a/tests/flow/arith/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/arith/__snapshots__/jsfmt.spec.js.snap
@@ -134,20 +134,24 @@ function bar5(x: number, y?: ?number) {
 
 num(null + null); // === 0
 num(undefined + undefined); // === NaN
+
 num(null + 1); // === 1
 num(1 + null); // === 1
 num(undefined + 1); // === NaN
 num(1 + undefined); // === NaN
+
 num(null + true); // === 1
 num(true + null); // === 1
 num(undefined + true); // === NaN
 num(true + undefined); // === NaN
+
 str(\"foo\" + true); // error
 str(true + \"foo\"); // error
 str(\"foo\" + null); // error
 str(null + \"foo\"); // error
 str(\"foo\" + undefined); // error
 str(undefined + \"foo\"); // error
+
 let tests = [
   function(x: mixed, y: mixed) {
     x + y; // error
@@ -170,6 +174,7 @@ let tests = [
   function(x: any, y: number, z: string) {
     (x + y: string); // ok
     (y + x: string); // ok
+
     (x + z: empty); // error, string ~> empty
     (z + x: empty); // error, string ~> empty
   }
@@ -197,6 +202,7 @@ x **= 4;
 
 let y: string = \"123\";
 y **= 2; // error
+
 1 + 2 ** 3 + 4;
 2 ** 2;
 (-2) ** 2;
@@ -304,9 +310,11 @@ let tests = [
 ({ foo: 1 }) < { foo: 1 }; // error
 \"foo\" < { foo: 1 }; // error
 ({ foo: 1 }) < \"foo\"; // error
+
 var x = (null: ?number);
 1 < x; // 2 errors: null !~> number; undefined !~> number
 x < 1; // 2 errors: null !~> number; undefined !~> number
+
 null < null; // error
 undefined < null; // error
 null < undefined; // error

--- a/tests/flow/arraylib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/arraylib/__snapshots__/jsfmt.spec.js.snap
@@ -83,6 +83,7 @@ var k: Array<number> = h.concat(h);
 var l: Array<number> = h.concat(1, 2, 3);
 var m: Array<number | string> = h.concat(\"a\", \"b\", \"c\");
 var n: Array<number> = h.concat(\"a\", \"b\", \"c\"); // Error
+
 function reduce_test() {
   /* Adapted from the following source:
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce

--- a/tests/flow/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,7 @@ var ident = <T>(x: T): T => x;
 var add = (x: number, y: number): number => x + y;
 
 var bad = (x: number): string => x; // Error!
+
 var ident = <T>(x: T): T => x;
 (ident(1): number);
 (ident(\"hi\"): number); // Error

--- a/tests/flow/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/async/__snapshots__/jsfmt.spec.js.snap
@@ -337,6 +337,7 @@ function test2() {
   }
 
   var voidoid2: () => Promise<void> = voidoid1; // ok
+
   var voidoid3: () => void = voidoid1; // error, void != Promise<void>
 }
 

--- a/tests/flow/binding/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/binding/__snapshots__/jsfmt.spec.js.snap
@@ -49,6 +49,7 @@ const { foo } = { foo: \"foo\" };
 const [bar] = [\"bar\"];
 (foo: number); // error: string ~> number
 (bar: number); // error: string ~> number
+
 declare var bazzes: { baz: string }[];
 for (const { baz } of bazzes) {
   (baz: number); // error: string ~> number
@@ -872,10 +873,13 @@ function f5() {
 //
 
 var x: C; // ok
+
 var y = new C(); // error: let ref before decl from value position
+
 class C {}
 
 var z: C = new C(); // ok
+
 // --- vars ---
 
 // it\'s possible to annotate a var with a non-maybe type,
@@ -883,11 +887,13 @@ var z: C = new C(); // ok
 // initialized before use)
 
 var a: number; // not an error per se - only if used before init
+
 function f(n: number) {
   return n;
 }
 
 f(a); // error: undefined ~/> number
+
 a = 10;
 
 f(a); // ok, a: number (not ?number)

--- a/tests/flow/bom/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/bom/__snapshots__/jsfmt.spec.js.snap
@@ -74,19 +74,23 @@ const a: FormData = new FormData(); // correct
 new FormData(\"\"); // incorrect
 new FormData(document.createElement(\"input\")); // incorrect
 new FormData(document.createElement(\"form\")); // correct
+
 // has
 const b: boolean = a.has(\"foo\"); // correct
+
 // get
 const c: ?(string | File) = a.get(\"foo\"); // correct
 const d: string = a.get(\"foo\"); // incorrect
 const e: Blob = a.get(\"foo\"); // incorrect
 const f: ?(string | File | Blob) = a.get(\"foo\"); // incorrect
 a.get(2); // incorrect
+
 // getAll
 const a1: Array<string | File> = a.getAll(\"foo\"); // correct
 const a2: Array<string | File | number> = a.getAll(\"foo\"); // incorrect
 const a3: Array<string | Blob | File> = a.getAll(\"foo\"); // incorrect
 a.getAll(23); // incorrect
+
 // set
 a.set(\"foo\", \"bar\"); // correct
 a.set(\"foo\", {}); // incorrect
@@ -98,6 +102,7 @@ a.set(\"bar\", new File([], \"q\"), 2); // incorrect
 a.set(\"bar\", new Blob()); // correct
 a.set(\"bar\", new Blob(), \"x\"); // correct
 a.set(\"bar\", new Blob(), 2); // incorrect
+
 // append
 a.append(\"foo\", \"bar\"); // correct
 a.append(\"foo\", {}); // incorrect
@@ -110,19 +115,23 @@ a.append(\"bar\", new File([], \"q\"), 2); // incorrect
 a.append(\"bar\", new Blob()); // correct
 a.append(\"bar\", new Blob(), \"x\"); // correct
 a.append(\"bar\", new Blob(), 2); // incorrect
+
 // delete
 a.delete(\"xx\"); // correct
 a.delete(3); // incorrect
+
 // keys
 for (let x: string of a.keys()) {
 } // correct
 for (let x: number of a.keys()) {
 } // incorrect
+
 // values
 for (let x: string | File of a.values()) {
 } // correct
 for (let x: string | File | Blob of a.values()) {
 } // incorrect
+
 // entries
 for (let [x, y]: [string, string | File] of a.entries()) {
 } // correct
@@ -183,6 +192,7 @@ new MutationObserver(() => {}); // correct
 new MutationObserver(); // incorrect
 new MutationObserver(42); // incorrect
 new MutationObserver((n: number) => {}); // incorrect
+
 // observe
 const div = document.createElement(\"div\");
 o.observe(div, { attributes: true, attributeFilter: [\"style\"] }); // correct
@@ -193,8 +203,10 @@ o.observe(div); // incorrect
 o.observe(div, {}); // incorrect
 o.observe(div, { subtree: true }); // incorrect
 o.observe(div, { attributes: true, attributeFilter: true }); // incorrect
+
 // takeRecords
 o.takeRecords(); // correct
+
 // disconnect
 o.disconnect(); // correct
 "

--- a/tests/flow/builtins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/builtins/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,7 @@ var b = a.map(function(x) {
   return 0;
 });
 var c: string = b[0]; // error: number !~> string
+
 var array = [];
 function f() {
   array = array.map(function() {

--- a/tests/flow/call_properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/call_properties/__snapshots__/jsfmt.spec.js.snap
@@ -111,6 +111,7 @@ var f: { (): mixed } = function(): string {
   return \"hi\";
 }; // return type
 var g: { (x: string): void } = function(x: mixed) {}; // param type
+
 // A function can be an object
 var y: {} = function(x: number): string {
   return \"hi\";
@@ -312,6 +313,7 @@ var f: { (): mixed } = () => \"hi\"; // return type
 var g: { (x: Date): void } = x => {
   x * 2;
 }; // param type (date < number)
+
 // A function can be an object
 var y: {} = x => \"hi\";
 var z: Object = x => \"hi\";

--- a/tests/flow/callable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/callable/__snapshots__/jsfmt.spec.js.snap
@@ -52,12 +52,14 @@ foo(Boolean);
 
 var dict: { [k: string]: any } = {};
 dict(); // error, callable signature not found
+
 interface ICall {
   (x: string): void
 }
 declare var icall: ICall;
 icall(0); // error, number ~> string
 icall.call(null, 0); // error, number ~> string
+
 type Callable = {
   (x: string): void
 };

--- a/tests/flow/class_statics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/class_statics/__snapshots__/jsfmt.spec.js.snap
@@ -68,6 +68,7 @@ class A {
   static bar(y: string) {}
 }
 A.qux = function(x: string) {}; // error?
+
 class B extends A {
   static x: string; // error?
   static foo(x: string) {} // error?
@@ -100,6 +101,7 @@ class C<X> {
 class D extends C<string> {
   static main() {
     D.foo(0); // error?
+
     D.bar(0);
   }
 }

--- a/tests/flow/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/classes/__snapshots__/jsfmt.spec.js.snap
@@ -29,6 +29,7 @@ class B extends A {}
 
 let b = new B();
 (b.foo: number); // error, number !~> function
+
 module.exports = B;
 "
 `;
@@ -53,6 +54,7 @@ class C extends B {
 
 let c = new C();
 (c.foo: number); // error, number !~> function
+
 module.exports = C;
 "
 `;
@@ -125,9 +127,11 @@ x.a; // ok
 x.b; // error, TestClass has no b
 x.c; // ok
 x.d; // error, TestClass has no d
+
 var y: Foo = x;
 y.b; // error, doesn\'t exist in TestClass
 y.d; // ok, it\'s optional
+
 class Test2Superclass {
   a: number; // conflicts with cast to Foo
   c: ?number; // conflicts with cast to Foo
@@ -181,13 +185,16 @@ var Bar = class Foo {
 
 var bar1: Bar = new Bar(); // OK
 var bar2: Bar = Bar.factory(); // OK
+
 // NB: Don\'t write expected errors using Foo to avoid error collapse hiding an
 // unexpected failure in the above code.
 
 var B = class Baz {};
 var b = new Baz(); // error: Baz is not a runtime binding in this scope
+
 var C = class Qux {};
 var c: Qux = new C(); // error: Qux is not a type in this scope
+
 // OK: anon classes create no binding, but can be bound manually
 var Anon = class {};
 var anon: Anon = new Anon();
@@ -243,6 +250,7 @@ C.p = \"hi\";
 // Class static fields are compatible with object types
 (C: { p: string }); // ok
 (C: { p: number }); // errors, string ~> number & vice versa (unify)
+
 declare var o: { p: number };
 (o: Class<C>); // error, object type incompatible with class type
 "

--- a/tests/flow/closure/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/closure/__snapshots__/jsfmt.spec.js.snap
@@ -99,9 +99,12 @@ function global_g() {
 
 global_f();
 takes_string(global_x); // ok
+
 global_g();
 takes_string(global_x); // error
+
 global_x = 42; // shouldn\'t pollute linear refinement
+
 // local write from function
 //
 
@@ -115,8 +118,10 @@ function local_func() {
 
   local_f();
   takes_string(local_x); // ok
+
   local_g();
   takes_string(local_x); // error
+
   local_x = 42; // shouldn\'t pollute linear refinement
 }
 
@@ -134,9 +139,12 @@ var global_o = {
 
 global_o.f();
 takes_string(global_y); // ok
+
 global_o.g();
 takes_string(global_y); // error
+
 global_y = 42; // shouldn\'t pollute linear refinement
+
 // local write from method
 //
 
@@ -152,8 +160,10 @@ function local_meth() {
 
   local_o.f();
   takes_string(local_y); // ok
+
   local_o.g();
   takes_string(local_y); // error
+
   local_y = 42; // shouldn\'t pollute linear refinement
 }
 "

--- a/tests/flow/computed_props/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/computed_props/__snapshots__/jsfmt.spec.js.snap
@@ -42,7 +42,9 @@ var ColorIdToNumber = {
 };
 
 (ColorIdToNumber[ColorId.RED]: \"ffffff\"); // oops
+
 ColorIdToNumber.XXX; // oops
+
 module.exports = { ColorId, ColorNumber };
 "
 `;
@@ -67,6 +69,7 @@ var ColorIdToNumber = {
 };
 
 (ColorIdToNumber[ColorId.GREEN]: \"ffffff\"); // oops
+
 module.exports = ColorIdToNumber;
 "
 `;
@@ -133,6 +136,7 @@ var obj = {
   }
 };
 var x: string = obj[\"m\"](); // error, number ~> string
+
 var arr = [
   function() {
     return this.length;

--- a/tests/flow/config_module_name_rewrite_node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/config_module_name_rewrite_node/__snapshots__/jsfmt.spec.js.snap
@@ -33,6 +33,7 @@ var a_2: string = m1.numVal; // Error: number ~> string
 import { numVal } from \"./1DoesntExist\";
 var a_3: number = numVal;
 var a_4: string = numVal; // Error: number ~> string
+
 // This tests that, for node, the first name mapping that both matches *and*
 // results in a valid module filename is picked.
 var m2 = require(\"./2DoesntExist\");
@@ -41,6 +42,7 @@ var b_2: string = m2.numVal; // Error: number ~> string
 import { numVal as numVal2 } from \"./3DoesntExist\";
 var b_3: number = numVal2;
 var b_4: string = numVal2; // Error: number ~> string
+
 // node_modules/Exists/index.js
 var m3 = require(\"4DoesntExist\");
 var c_1: number = m3.numVal;

--- a/tests/flow/core_tests/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/core_tests/__snapshots__/jsfmt.spec.js.snap
@@ -269,6 +269,7 @@ ws.delete(dict);
 let ws2 = new WeakSet([obj, dict]);
 
 let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
+
 function* generator(): Iterable<{ foo: string }> {
   while (true) {
     yield { foo: \"bar\" };

--- a/tests/flow/covariance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/covariance/__snapshots__/jsfmt.spec.js.snap
@@ -53,6 +53,7 @@ type CovArrayVerbose<X, Y: X> = Array<Y>;
 var b: CovArrayVerbose<number, *> = [];
 var y: CovArrayVerbose<mixed, *> = b;
 y[0] = \"\"; // error
+
 class NVerbose<E, I: E> {
   x: CovArrayVerbose<E, I>;
   foo(): CovArrayVerbose<mixed, I> {

--- a/tests/flow/declaration_files_incremental_haste/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declaration_files_incremental_haste/__snapshots__/jsfmt.spec.js.snap
@@ -91,8 +91,10 @@ var ExplicitDifferentName = require(\'ExplicitProvidesModuleDifferentName\');
 
 var Implicit = require(\"ImplicitProvidesModule\");
 (Implicit.fun(): boolean); // Error: Either Implementation ~> boolean or Declaration ~> boolean
+
 var ExplicitSameName = require(\"ExplicitProvidesModuleSameName\");
 (ExplicitSameName.fun(): boolean); // Error: Either Implementation ~> boolean or Declaration ~> boolean
+
 var ExplicitDifferentName = require(\"ExplicitProvidesModuleDifferentName\");
 (ExplicitDifferentName.fun(): boolean); // Error: Either Implementation ~> boolean or Declaration ~> boolean
 "

--- a/tests/flow/declaration_files_incremental_node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declaration_files_incremental_node/__snapshots__/jsfmt.spec.js.snap
@@ -57,29 +57,40 @@ var F = require(\'package_with_dir_main\');
 // This will require ./node_modules/B.js.flow
 var B1 = require(\"B\");
 (B1.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 // This will require ./node_modules/B.js.flow
 var B2 = require(\"B.js\");
 (B2.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 var C = require(\"package_with_full_main\");
 (C.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 var D = require(\"package_with_partial_main\");
 (D.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 var E = require(\"package_with_no_package_json\");
 (E.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 var F = require(\"package_with_dir_main\");
 (F.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 // This will require ./node_modules/B.js.flow
 var B1 = require(\"B\");
 (B1.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 // This will require ./node_modules/B.js.flow
 var B2 = require(\"B.js\");
 (B2.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 var C = require(\"package_with_full_main\");
 (C.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 var D = require(\"package_with_partial_main\");
 (D.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 var E = require(\"package_with_no_package_json\");
 (E.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
 var F = require(\"package_with_dir_main\");
 (F.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
 "

--- a/tests/flow/declaration_files_node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declaration_files_node/__snapshots__/jsfmt.spec.js.snap
@@ -46,15 +46,20 @@ var F = require(\'package_with_dir_main\');
 // This will require ./node_modules/B.js.flow
 var B1 = require(\"B\");
 (B1.fun(): string); // Error number ~> string
+
 // This will require ./node_modules/B.js.flow
 var B2 = require(\"B.js\");
 (B2.fun(): string); // Error number ~> string
+
 var C = require(\"package_with_full_main\");
 (C.fun(): string); // Error number ~> string
+
 var D = require(\"package_with_partial_main\");
 (D.fun(): string); // Error number ~> string
+
 var E = require(\"package_with_no_package_json\");
 (E.fun(): string); // Error number ~> string
+
 var F = require(\"package_with_dir_main\");
 (F.fun(): string); // Error number ~> string
 "
@@ -80,9 +85,11 @@ var CJS = require(\'./CJS.js\');
 // This will require ./A.js.flow
 var A1 = require(\"./A\");
 (A1.fun(): string); // Error number ~> string
+
 // This will require ./A.js.flow
 var A2 = require(\"./A.js\");
 (A2.fun(): string); // Error number ~> string
+
 var CJS = require(\"./CJS.js\");
 (CJS: string);
 (CJS: number); // Error: string ~> number

--- a/tests/flow/declare_export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_export/__snapshots__/jsfmt.spec.js.snap
@@ -891,45 +891,56 @@ var at4: string = numberValue9; // Error: number ~> string
 import * as DefaultA from \"A\";
 var a1: number = DefaultA.numberValue1;
 var a2: string = DefaultA.numberValue1; // Error: number ~> string
+
 // File path
 import * as DefaultB from \"./B\";
 var b1: number = DefaultB.numberValue;
 var b2: string = DefaultB.numberValue; // Error: number ~> string
+
 // C.js exists, but not as a providesModule
 import DefaultC from \"C\"; // Error: No such module
+
 // @providesModule D exists, but not as a filename
 import DefaultD from \"./D\"; // Error: No such module
+
 // ================================================ //
 // == CommonJS Clobbering Literal Exports -> ES6 == //
 // ================================================ //
 
 import { doesntExist1 } from \"CommonJS_Clobbering_Lit\"; // Error: Not an exported binding
+
 import { numberValue1 } from \"CommonJS_Clobbering_Lit\";
 var c1: number = numberValue1;
 var c2: string = numberValue1; // Error: number ~> string
+
 import { numberValue2 as numVal1 } from \"CommonJS_Clobbering_Lit\";
 var d1: number = numVal1;
 var d2: string = numVal1; // Error: number ~> string
+
 import CJS_Clobb_Lit from \"CommonJS_Clobbering_Lit\";
 var e1: number = CJS_Clobb_Lit.numberValue3;
 var e2: string = CJS_Clobb_Lit.numberValue3; // Error: number ~> string
 CJS_Clobb_Lit.doesntExist; // Error: doesntExist isn\'t a property
+
 import * as CJS_Clobb_Lit_NS from \"CommonJS_Clobbering_Lit\";
 var f1: number = CJS_Clobb_Lit_NS.numberValue4;
 var f2: number = CJS_Clobb_Lit_NS.default.numberValue4;
 CJS_Clobb_Lit_NS.default.default; // Error: No \'default\' property on the exported obj
 var f3: string = CJS_Clobb_Lit_NS.numberValue4; // Error: number ~> string
 var f4: string = CJS_Clobb_Lit_NS.default.numberValue5; // Error: number ~> string
+
 // ============================================== //
 // == CommonJS Clobbering Class Exports -> ES6 == //
 // ============================================== //
 
 import { doesntExist2 } from \"CommonJS_Clobbering_Class\"; // Error: Not an exported binding
+
 // The following import should error because class statics are not turned into
 // named exports for now. This avoids complexities with polymorphic static
 // members (where the polymophism is defined on the class itself rather than the
 // method).
 import { staticNumber1, baseProp, childProp } from \"CommonJS_Clobbering_Class\"; // Error
+
 import CJS_Clobb_Class from \"CommonJS_Clobbering_Class\";
 new CJS_Clobb_Class();
 new CJS_Clobb_Class().doesntExist; // Error: Class has no \`doesntExist\` property
@@ -937,97 +948,123 @@ var h1: number = CJS_Clobb_Class.staticNumber2();
 var h2: string = CJS_Clobb_Class.staticNumber2(); // Error: number ~> string
 var h3: number = new CJS_Clobb_Class().instNumber1();
 var h4: string = new CJS_Clobb_Class().instNumber1(); // Error: number ~> string
+
 import * as CJS_Clobb_Class_NS from \"CommonJS_Clobbering_Class\";
 new CJS_Clobb_Class_NS(); // Error: Namespace object isn\'t constructable
 var i1: number = CJS_Clobb_Class_NS.staticNumber3(); // Error: Class statics not copied to Namespace object
 var i2: number = new CJS_Clobb_Class_NS.default().instNumber2();
 var i3: string = new CJS_Clobb_Class_NS.default().instNumber2(); // Error: number ~> string
+
 // =================================== //
 // == CommonJS Named Exports -> ES6 == //
 // =================================== //
 
 import { doesntExist3 } from \"CommonJS_Named\"; // Error: Not an exported binding
+
 import { numberValue2 } from \"CommonJS_Named\";
 var j1: number = numberValue2;
 var j2: string = numberValue2; // Error: number ~> string
+
 import { numberValue3 as numVal3 } from \"CommonJS_Named\";
 var k1: number = numVal3;
 var k2: string = numVal3; // Error: number ~> string
+
 import * as CJS_Named from \"CommonJS_Named\";
 var l1: number = CJS_Named.numberValue1;
 var l2: string = CJS_Named.numberValue1; // Error: number ~> string
 CJS_Named.doesntExist; // Error: doesntExist isn\'t a property
+
 import * as CJS_Named_NS from \"CommonJS_Named\";
 var m1: number = CJS_Named_NS.numberValue4;
 var m2: string = CJS_Named_NS.default.numberValue4; // Error: CommonJS_Named has no default export
 var m3: string = CJS_Named_NS.numberValue4; // Error: number ~> string
+
 //////////////////////////////
 // == ES6 Default -> ES6 == //
 //////////////////////////////
 
 import { doesntExist4 } from \"ES6_Default_AnonFunction1\"; // Error: Not an exported binding
+
 import ES6_Def_AnonFunc1 from \"ES6_Default_AnonFunction1\";
 var n1: number = ES6_Def_AnonFunc1();
 var n2: string = ES6_Def_AnonFunc1(); // Error: number ~> string
+
 import ES6_Def_NamedFunc1 from \"ES6_Default_NamedFunction1\";
 var o1: number = ES6_Def_NamedFunc1();
 var o2: string = ES6_Def_NamedFunc1(); // Error: number ~> string
+
 import ES6_Def_NamedClass1 from \"ES6_Default_NamedClass1\";
 var q1: number = new ES6_Def_NamedClass1().givesANum();
 var q2: string = new ES6_Def_NamedClass1().givesANum(); // Error: number ~> string
+
 ////////////////////////////
 // == ES6 Named -> ES6 == //
 ////////////////////////////
 
 import doesntExist5 from \"ES6_Named1\"; // Error: Not an exported binding
+
 import { specifierNumber1 as specifierNumber1_1 } from \"ES6_Named1\";
 var r1: number = specifierNumber1_1;
 var r2: string = specifierNumber1_1; // Error: number ~> string
+
 import { specifierNumber2Renamed } from \"ES6_Named1\";
 var s1: number = specifierNumber2Renamed;
 var s2: string = specifierNumber2Renamed; // Error: number ~> string
+
 import { specifierNumber3 as specifierNumber3Renamed } from \"ES6_Named1\";
 var t1: number = specifierNumber3Renamed;
 var t2: string = specifierNumber3Renamed; // Error: number ~> string
+
 import { groupedSpecifierNumber1, groupedSpecifierNumber2 } from \"ES6_Named1\";
 var u1: number = groupedSpecifierNumber1;
 var u2: number = groupedSpecifierNumber2;
 var u3: string = groupedSpecifierNumber1; // Error: number ~> string
 var u4: string = groupedSpecifierNumber2; // Error: number ~> string
+
 import { givesANumber } from \"ES6_Named1\";
 var v1: number = givesANumber();
 var v2: string = givesANumber(); // Error: number ~> string
+
 import { NumberGenerator } from \"ES6_Named1\";
 var w1: number = new NumberGenerator().givesANumber();
 var w2: string = new NumberGenerator().givesANumber(); // Error: number ~> string
+
 import { varDeclNumber1, varDeclNumber2 } from \"ES6_Named1\";
 var x1: number = varDeclNumber1;
 var x2: number = varDeclNumber2;
 var x3: string = varDeclNumber1; // Error: number ~> string
 var x4: string = varDeclNumber2; // Error: number ~> string
+
 import { numberValue1 as numberValue4 } from \"ES6_ExportFrom_Intermediary1\";
 var aa1: number = numberValue4;
 var aa2: string = numberValue4; // Error: number ~> string
+
 import { numberValue2_renamed } from \"ES6_ExportFrom_Intermediary1\";
 var ab1: number = numberValue2_renamed;
 var ab2: string = numberValue2_renamed; // Error: number ~> string
+
 import { numberValue1 as numberValue5 } from \"ES6_ExportAllFrom_Intermediary1\";
 var ac1: number = numberValue5;
 var ac2: string = numberValue5; // Error: number ~> string
+
 ///////////////////////////////////
 // == ES6 Default -> CommonJS == //
 ///////////////////////////////////
 
 require(\"ES6_Default_AnonFunction2\").doesntExist; // Error: \'doesntExist\' isn\'t an export
+
 var ES6_Def_AnonFunc2 = require(\"ES6_Default_AnonFunction2\").default;
 var ad1: number = ES6_Def_AnonFunc2();
 var ad2: string = ES6_Def_AnonFunc2(); // Error: number ~> string
+
 var ES6_Def_NamedFunc2 = require(\"ES6_Default_NamedFunction2\").default;
 var ae1: number = ES6_Def_NamedFunc2();
 var ae2: string = ES6_Def_NamedFunc2(); // Error: number ~> string
+
 var ES6_Def_NamedClass2 = require(\"ES6_Default_NamedClass2\").default;
 var ag1: number = new ES6_Def_NamedClass2().givesANum();
 var ag2: string = new ES6_Def_NamedClass2().givesANum(); // Error: number ~> string
+
 /////////////////////////////////
 // == ES6 Named -> CommonJS == //
 /////////////////////////////////
@@ -1035,38 +1072,47 @@ var ag2: string = new ES6_Def_NamedClass2().givesANum(); // Error: number ~> str
 var specifierNumber4 = require(\"ES6_Named2\").specifierNumber4;
 var ah1: number = specifierNumber4;
 var ah2: string = specifierNumber4; // Error: number ~> string
+
 var specifierNumber5Renamed = require(\"ES6_Named2\").specifierNumber5Renamed;
 var ai1: number = specifierNumber5Renamed;
 var ai2: string = specifierNumber5Renamed; // Error: number ~> string
+
 var groupedSpecifierNumber3 = require(\"ES6_Named2\").groupedSpecifierNumber3;
 var groupedSpecifierNumber4 = require(\"ES6_Named2\").groupedSpecifierNumber4;
 var aj1: number = groupedSpecifierNumber3;
 var aj2: number = groupedSpecifierNumber4;
 var aj3: string = groupedSpecifierNumber3; // Error: number ~> string
 var aj4: string = groupedSpecifierNumber4; // Error: number ~> string
+
 var givesANumber2 = require(\"ES6_Named2\").givesANumber2;
 var ak1: number = givesANumber2();
 var ak2: string = givesANumber2(); // Error: number ~> string
+
 var NumberGenerator2 = require(\"ES6_Named2\").NumberGenerator2;
 var al1: number = new NumberGenerator2().givesANumber();
 var al2: string = new NumberGenerator2().givesANumber(); // Error: number ~> string
+
 var varDeclNumber3 = require(\"ES6_Named2\").varDeclNumber3;
 var varDeclNumber4 = require(\"ES6_Named2\").varDeclNumber4;
 var am1: number = varDeclNumber3;
 var am2: number = varDeclNumber4;
 var am3: string = varDeclNumber3; // Error: number ~> string
 var am4: string = varDeclNumber4; // Error: number ~> string
+
 var numberValue6 = require(\"ES6_ExportFrom_Intermediary2\").numberValue1;
 var ap1: number = numberValue6;
 var ap2: string = numberValue6; // Error: number ~> string
+
 var numberValue2_renamed2 = require(
   \"ES6_ExportFrom_Intermediary2\"
 ).numberValue2_renamed2;
 var aq1: number = numberValue2_renamed2;
 var aq2: string = numberValue2_renamed2; // Error: number ~> string
+
 var numberValue7 = require(\"ES6_ExportAllFrom_Intermediary2\").numberValue2;
 var ar1: number = numberValue7;
 var ar2: string = numberValue7; // Error: number ~> string
+
 ////////////////////////////////////////////////////////
 // == ES6 Default+Named -> ES6 import Default+Named== //
 ////////////////////////////////////////////////////////
@@ -1075,8 +1121,10 @@ import defaultNum, { str as namedStr } from \"./ES6_DefaultAndNamed\";
 
 var as1: number = defaultNum;
 var as2: string = defaultNum; // Error: number ~> string
+
 var as3: string = namedStr;
 var as4: number = namedStr; // Error: string ~> number
+
 ////////////////////////////////////////
 // == Side-effect only ES6 imports == //
 ////////////////////////////////////////
@@ -1088,6 +1136,7 @@ import \"./SideEffects\";
 //////////////////////////////////////////////
 import specifierNumber1 from \"ES6_Named1\"; // Error: Did you mean \`import {specifierNumber1} from ...\`?
 import { specifierNumber } from \"ES6_Named1\"; // Error: Did you mean \`specifierNumber1\`?
+
 ///////////////////////////////////////////////////
 // == Multi \`export *\` should combine exports == //
 ///////////////////////////////////////////////////
@@ -1098,6 +1147,7 @@ import {
 
 var at1: number = numberValue8;
 var at2: string = numberValue8; // Error: number ~> string
+
 var at3: number = numberValue9;
 var at4: string = numberValue9; // Error: number ~> string
 "

--- a/tests/flow/declare_module_exports/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_module_exports/__snapshots__/jsfmt.spec.js.snap
@@ -30,12 +30,14 @@ import declare_m_e_with_declare_var_e from \"declare_m_e_with_declare_var_e\";
 import declare_module_exports from \"declare_module_exports\";
 (declare_module_exports: number);
 (declare_module_exports: string); // Error: number ~> string
+
 // Error: Has no named export \"str\"!
 import { str } from \"declare_m_e_with_other_value_declares\";
 
 import type { str2 } from \"declare_m_e_with_other_type_declares\";
 (\"asdf\": str2);
 (42: str2); // Error: number ~> string
+
 /**
  * \`declare var exports\` is deprecated, so we have a grace period where both
  * syntaxes will work.
@@ -44,6 +46,7 @@ import type { str2 } from \"declare_m_e_with_other_type_declares\";
 import DEPRECATED__declare_var_exports from \"DEPRECATED__declare_var_exports\";
 (DEPRECATED__declare_var_exports: number);
 (DEPRECATED__declare_var_exports: string); // Error: number ~> string
+
 import declare_m_e_with_declare_var_e from \"declare_m_e_with_declare_var_e\";
 (declare_m_e_with_declare_var_e: number);
 (declare_m_e_with_declare_var_e: string); // Error: number ~> string

--- a/tests/flow/declare_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_type/__snapshots__/jsfmt.spec.js.snap
@@ -42,8 +42,10 @@ import { foo } from \"ModuleAliasFoo\";
 var k1: baz = 42;
 var k2: baz = \"shab\"; // Error: string to int
 var k3: toz = foo(k1); // works
+
 import type { toz } from \"ModuleAliasFoo\";
 var k4: toz = foo(k1); // works
+
 //////////////////////////////////////////////////////////
 // == Declared Module with exports prop (issue 880) == //
 ////////////////////////////////////////////////////////
@@ -54,7 +56,9 @@ import type { Foo, Bar, Id } from \"foo\";
 blah(0, 0);
 
 ({ toz: 3 }: Foo); // error : {toz : number} ~> string
+
 (3: Bar); // error : number ~> A
+
 (\"lol\": Id<number>); // error : string ~> number
 "
 `;

--- a/tests/flow/def_site_variance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/def_site_variance/__snapshots__/jsfmt.spec.js.snap
@@ -55,6 +55,7 @@ class PropVariance<+Out, -In> {
   -co2: In; // ok
   +con1: Out; // ok
   +con2: In; // error
+
   inv_dict1: { [k: string]: Out }; // error
   inv_dict2: { [k: string]: In }; // error
   co_dict1: { +[k: string]: Out }; // ok

--- a/tests/flow/destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -17,10 +17,12 @@ let [a, ...ys] = xs;
 let [b, ...zs] = ys;
 let c = zs[0]; // retain tuple info
 let d = zs[1]; // run off the end
+
 (a: void); // error: number ~> void
 (b: void); // error: string ~> void
 (c: void); // error: boolean ~> void
 (d: void); // error: number|string|boolean ~> void
+
 let [...e] = 0;
 "
 `;
@@ -38,9 +40,11 @@ var { [\"key\"]: val3, ...spread } = { key: \"val\" };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var { [\"key\"]: val1 } = { key: \"val\" };
 (val1: void); // error: string ~> void
+
 var key: string = \"key\";
 var { [key]: val2 } = { key: \"val\" };
 (val2: void); // ok (gasp!) by existing StrT -> ElemT rule
+
 var { [\"key\"]: val3, ...spread } = { key: \"val\" };
 (spread.key: void); // error (gasp!) in general we don\'t know if a computed prop should be excluded from spread
 "
@@ -144,6 +148,7 @@ obj_prop_fun(); // ok
 obj_prop_fun({}); // ok
 obj_prop_fun({ p: {} }); // ok
 obj_prop_fun({ p: { q: null } }); // ok, provides add\'l lower bound
+
 function obj_prop_var(o = { p: { q: \"\" } }) {
   var { p: { q = 0 } = { q: true } } = o;
   // errors:
@@ -157,6 +162,7 @@ obj_prop_var(); // ok
 obj_prop_var({}); // ok
 obj_prop_var({ p: {} }); // ok
 obj_prop_var({ p: { q: null } }); // ok, provides add\'l lower bound
+
 function obj_rest(
   { p: { q, ...o } = { q: 0, r: 0 } } = { p: { q: 0, r: \"\" } }
 ) {
@@ -191,10 +197,12 @@ var {
   p: 0 // error: number ~> string
 };
 (p: void); // error: string ~> void
+
 function obj_prop_err({ x: { y } } = null) {} // error: property \`x\` cannot be accessed on null
 function obj_rest_err({ ...o } = 0) {} // error: expected object instead of number
 function arr_elem_err([x] = null) {} // error: element 0 cannot be accessed on null
 function arr_rest_err([...a] = null) {} // error: expected array instead of null
+
 function gen<T>(x: T, { p = x }: { p: T }): T {
   return p;
 }
@@ -202,6 +210,7 @@ function gen<T>(x: T, { p = x }: { p: T }): T {
 // Default values in destructuring unwrap optional types
 obj_prop_fun(({}: { p?: { q?: null } })); // ok
 obj_prop_var(({}: { p?: { q?: null } })); // ok
+
 // union-like upper bounds preserved through destructuring
 function obj_prop_opt({ p }: { p?: string } = { p: 0 }) {}
 function obj_prop_maybe({ p }: { p: ?string } = { p: 0 }) {}
@@ -353,6 +362,7 @@ var bp1: number = baseprop1;
 var bp1_err: string = baseprop1; // Error: number ~> string
 var bp2: number = others.baseprop2;
 var bp2_err: string = others.baseprop2; // Error: number ~> string
+
 var cp1: number = childprop1;
 var cp1_err: string = childprop1; // Error: number ~> string
 var cp2: number = others.childprop1;
@@ -436,14 +446,18 @@ function arr_rest_pattern<X>([ _, ...a ] : ArrRest<X>) { // a: [X]
 function obj_pattern<X>({ prop }: { prop: X }) {} // prop: X
 type Prop<X> = { prop: X };
 function obj_pattern2<X>({ prop }: Prop<X>) {} // prop: X
+
 function arr_pattern<X>([elem]: X[]) {} // elem: X
 type Elem<X> = X[];
 function arr_pattern2<X>([elem]: Elem<X>) {} // elem: X
+
 function tup_pattern<X>([proj]: [X]) {} // proj: X
 type Proj<X> = [X];
 function tup_pattern2<X>([proj]: Proj<X>) {} // proj: X
+
 function rest_antipattern<T>(...t: T) {} // nonsense
 function rest_pattern<X>(...r: X[]) {} // r: X[]
+
 function obj_rest_pattern<X>(
   { _, ...o }: { _: any, x: X } // o: { x: X }
 ) {
@@ -524,6 +538,7 @@ var { \"with-dash\": with_dash } = { \"with-dash\": \"motivating example\" };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var { key: val } = { key: \"val\" };
 (val: void); // error: string ~> void
+
 var { \"with-dash\": with_dash } = { \"with-dash\": \"motivating example\" };
 (with_dash: \"motivating example\"); // ok
 "

--- a/tests/flow/dictionary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/dictionary/__snapshots__/jsfmt.spec.js.snap
@@ -465,7 +465,9 @@ function unsound_string_conversion_alias_declared_prop(
 function unification_dict_values_invariant(x: Array<{ [k: string]: B }>) {
   let a: Array<{ [k: string]: A }> = x; // error
   a[0].p = new A(); // in[0].p no longer B
+
   let b: Array<{ [k: string]: B }> = x; // ok
+
   let c: Array<{ [k: string]: C }> = x; // error
   (x[0].p: C); // not true
 }
@@ -473,7 +475,9 @@ function unification_dict_values_invariant(x: Array<{ [k: string]: B }>) {
 function subtype_dict_values_invariant(x: { [k: string]: B }) {
   let a: { [k: string]: A } = x; // error
   a.p = new A(); // x[0].p no longer B
+
   let b: { [k: string]: B } = x; // ok
+
   let c: { [k: string]: C } = x; // error
   (x.p: C); // not true
 }
@@ -520,7 +524,9 @@ function unification_mix_with_declared_props_invariant_l(
 ) {
   let a: Array<{ [k: string]: B, p: A }> = x; // error: A ~> B
   a[0].p = new A(); // x[0].p no longer B
+
   let b: Array<{ [k: string]: B, p: B }> = x; // ok
+
   let c: Array<{ [k: string]: B, p: C }> = x; // error
   (x[0].p: C); // not true
 }
@@ -532,7 +538,9 @@ function unification_mix_with_declared_props_invariant_r(
 ) {
   let a: Array<{ [k: string]: A }> = xa; // error
   a[0].p = new A(); // xa[0].p no longer B
+
   let b: Array<{ [k: string]: B }> = xb; // ok
+
   let c: Array<{ [k: string]: C }> = xc; // error
   (xc[0].p: C); // not true
 }
@@ -540,7 +548,9 @@ function unification_mix_with_declared_props_invariant_r(
 function subtype_mix_with_declared_props_invariant_l(x: { [k: string]: B }) {
   let a: { [k: string]: B, p: A } = x; // error: A ~> B
   a.p = new A(); // x.p no longer B
+
   let b: { [k: string]: B, p: B } = x; // ok
+
   let c: { [k: string]: B, p: C } = x; // error
   (x.p: C); // not true
 }
@@ -552,7 +562,9 @@ function subtype_mix_with_declared_props_invariant_r(
 ) {
   let a: { [k: string]: A } = xa; // error
   a.p = new A(); // xa.p no longer B
+
   let b: { [k: string]: B } = xb; // ok
+
   let c: { [k: string]: C } = xc; // error
   (xc.p: C); // not true
 }
@@ -572,7 +584,9 @@ function unification_obj_to_dict(
 function subtype_dict_to_obj(x: { [k: string]: B }) {
   let a: { p: A } = x; // error
   a.p = new A(); // x.p no longer B
+
   let b: { p: B } = x; // ok
+
   let c: { p: C } = x; // error
   (x.p: C); // not true
 }
@@ -580,6 +594,7 @@ function subtype_dict_to_obj(x: { [k: string]: B }) {
 function subtype_obj_to_dict(x: { p: B }) {
   let a: { [k: string]: A } = x; // error
   a.p = new A(); // x.p no longer B
+
   let b: { [k: string]: B } = x;
 
   let c: { [k: string]: C } = x; // error
@@ -702,9 +717,11 @@ function foo8(x: {[key: string]: number}) {
 var x: { [key: string]: string } = {};
 var y: { [key: string]: number } = x; // 2 errors, number !~> string & vice versa
 var z: { [key: number]: string } = x; // 2 errors, string !~> number & vice versa
+
 var a: { [key: string]: ?string } = {};
 var b: { [key: string]: string } = a; // 2 errors (null & undefined)
 var c: { [key: string]: ?string } = b; // 2 errors, since c[\'x\'] = null updates b
+
 // 2 errors (number !~> string, string !~> number)
 function foo0(
   x: Array<{ [key: string]: number }>

--- a/tests/flow/dom/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/dom/__snapshots__/jsfmt.spec.js.snap
@@ -237,6 +237,7 @@ const r: string = c.username; // correct
 const a = new URL(\"http://flowtype.org/\"); // correct
 const b = new URL(\"/docs\", a); // correct
 const c = new URL(\"/docs\", \"http://flowtype.org/\"); // correct
+
 const d: URLSearchParams = c.searchParams; // correct
 const e: string = c.path; // not correct
 const f: string = c.pathname; // correct

--- a/tests/flow/encaps/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/encaps/__snapshots__/jsfmt.spec.js.snap
@@ -19,6 +19,7 @@ var s3 = tag2 \`la la la\`;
 class A {}
 var a = new A();
 var s1 = \`l\${a.x}r\`; // error: no prop x in A
+
 function tag(strings, ...values) {
   var x: number = strings[0]; // error: string ~> number
   return x;

--- a/tests/flow/equals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/equals/__snapshots__/jsfmt.spec.js.snap
@@ -20,6 +20,7 @@ var x = (null : ?number);
 null == 1;
 1 == \"\"; // error
 \"\" == 1; // error
+
 var x = (null: ?number);
 x == 1;
 1 == x;

--- a/tests/flow/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -996,45 +996,56 @@ import {typeAlias} from \"./ExportType\"; // Error: Cannot vanilla-import a type
 import * as DefaultA from \"A\";
 var a1: number = DefaultA.numberValue1;
 var a2: string = DefaultA.numberValue1; // Error: number ~> string
+
 // File path
 import * as DefaultB from \"./B\";
 var b1: number = DefaultB.numberValue;
 var b2: string = DefaultB.numberValue; // Error: number ~> string
+
 // C.js exists, but not as a providesModule
 import DefaultC from \"C\"; // Error: No such module
+
 // @providesModule D exists, but not as a filename
 import DefaultD from \"./D\"; // Error: No such module
+
 // ================================================ //
 // == CommonJS Clobbering Literal Exports -> ES6 == //
 // ================================================ //
 
 import { doesntExist1 } from \"CommonJS_Clobbering_Lit\"; // Error: Not an exported binding
+
 import { numberValue1 } from \"CommonJS_Clobbering_Lit\";
 var c1: number = numberValue1;
 var c2: string = numberValue1; // Error: number ~> string
+
 import { numberValue2 as numVal1 } from \"CommonJS_Clobbering_Lit\";
 var d1: number = numVal1;
 var d2: string = numVal1; // Error: number ~> string
+
 import CJS_Clobb_Lit from \"CommonJS_Clobbering_Lit\";
 var e1: number = CJS_Clobb_Lit.numberValue3;
 var e2: string = CJS_Clobb_Lit.numberValue3; // Error: number ~> string
 CJS_Clobb_Lit.doesntExist; // Error: doesntExist isn\'t a property
+
 import * as CJS_Clobb_Lit_NS from \"CommonJS_Clobbering_Lit\";
 var f1: number = CJS_Clobb_Lit_NS.numberValue4;
 var f2: number = CJS_Clobb_Lit_NS.default.numberValue4;
 CJS_Clobb_Lit_NS.default.default; // Error: No \'default\' property on the exported obj
 var f3: string = CJS_Clobb_Lit_NS.numberValue4; // Error: number ~> string
 var f4: string = CJS_Clobb_Lit_NS.default.numberValue5; // Error: number ~> string
+
 // ============================================== //
 // == CommonJS Clobbering Class Exports -> ES6 == //
 // ============================================== //
 
 import { doesntExist2 } from \"CommonJS_Clobbering_Class\"; // Error: Not an exported binding
+
 // The following import should error because class statics are not turned into
 // named exports for now. This avoids complexities with polymorphic static
 // members (where the polymophism is defined on the class itself rather than the
 // method).
 import { staticNumber1, baseProp, childProp } from \"CommonJS_Clobbering_Class\"; // Error
+
 import CJS_Clobb_Class from \"CommonJS_Clobbering_Class\";
 new CJS_Clobb_Class();
 new CJS_Clobb_Class().doesntExist; // Error: Class has no \`doesntExist\` property
@@ -1042,109 +1053,139 @@ var h1: number = CJS_Clobb_Class.staticNumber2();
 var h2: string = CJS_Clobb_Class.staticNumber2(); // Error: number ~> string
 var h3: number = new CJS_Clobb_Class().instNumber1();
 var h4: string = new CJS_Clobb_Class().instNumber1(); // Error: number ~> string
+
 import * as CJS_Clobb_Class_NS from \"CommonJS_Clobbering_Class\";
 new CJS_Clobb_Class_NS(); // Error: Namespace object isn\'t constructable
 var i1: number = CJS_Clobb_Class_NS.staticNumber3(); // Error: Class statics not copied to Namespace object
 var i2: number = new CJS_Clobb_Class_NS.default().instNumber2();
 var i3: string = new CJS_Clobb_Class_NS.default().instNumber2(); // Error: number ~> string
+
 // =================================== //
 // == CommonJS Named Exports -> ES6 == //
 // =================================== //
 
 import { doesntExist3 } from \"CommonJS_Named\"; // Error: Not an exported binding
+
 import { numberValue2 } from \"CommonJS_Named\";
 var j1: number = numberValue2;
 var j2: string = numberValue2; // Error: number ~> string
+
 import { numberValue3 as numVal3 } from \"CommonJS_Named\";
 var k1: number = numVal3;
 var k2: string = numVal3; // Error: number ~> string
+
 import * as CJS_Named from \"CommonJS_Named\";
 var l1: number = CJS_Named.numberValue1;
 var l2: string = CJS_Named.numberValue1; // Error: number ~> string
 CJS_Named.doesntExist; // Error: doesntExist isn\'t a property
+
 import * as CJS_Named_NS from \"CommonJS_Named\";
 var m1: number = CJS_Named_NS.numberValue4;
 var m2: string = CJS_Named_NS.default.numberValue4; // Error: CommonJS_Named has no default export
 var m3: string = CJS_Named_NS.numberValue4; // Error: number ~> string
+
 //////////////////////////////
 // == ES6 Default -> ES6 == //
 //////////////////////////////
 
 import { doesntExist4 } from \"ES6_Default_AnonFunction1\"; // Error: Not an exported binding
+
 import ES6_Def_AnonFunc1 from \"ES6_Default_AnonFunction1\";
 var n1: number = ES6_Def_AnonFunc1();
 var n2: string = ES6_Def_AnonFunc1(); // Error: number ~> string
+
 import ES6_Def_NamedFunc1 from \"ES6_Default_NamedFunction1\";
 var o1: number = ES6_Def_NamedFunc1();
 var o2: string = ES6_Def_NamedFunc1(); // Error: number ~> string
+
 import ES6_Def_AnonClass1 from \"ES6_Default_AnonClass1\";
 var p1: number = new ES6_Def_AnonClass1().givesANum();
 var p2: string = new ES6_Def_AnonClass1().givesANum(); // Error: number ~> string
+
 import ES6_Def_NamedClass1 from \"ES6_Default_NamedClass1\";
 var q1: number = new ES6_Def_NamedClass1().givesANum();
 var q2: string = new ES6_Def_NamedClass1().givesANum(); // Error: number ~> string
+
 ////////////////////////////
 // == ES6 Named -> ES6 == //
 ////////////////////////////
 
 import doesntExist5 from \"ES6_Named1\"; // Error: Not an exported binding
+
 import { specifierNumber1 as specifierNumber1_1 } from \"ES6_Named1\";
 var r1: number = specifierNumber1_1;
 var r2: string = specifierNumber1_1; // Error: number ~> string
+
 import { specifierNumber2Renamed } from \"ES6_Named1\";
 var s1: number = specifierNumber2Renamed;
 var s2: string = specifierNumber2Renamed; // Error: number ~> string
+
 import { specifierNumber3 as specifierNumber3Renamed } from \"ES6_Named1\";
 var t1: number = specifierNumber3Renamed;
 var t2: string = specifierNumber3Renamed; // Error: number ~> string
+
 import { groupedSpecifierNumber1, groupedSpecifierNumber2 } from \"ES6_Named1\";
 var u1: number = groupedSpecifierNumber1;
 var u2: number = groupedSpecifierNumber2;
 var u3: string = groupedSpecifierNumber1; // Error: number ~> string
 var u4: string = groupedSpecifierNumber2; // Error: number ~> string
+
 import { givesANumber } from \"ES6_Named1\";
 var v1: number = givesANumber();
 var v2: string = givesANumber(); // Error: number ~> string
+
 import { NumberGenerator } from \"ES6_Named1\";
 var w1: number = new NumberGenerator().givesANumber();
 var w2: string = new NumberGenerator().givesANumber(); // Error: number ~> string
+
 import { varDeclNumber1, varDeclNumber2 } from \"ES6_Named1\";
 var x1: number = varDeclNumber1;
 var x2: number = varDeclNumber2;
 var x3: string = varDeclNumber1; // Error: number ~> string
 var x4: string = varDeclNumber2; // Error: number ~> string
+
 import { destructuredObjNumber } from \"ES6_Named1\";
 var y1: number = destructuredObjNumber;
 var y2: string = destructuredObjNumber; // Error: number ~> string
+
 import { destructuredArrNumber } from \"ES6_Named1\";
 var z1: number = destructuredArrNumber;
 var z2: string = destructuredArrNumber; // Error: number ~> string
+
 import { numberValue1 as numberValue4 } from \"ES6_ExportFrom_Intermediary1\";
 var aa1: number = numberValue4;
 var aa2: string = numberValue4; // Error: number ~> string
+
 import { numberValue2_renamed } from \"ES6_ExportFrom_Intermediary1\";
 var ab1: number = numberValue2_renamed;
 var ab2: string = numberValue2_renamed; // Error: number ~> string
+
 import { numberValue1 as numberValue5 } from \"ES6_ExportAllFrom_Intermediary1\";
 var ac1: number = numberValue5;
 var ac2: string = numberValue5; // Error: number ~> string
+
 ///////////////////////////////////
 // == ES6 Default -> CommonJS == //
 ///////////////////////////////////
 
 require(\"ES6_Default_AnonFunction2\").doesntExist; // Error: \'doesntExist\' isn\'t an export
+
 var ES6_Def_AnonFunc2 = require(\"ES6_Default_AnonFunction2\").default;
 var ad1: number = ES6_Def_AnonFunc2();
 var ad2: string = ES6_Def_AnonFunc2(); // Error: number ~> string
+
 var ES6_Def_NamedFunc2 = require(\"ES6_Default_NamedFunction2\").default;
 var ae1: number = ES6_Def_NamedFunc2();
 var ae2: string = ES6_Def_NamedFunc2(); // Error: number ~> string
+
 var ES6_Def_AnonClass2 = require(\"ES6_Default_AnonClass2\").default;
 var af1: number = new ES6_Def_AnonClass2().givesANum();
 var af2: string = new ES6_Def_AnonClass2().givesANum(); // Error: number ~> string
+
 var ES6_Def_NamedClass2 = require(\"ES6_Default_NamedClass2\").default;
 var ag1: number = new ES6_Def_NamedClass2().givesANum();
 var ag2: string = new ES6_Def_NamedClass2().givesANum(); // Error: number ~> string
+
 /////////////////////////////////
 // == ES6 Named -> CommonJS == //
 /////////////////////////////////
@@ -1152,44 +1193,55 @@ var ag2: string = new ES6_Def_NamedClass2().givesANum(); // Error: number ~> str
 var specifierNumber4 = require(\"ES6_Named2\").specifierNumber4;
 var ah1: number = specifierNumber4;
 var ah2: string = specifierNumber4; // Error: number ~> string
+
 var specifierNumber5Renamed = require(\"ES6_Named2\").specifierNumber5Renamed;
 var ai1: number = specifierNumber5Renamed;
 var ai2: string = specifierNumber5Renamed; // Error: number ~> string
+
 var groupedSpecifierNumber3 = require(\"ES6_Named2\").groupedSpecifierNumber3;
 var groupedSpecifierNumber4 = require(\"ES6_Named2\").groupedSpecifierNumber4;
 var aj1: number = groupedSpecifierNumber3;
 var aj2: number = groupedSpecifierNumber4;
 var aj3: string = groupedSpecifierNumber3; // Error: number ~> string
 var aj4: string = groupedSpecifierNumber4; // Error: number ~> string
+
 var givesANumber2 = require(\"ES6_Named2\").givesANumber2;
 var ak1: number = givesANumber2();
 var ak2: string = givesANumber2(); // Error: number ~> string
+
 var NumberGenerator2 = require(\"ES6_Named2\").NumberGenerator2;
 var al1: number = new NumberGenerator2().givesANumber();
 var al2: string = new NumberGenerator2().givesANumber(); // Error: number ~> string
+
 var varDeclNumber3 = require(\"ES6_Named2\").varDeclNumber3;
 var varDeclNumber4 = require(\"ES6_Named2\").varDeclNumber4;
 var am1: number = varDeclNumber3;
 var am2: number = varDeclNumber4;
 var am3: string = varDeclNumber3; // Error: number ~> string
 var am4: string = varDeclNumber4; // Error: number ~> string
+
 var destructuredObjNumber2 = require(\"ES6_Named2\").destructuredObjNumber2;
 var an1: number = destructuredObjNumber2;
 var an2: string = destructuredObjNumber2; // Error: number ~> string
+
 var destructuredArrNumber2 = require(\"ES6_Named2\").destructuredArrNumber2;
 var ao1: number = destructuredArrNumber2;
 var ao2: string = destructuredArrNumber2; // Error: number ~> string
+
 var numberValue6 = require(\"ES6_ExportFrom_Intermediary2\").numberValue1;
 var ap1: number = numberValue6;
 var ap2: string = numberValue6; // Error: number ~> string
+
 var numberValue2_renamed2 = require(
   \"ES6_ExportFrom_Intermediary2\"
 ).numberValue2_renamed2;
 var aq1: number = numberValue2_renamed2;
 var aq2: string = numberValue2_renamed2; // Error: number ~> string
+
 var numberValue7 = require(\"ES6_ExportAllFrom_Intermediary2\").numberValue2;
 var ar1: number = numberValue7;
 var ar2: string = numberValue7; // Error: number ~> string
+
 ////////////////////////////////////////////////////////
 // == ES6 Default+Named -> ES6 import Default+Named== //
 ////////////////////////////////////////////////////////
@@ -1198,8 +1250,10 @@ import defaultNum, { str as namedStr } from \"./ES6_DefaultAndNamed\";
 
 var as1: number = defaultNum;
 var as2: string = defaultNum; // Error: number ~> string
+
 var as3: string = namedStr;
 var as4: number = namedStr; // Error: string ~> number
+
 ////////////////////////////////////////
 // == Side-effect only ES6 imports == //
 ////////////////////////////////////////
@@ -1211,6 +1265,7 @@ import \"./SideEffects\";
 //////////////////////////////////////////////
 import specifierNumber1 from \"ES6_Named1\"; // Error: Did you mean \`import {specifierNumber1} from ...\`?
 import { specifierNumber } from \"ES6_Named1\"; // Error: Did you mean \`specifierNumber1\`?
+
 ///////////////////////////////////////////////////
 // == Multi \`export *\` should combine exports == //
 ///////////////////////////////////////////////////
@@ -1221,8 +1276,10 @@ import {
 
 var at1: number = numberValue8;
 var at2: string = numberValue8; // Error: number ~> string
+
 var at3: number = numberValue9;
 var at4: string = numberValue9; // Error: number ~> string
+
 /////////////////////////////////////////////////////////////
 // == Vanilla \`import\` cannot import a type-only export == //
 /////////////////////////////////////////////////////////////
@@ -1293,21 +1350,27 @@ function testRequires() {
 // CommonJS module
 import * as DefaultA from \"A\";
 DefaultA.numberValue1 = 123; // Error: DefaultA is frozen
+
 // ES6 module
 import * as ES6_Named1 from \"ES6_Named1\";
 ES6_Named1.varDeclNumber1 = 123; // Error: ES6_Named1 is frozen
+
 // CommonJS module that clobbers module.exports
 import * as CommonJS_Star from \"CommonJS_Clobbering_Lit\";
 CommonJS_Star.numberValue1 = 123; // Error: frozen
 CommonJS_Star.default.numberValue1 = 123; // ok
+
 import CommonJS_Clobbering_Lit from \"CommonJS_Clobbering_Lit\";
 CommonJS_Clobbering_Lit.numberValue1 = 123; // ok
+
 // CommonJS module that clobbers module.exports with a frozen object
 import * as CommonJS_Frozen_Star from \"CommonJS_Clobbering_Frozen\";
 CommonJS_Frozen_Star.numberValue1 = 123; // Error: frozen
 CommonJS_Frozen_Star.default.numberValue1 = 123; // Error: frozen
+
 import CommonJS_Clobbering_Frozen from \"CommonJS_Clobbering_Frozen\";
 CommonJS_Clobbering_Frozen.numberValue1 = 123; // Error: exports are frozen
+
 //
 // Requires
 //
@@ -1316,12 +1379,15 @@ function testRequires() {
   // CommonJS module
   var DefaultA = require(\"A\");
   DefaultA.numberValue1 = 123; // ok, not frozen by default
+
   // ES6 module
   var ES6_Named1 = require(\"ES6_Named1\");
   ES6_Named1.numberValue = 123; // error, es6 exports are frozen
+
   // CommonJS module that clobbers module.exports
   var CommonJS_Star = require(\"CommonJS_Clobbering_Lit\");
   CommonJS_Star.numberValue1 = 123; // ok, not frozen by default
+
   // CommonJS module that clobbers module.exports with a frozen object
   var CommonJS_Frozen_Star = require(\"CommonJS_Clobbering_Frozen\");
   CommonJS_Frozen_Star.numberValue1 = 123; // Error: frozen

--- a/tests/flow/es_declare_module/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/es_declare_module/__snapshots__/jsfmt.spec.js.snap
@@ -51,6 +51,7 @@ import CJS_Named from \"CJS_Named\";
 (str1: number); // Error: string ~> number
 (CJS_Named: { num1: number, str1: string });
 (CJS_Named: number); // Error: Module ~> number
+
 import { num2 } from \"CJS_Clobbered\"; // Error: No such export!
 import { numExport } from \"CJS_Clobbered\";
 (numExport: number);
@@ -58,23 +59,28 @@ import { numExport } from \"CJS_Clobbered\";
 import type { numType } from \"CJS_Clobbered\";
 (42: numType);
 (\"asdf\": numType); // Error: string ~> number
+
 import { strHidden } from \"ES\"; // Error: No such export!
 import { str3 } from \"ES\";
 (str3: string);
 (str3: number); // Error: string ~> number
+
 import { num3 } from \"ES\";
 (num3: number);
 (num3: string); // Error: number ~> string
+
 import { C } from \"ES\";
 import type { C as CType } from \"ES\";
 (new C(): C);
 (42: C); // Error: number ~> C
 (new C(): CType);
 (42: CType); // Error: number ~> CType
+
 import { T } from \"ES\"; // Error: T is a type import, not a value
 import type { T as T2 } from \"ES\";
 (42: T2);
 (\"asdf\": T2); // Error: string ~> number
+
 import { exports as nope } from \"ES\"; // Error: Not an export
 "
 `;

--- a/tests/flow/esproposal_export_star_as.enable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/esproposal_export_star_as.enable/__snapshots__/jsfmt.spec.js.snap
@@ -15,6 +15,7 @@ import { source } from \"./test\";
 
 var a: number = source.num;
 var b: string = source.num; // Error: num ~> string
+
 var c: string = source.str;
 var d: number = source.str; // Error: num ~> string
 "

--- a/tests/flow/esproposal_export_star_as.ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/esproposal_export_star_as.ignore/__snapshots__/jsfmt.spec.js.snap
@@ -15,6 +15,7 @@ import { source } from \"./test\";
 
 var a: number = source.num;
 var b: string = source.num; // Error: num ~> string
+
 var c: string = source.str;
 var d: number = source.str; // Ignored error: num ~> string
 "

--- a/tests/flow/export_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/export_type/__snapshots__/jsfmt.spec.js.snap
@@ -60,19 +60,25 @@ import type {
 
 var a: inlinedType1 = 42;
 var b: inlinedType1 = \"asdf\"; // Error: string ~> number
+
 var c: standaloneType1 = 42;
 var d: standaloneType1 = \"asdf\"; // Error: string ~> number
+
 var e: talias1 = 42;
 var f: talias1 = \"asdf\"; // Error: string ~> number
+
 var g: talias3 = 42;
 var h: talias3 = \"asdf\"; // Error: string ~> number
+
 import type { talias4 } from \"./cjs_with_types\";
 var i: talias4 = 42;
 var j: talias4 = \"asdf\"; // Error: string ~> number
+
 import { IFoo, IFoo2 } from \"./types_only\";
 
 var k: IFoo = { prop: 42 };
 var l: IFoo = { prop: \"asdf\" }; // Error: {prop:string} ~> {prop:number}
+
 var m: IFoo2 = { prop: \"asdf\" };
 var n: IFoo2 = { prop: 42 }; // Error: {prop:number} ~> {prop:string}
 "
@@ -100,11 +106,13 @@ export interface IFoo { prop: number };
 export type inlinedType1 = number;
 var a: inlinedType1 = 42;
 var b: inlinedType1 = \"asdf\"; // Error: string ~> number
+
 type standaloneType1 = number;
 export type { standaloneType1 };
 
 type standaloneType2 = number;
 export { standaloneType2 }; // Error: Missing \`type\` keyword
+
 export type { talias1, talias2 as talias3, IFoo2 } from \"./types_only2\";
 
 export interface IFoo { prop: number }

--- a/tests/flow/fetch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/fetch/__snapshots__/jsfmt.spec.js.snap
@@ -35,6 +35,7 @@ const myRequest = new Request(\"http://google.com\");
 const a: Promise<string> = fetch(myRequest).then(response => response.text());
 
 const b: Promise<string> = fetch(myRequest); // incorrect
+
 var myInit = {
   method: \"GET\",
   headers: {
@@ -45,6 +46,7 @@ var myInit = {
 };
 
 const c: Promise<Blob> = fetch(\"image.png\").then(response => response.blob()); // correct
+
 const d: Promise<Blob> = fetch(\"image.png\"); // incorrect
 "
 `;
@@ -92,9 +94,12 @@ e.append({ \"Content-Type\", \"image/jpeg\" }); // not correct
 e.set(\"Content-Type\", \"image/jpeg\"); // correct
 e.set(\"Content-Type\"); // not correct
 e.set({ \"Content-Type\", \"image/jpeg\" }); // not correct
+
 const f: Headers = e.append(\"Content-Type\", \"image/jpeg\"); // not correct
+
 const g: string = e.get(\"Content-Type\"); // correct
 const h: number = e.get(\"Content-Type\"); // not correct
+
 for (let v of e) {
   const [i, j]: [string, string] = v; // correct
 }
@@ -166,8 +171,10 @@ const b: Request = new Request(\"http://example.org\"); // correct
 const c: Request = new Request(b); // correct
 const d: Request = new Request(c.clone()); // correct (doesn\'t make much sense though)
 const e: Request = new Request(b, c); // incorrect
+
 const f: Request = new Request({}); // incorrect
 const g: Request = new Request(\"http://example.org\", {}); // correct
+
 const h: Request = new Request(\"http://example.org\", {
   method: \"GET\",
   headers: {
@@ -176,6 +183,7 @@ const h: Request = new Request(\"http://example.org\", {
   mode: \"cors\",
   cache: \"default\"
 }); // correct
+
 const i: Request = new Request(\"http://example.org\", {
   method: \"POST\",
   headers: {
@@ -185,12 +193,14 @@ const i: Request = new Request(\"http://example.org\", {
   mode: \"cors\",
   cache: \"default\"
 }); // correct
+
 const j: Request = new Request(\"http://example.org\", {
   method: \"GET\",
   headers: \"Content-Type: image/jpeg\",
   mode: \"cors\",
   cache: \"default\"
 }); // incorrect - headers is string
+
 const k: Request = new Request(\"http://example.org\", {
   method: \"CONNECT\",
   headers: {
@@ -199,6 +209,7 @@ const k: Request = new Request(\"http://example.org\", {
   mode: \"cors\",
   cache: \"default\"
 }); // incorrect - CONNECT is forbidden
+
 var l: boolean = h.bodyUsed;
 
 h.text().then((t: string) => t); // correct
@@ -260,34 +271,41 @@ h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
 const a: Response = new Response(); // correct
 const b: Response = new Response(new Blob()); // correct
 const c: Response = new Response(new FormData()); // correct
+
 const d: Response = new Response(new FormData(), {
   status: 404
 }); // correct
+
 const e: Response = new Response(\"responsebody\", {
   status: \"404\"
 }); // incorrect
+
 const f: Response = new Response(\"responsebody\", {
   status: 404,
   headers: \"\'Content-Type\': \'image/jpeg\'\"
 }); // incorrect
+
 const g: Response = new Response(\"responsebody\", {
   status: 404,
   headers: {
     \"Content-Type\": \"image/jpeg\"
   }
 }); // correct
+
 const h: Response = new Response(\"responsebody\", {
   status: 404,
   headers: new Headers({
     \"Content-Type\": \"image/jpeg\"
   })
 }); // correct, if verbose
+
 const i: Response = new Response({
   status: 404,
   headers: new Headers({
     \"Content-Type\": \"image/jpeg\"
   })
 }); // incorrect
+
 const ok: boolean = h.ok;
 const status: number = h.status;
 
@@ -341,9 +359,12 @@ e.append({ \"key1\", \"value1\" }); // not correct
 e.set(\"key1\", \"value1\"); // correct
 e.set(\"key1\"); // not correct
 e.set({ \"key1\", \"value1\" }); // not correct
+
 const f: URLSearchParams = e.append(\"key1\", \"value1\"); // not correct
+
 const g: string = e.get(\"key1\"); // correct
 const h: number = e.get(\"key1\"); // not correct
+
 for (let v of e) {
   const [i, j]: [string, string] = v; // correct
 }

--- a/tests/flow/function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/function/__snapshots__/jsfmt.spec.js.snap
@@ -51,11 +51,14 @@ test.apply(\"\", [\"\", 0]);
 
 // wrong this is an error
 test.apply(0, [\"\", 0]); // error: lookup \`length\` on Number
+
 // not enough arguments is an error (via incompatible RestT)
 test.apply(\"\", [\"\"]); // error: string ~> number
+
 // mistyped arguments is an error
 test.apply(\"\", [\"\", \"\"]); // error: string ~> number (2nd arg)
 test.apply(\"\", [0, 0]); // error: number ~> string (1st arg)
+
 // resolve args array from tvar
 function f(args) {
   test.apply(\"\", args);
@@ -63,8 +66,10 @@ function f(args) {
 f([\"\", 0]); // OK
 f([\"\", \"\"]); // error: string ~> number (2nd arg)
 f([0, 0]); // error: number ~> string (1st arg)
+
 // expect array
 test.apply(\"\", \"not array\"); // error: expect array of args
+
 // expect 4 errors:
 // - lookup length on Number (because 0 is used as \`this\`)
 // - 123 is not a string
@@ -157,11 +162,14 @@ test.call(\"\", \"\", 0);
 
 // wrong this is an error
 test.call(0, \"\", 0); // error: lookup \`length\` on Number
+
 // not enough arguments is an error (via incompatible RestT)
 test.call(\"\", \"\"); // error: string ~> number
+
 // mistyped arguments is an error
 test.call(\"\", \"\", \"\"); // error: string ~> number (2nd arg)
 test.call(\"\", 0, 0); // error: number ~> string (1st arg)
+
 // resolve args array from tvar
 function f(args) {
   test.call(\"\", args[0], args[1]);
@@ -169,6 +177,7 @@ function f(args) {
 f([\"\", 0]); // OK
 f([\"\", \"\"]); // error: string ~> number (2nd arg)
 f([0, 0]); // error: number ~> string (1st arg)
+
 // expect 3 errors:
 // - lookup length on Number (0 used as \`this\`)
 // - number !~> string (param a)
@@ -293,6 +302,7 @@ let tests = [
     (x.length: void); // error, it\'s a number
     (y.length: void); // error, it\'s a number
     (z.length: void); // error, it\'s a number
+
     (x.name: void); // error, it\'s a string
     (y.name: void); // error, it\'s a string
     (z.name: void); // error, it\'s a string
@@ -302,9 +312,11 @@ let tests = [
     x.length = \"foo\"; // error, it\'s a number
     y.length = \"foo\"; // error, it\'s a number
     z.length = \"foo\"; // error, it\'s a number
+
     x.name = 123; // error, it\'s a string
     y.name = 123; // error, it\'s a string
     z.name = 123; // error, it\'s a string
+
     // Non-(Function.prototype) properties on a \`Function\` type should be \`any\`
     (z.foo: number);
     (z.foo: string);

--- a/tests/flow/generators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/generators/__snapshots__/jsfmt.spec.js.snap
@@ -229,6 +229,7 @@ var examples = new GeneratorExamples();
 for (var x of examples.infer_stmt()) {
   (x: string);
 } // error: number ~> string
+
 var infer_stmt_next = examples.infer_stmt().next(0).value; // error: number ~> boolean
 if (typeof infer_stmt_next === \"undefined\") {
 } else if (typeof infer_stmt_next === \"number\") {
@@ -255,6 +256,7 @@ for (var x of examples.delegate_yield_generator()) {
 }
 
 examples.delegate_next_iterable([]).next(\"\"); // error: Iterator has no next value
+
 for (var x of examples.delegate_yield_iterable([])) {
   (x: string); // error: number ~> string
 }
@@ -297,7 +299,9 @@ var examples = new GeneratorExamples();
 for (var x of examples.infer_stmt()) {
   (x: string);
 } // error: number ~> string
+
 var infer_stmt_next = examples.infer_stmt().next(0).value; // error: number ~> boolean
+
 if (typeof infer_stmt_next === \"undefined\") {
 } else if (typeof infer_stmt_next === \"number\") {
 } else {
@@ -533,6 +537,7 @@ function* delegate_next_iterable(xs: Array<number>) {
   yield* xs;
 }
 delegate_next_iterable([]).next(\"\"); // error: Iterator has no next value
+
 function* delegate_yield_iterable(xs: Array<number>) {
   yield* xs;
 }

--- a/tests/flow/get-def2/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/get-def2/__snapshots__/jsfmt.spec.js.snap
@@ -44,13 +44,16 @@ var Parent = require(\"./Parent\");
 let ParentFoo;
 ({ ParentFoo } = Parent);
 ParentFoo; // Points to lval in line above this
+
 // Follows assignment on simple/\"non-destructuring\" patterns
 let ParentFoo2;
 ParentFoo2 = Parent;
 ParentFoo2; // Points to LHS of line above this
+
 // Follows assignment with declaration
 let ParentFoo3 = Parent;
 ParentFoo3; // Points to LHS of line above this
+
 // Follows non-destructured property access of \`require(\'Parent\')\`
 let foo = require(\"./Parent\").ParentFoo.foo;
 foo;

--- a/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
@@ -97,6 +97,7 @@ class Foo {
     return 4;
   }
   set propWithMismatchingGetterAndSetter(x: string) {} // doesn\'t match getter (OK)
+
   propOverriddenWithGetter: number;
   get propOverriddenWithGetter() {
     return \"hello\";
@@ -114,6 +115,7 @@ var testGetterNoError2: number = foo.goodGetterWithAnnotation;
 
 var testGetterWithError1: string = foo.goodGetterNoAnnotation; // Error number ~> string
 var testGetterWithError2: string = foo.goodGetterWithAnnotation; // Error number ~> string
+
 // Test setting properties with getters
 foo.goodSetterNoAnnotation = 123;
 foo.goodSetterWithAnnotation = 123;
@@ -121,7 +123,9 @@ foo.goodSetterWithAnnotation = 123;
 // TODO: Why does no annotation mean no error?
 foo.goodSetterNoAnnotation = \"hello\"; // Error string ~> number
 foo.goodSetterWithAnnotation = \"hello\"; // Error string ~> number
+
 var testSubtypingGetterAndSetter: number = foo.propWithSubtypingGetterAndSetter; // Error ?number ~> number
+
 var testPropOverridenWithGetter: number = foo.propOverriddenWithGetter; // Error string ~> number
 foo.propOverriddenWithSetter = 123; // Error number ~> string
 "
@@ -241,17 +245,21 @@ var testGetterNoError2: number = obj.goodGetterWithAnnotation;
 
 var testGetterWithError1: string = obj.goodGetterNoAnnotation; // Error number ~> string
 var testGetterWithError2: string = obj.goodGetterWithAnnotation; // Error number ~> string
+
 // Test setting properties with getters
 obj.goodSetterNoAnnotation = 123;
 obj.goodSetterWithAnnotation = 123;
 
 obj.goodSetterNoAnnotation = \"hello\"; // Error string ~> number
 obj.goodSetterWithAnnotation = \"hello\"; // Error string ~> number
+
 var testSubtypingGetterAndSetter: number = obj.propWithSubtypingGetterAndSetter; // Error ?number ~> number
+
 // When building this feature, it was tempting to flow the setter into the
 // getter and then use either the getter or setter as the type of the property.
 // This example shows the danger of using the getter\'s type
 obj.exampleOfOrderOfGetterAndSetter = new C(); // Error C ~> B
+
 // And this example shows the danger of using the setter\'s type.
 var testExampleOrOrderOfGetterAndSetterReordered: number = obj.exampleOfOrderOfGetterAndSetterReordered; // Error A ~> B
 "

--- a/tests/flow/import_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/import_type/__snapshots__/jsfmt.spec.js.snap
@@ -274,6 +274,7 @@ import { foo1Inst } from \"./ExportDefault_Class\";
 var a1: ClassFoo1 = foo1Inst;
 var a2: number = foo1Inst; // Error: ClassFoo1 ~> number
 new ClassFoo1(); // Error: ClassFoo1 is not a value-identifier
+
 ///////////////////////////////////////////////
 // == Importing Class Type (Named Export) == //
 ///////////////////////////////////////////////
@@ -284,6 +285,7 @@ import { foo2Inst } from \"./ExportNamed_Class\";
 var b1: ClassFoo2 = foo2Inst;
 var b2: number = foo2Inst; // Error: ClassFoo2 ~> number
 new ClassFoo2(); // Error: ClassFoo2 is not a value-identifier
+
 /////////////////////////////////////////////////////
 // == Importing Class Type (CJS Default Export) == //
 /////////////////////////////////////////////////////
@@ -292,6 +294,7 @@ import type ClassFoo3T from \"./ExportCJSDefault_Class\";
 import ClassFoo3 from \"./ExportCJSDefault_Class\";
 var c1: ClassFoo3T = new ClassFoo3();
 new ClassFoo3T(); // Error: ClassFoo3 is not a value-identifier
+
 ///////////////////////////////////////////////////
 // == Importing Class Type (CJS Named Export) == //
 ///////////////////////////////////////////////////
@@ -304,6 +307,7 @@ var d2: number = foo4Inst; // Error: ClassFoo4 ~> number
 new ClassFoo4(); // Error: ClassFoo4 is not a value-identifier
 // TODO: this errors correctly, but the message is just \'can\'t resolve name\'
 var d3: typeof ClassFoo5 = foo5Inst; // Error: Can\'t typeof a type alias
+
 ////////////////////////////////////////////
 // == Import Type Alias (Named Export) == //
 ////////////////////////////////////////////
@@ -313,6 +317,7 @@ import { givesAFoo3Obj } from \"./ExportNamed_Alias\";
 var e1: AliasFoo3 = givesAFoo3Obj();
 var e2: number = givesAFoo3Obj(); // Error: AliasFoo3 ~> number
 var e3: typeof AliasFoo3 = givesAFoo3Obj(); // Error: Can\'t typeof a type alias
+
 //////////////////////////////////////////////
 // == Import Type Alias (Default Export) == //
 //////////////////////////////////////////////
@@ -326,6 +331,7 @@ var e3: typeof AliasFoo3 = givesAFoo3Obj(); // Error: Can\'t typeof a type alias
 ///////////////////////////////////////////////////////
 
 import type { numValue } from \"./ExportsANumber\"; // Error: Cannot import-type a number value
+
 ////////////////////////////////////////////////////////////////////////
 // == Regression Test: https://github.com/facebook/flow/issues/359 == //
 // Ensure that type bindings stay type bindings across function body  //

--- a/tests/flow/import_typeof/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/import_typeof/__snapshots__/jsfmt.spec.js.snap
@@ -305,6 +305,7 @@ import ClassFoo1 from \"./ExportDefault_Class\";
 var a1: ClassFoo1T = ClassFoo1;
 var a2: ClassFoo1T = new ClassFoo1(); // Error: ClassFoo1 (inst) ~> ClassFoo1 (class)
 new ClassFoo1T(); // Error: ClassFoo1T is not bound to a value
+
 /////////////////////////////////////////////////
 // == Importing Class Typeof (Named Export) == //
 /////////////////////////////////////////////////
@@ -315,6 +316,7 @@ import { ClassFoo2 } from \"./ExportNamed_Class\";
 var b1: ClassFoo2T = ClassFoo2;
 var b2: ClassFoo2T = new ClassFoo2(); // Error: ClassFoo2 (inst) ~> ClassFoo2 (class)
 new ClassFoo2T(); // Error: ClassFoo2T is not bound to a value
+
 ///////////////////////////////////////////////////////
 // == Importing Class Typeof (CJS Default Export) == //
 ///////////////////////////////////////////////////////
@@ -324,6 +326,7 @@ import ClassFoo3 from \"./ExportCJSDefault_Class\";
 
 var c1: ClassFoo3T = ClassFoo3;
 var c2: ClassFoo3T = new ClassFoo3(); // Error: ClassFoo3 (inst) ~> ClassFoo3 (class)
+
 /////////////////////////////////////////////////////
 // == Importing Class Typeof (CJS Named Export) == //
 /////////////////////////////////////////////////////
@@ -333,11 +336,13 @@ import { ClassFoo4 } from \"./ExportCJSNamed_Class\";
 
 var d1: ClassFoo4T = ClassFoo4;
 var d2: ClassFoo4T = new ClassFoo4(); // Error: ClassFoo4 (inst) ~> ClassFoo4 (class)
+
 //////////////////////////////////////////////
 // == Import Typeof Alias (Named Export) == //
 //////////////////////////////////////////////
 
 import typeof { AliasFoo3 } from \"./ExportNamed_Alias\"; // Error: Can\'t \`import typeof\` type aliases!
+
 ////////////////////////////////////////////////
 // == Import Typeof Alias (Default Export) == //
 ////////////////////////////////////////////////
@@ -354,6 +359,7 @@ import typeof num_default from \"./ExportDefault_Number\";
 
 var f1: num_default = 42;
 var f2: num_default = \"asdf\"; // Error: string ~> number
+
 /////////////////////////////////////////////////////////////
 // == Import Typeof With Non-Class Value (Named Export) == //
 /////////////////////////////////////////////////////////////
@@ -362,6 +368,7 @@ import typeof { num as num_named } from \"./ExportNamed_Number\";
 
 var g1: num_named = 42;
 var g2: num_named = \"asdf\"; // Error: string ~> number
+
 ///////////////////////////////////////////////////////////////////
 // == Import Typeof With Non-Class Value (CJS Default Export) == //
 ///////////////////////////////////////////////////////////////////
@@ -370,6 +377,7 @@ import typeof num_cjs_default from \"./ExportCJSDefault_Number\";
 
 var h1: num_cjs_default = 42;
 var h2: num_cjs_default = \"asdf\"; // Error: string ~> number
+
 /////////////////////////////////////////////////////////////////
 // == Import Typeof With Non-Class Value (CJS Named Export) == //
 /////////////////////////////////////////////////////////////////
@@ -378,6 +386,7 @@ import typeof { num as num_cjs_named } from \"./ExportCJSNamed_Number\";
 
 var i1: num_cjs_named = 42;
 var i2: num_cjs_named = \"asdf\"; // Error: string ~> number
+
 ///////////////////////////////////////////////
 // == Import Typeof ModuleNamespaceObject == //
 ///////////////////////////////////////////////

--- a/tests/flow/interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/interface/__snapshots__/jsfmt.spec.js.snap
@@ -53,6 +53,7 @@ var x: string = new C().x;
 interface I { x: number }
 
 var i = new I(); // error
+
 function testInterfaceName(o: I) {
   (o.name: string); // error, name is static
   (o.constructor.name: string); // ok
@@ -130,6 +131,7 @@ function foo(l: L) {
   l.y;
   l.z;
 } // error: z not found in L
+
 // interface + multiple inheritance is similar to object type + intersection
 type M = { y: string } & J & { z: boolean };
 
@@ -173,6 +175,7 @@ new C().bar((x: string) => { }); // error, number ~/~> string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface I { foo(x: number): void }
 (function foo(x: number) {}: I); // error, property \`foo\` not found function
+
 declare class C {
   bar(i: I): void,
   bar(f: (x: number) => void): void

--- a/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -223,6 +223,7 @@ var b: B = a;
 // intersection of dictionary types:
 declare var c: C;
 var d: D = c; // ok
+
 // dict type mismatch
 type E = { [key: string]: string };
 var e: E = c; // error

--- a/tests/flow/iterable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/iterable/__snapshots__/jsfmt.spec.js.snap
@@ -265,6 +265,7 @@ exports[`test variance.js 1`] = `
 /* @flow */
 
 (([]: Array<string>): Iterable<?string>); // ok, Iterable<+T>
+
 (([]: Array<string>).values(): Iterable<?string>); // ok, Iterator<+T>
 "
 `;

--- a/tests/flow/jsx_intrinsics.builtin/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/jsx_intrinsics.builtin/__snapshots__/jsfmt.spec.js.snap
@@ -33,6 +33,7 @@ class CustomComponent extends React.Component {
 
 var a: React.Element<{ prop: string }> = <CustomComponent prop=\"asdf\" />;
 var b: React.Element<{ prop1: string }> = <CustomComponent prop=\"asdf\" />; // Error: Props<{prop}> ~> Props<{prop1}>
+
 // Since intrinsics are typed as \`any\` out of the box, we can pass any
 // attributes to intrinsics!
 var c: React.Element<any> = <div not_a_real_attr=\"asdf\" />;
@@ -79,8 +80,10 @@ var Str: string = \"str\";
 <Div />; /* This is fine*/
 <Bad />; /* This is fine*/
 <Str />; // This is fine
+
 React.createElement(\"div\", {}); // This is fine
 React.createElement(\"bad\", {}); /* This is fine*/
+
 <Div id={42} />; // This is fine
 "
 `;

--- a/tests/flow/jsx_intrinsics.custom/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/jsx_intrinsics.custom/__snapshots__/jsfmt.spec.js.snap
@@ -31,6 +31,7 @@ var a: React.Element<{ prop: string }> = <CustomComponent prop=\"asdf\" />;
 var b: React.Element<{ prop1: string }> = (
   <CustomComponent prop=\"asdf\" />
 ); /* Error: Props<{prop}> ~> Props<{prop1}>*/
+
 <div id=\"asdf\" />;
 <div id={42} />; // Error: (\`id\` prop) number ~> string
 var c: React.Element<{ id: string }> = <div id=\"asdf\" />;
@@ -69,9 +70,11 @@ var Str: string = \"str\";
 <Div />; /* This is fine*/
 <Bad />; /* Error: \'bad\' not in JSXIntrinsics*/
 <Str />; // Error: string ~> keys of JSXIntrinsics
+
 React.createElement(\"div\", {}); // This is fine
 React.createElement(\"bad\", {}); // Error: \'bad\' not in JSXIntrinsics
 React.createElement(Str, {}); /* Error: string ~> keys of JSXIntrinsics*/
+
 /* TODO: Make this an error*/
 <Div id={42} />; // Not an error but should be eventually
 "

--- a/tests/flow/keys/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/keys/__snapshots__/jsfmt.spec.js.snap
@@ -53,6 +53,7 @@ function testKeysOfObject(str: string, lit: \"hi\") {
     (str: $Keys<Object>); // No error, truthy string should be fine
   }
   (\"hi\": $Keys<Object>); // String literal should be fine
+
   (123: $Keys<Object>); // Error: number -> keys of Object
 }
 
@@ -63,6 +64,7 @@ function testKeysOfStrDict(str: string, lit: \"hi\") {
     (str: $Keys<StrDict>); // No error, truthy string should be fine
   }
   (\"hi\": $Keys<StrDict>); // String literal should be fine
+
   (123: $Keys<StrDict>); // Error: number -> keys of StrDict
 }
 
@@ -74,6 +76,7 @@ function testKeysOfStrLitDict(str: string, lit: \"hi\") {
   }
   (\"hi\": $Keys<StrLitDict>); // The right string literal is allowed
   (\"bye\": $Keys<StrLitDict>); // Error: The wrong string literal is not allowed
+
   (123: $Keys<StrLitDict>); // Error: number -> keys of StrLitDict
 }
 
@@ -84,6 +87,7 @@ function testKeysOfOtherObj(str: string, lit: \"hi\") {
     (str: $Keys<ObjLit>); // Error: truthy string -> keys of ObjLit
   }
   (\"hi\": $Keys<ObjLit>); // String literal should be fine
+
   (123: $Keys<ObjLit>); // Error: number -> keys of ObjLit
 }
 "

--- a/tests/flow/last_duplicate_property_wins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/last_duplicate_property_wins/__snapshots__/jsfmt.spec.js.snap
@@ -70,6 +70,7 @@ class C {
 (new C().x: boolean); // last wins
 (new C().bar: boolean); // last wins
 (new C().qux: boolean); // weird outlier where last doesn\'t win in classes
+
 // Objects
 
 const o = {

--- a/tests/flow/literal/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/literal/__snapshots__/jsfmt.spec.js.snap
@@ -44,14 +44,18 @@ var APIKeys = require(\"./enum\");
 function foo(x: $Keys<typeof APIKeys>) {}
 foo(\"AGE\");
 foo(\"LOCATION\"); // error
+
 function bar(x: $Keys<{ age: number }>) {}
 bar(APIKeys.AGE); // not an error: APIKeys.AGE = \"age\"
 bar(APIKeys.NAME); // error: since \"NAME\" is not in the smaller enum
+
 var object = {};
 object[APIKeys.AGE] = 123; // i.e., object.age = 123
 object[APIKeys.NAME] = \"FOO\"; // i.e., object.name = \"FOO\"
+
 var age: number = object[APIKeys.AGE];
 var name: number = object[APIKeys.NAME]; // error: object.name is a string
+
 var indices = { red: 0, green: 1, blue: 2 };
 var tuple = [42, \"hello\", false];
 var red: string = tuple[indices.red]; // error: tuple[0] is a number

--- a/tests/flow/method_properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/method_properties/__snapshots__/jsfmt.spec.js.snap
@@ -52,6 +52,7 @@ C.bar.x;
 import { Foo } from \"./exports_optional_prop\";
 const foo = new Foo();
 (foo.bar(): string); // error, could be undefined
+
 function f(x) {
   (x.bar(): string); // error. caused by \`f(foo)\`; annotate x to track it down.
 }

--- a/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,7 @@ var app = require(\"JSX\");
 
 app.setProps({ y: 42 }); // error, y:number but foo expects string in App.react
 app.setState({ z: 42 }); // error, z:number but foo expects string in App.react
+
 function bar(x: number) {}
 bar(app.props.children); // No error, App doesn\'t specify propTypes so anything goes
 "

--- a/tests/flow/name_prop/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/name_prop/__snapshots__/jsfmt.spec.js.snap
@@ -15,6 +15,7 @@ class A {}
 var test1 = A.bar; // Error bar doesn\'t exist
 var test2: string = A.name;
 var test3: number = A.name; // Error string ~> number
+
 var a = new A();
 var test4 = a.constructor.bar; // Error bar doesn\'t exist
 var test5: string = a.constructor.name;

--- a/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
@@ -513,6 +513,7 @@ var C = React.createClass({
 });
 
 <C statistics={[{}, { label: \"\", value: undefined }]} />; // error (label is required, value not required)
+
 var props: Array<{ label: string, value?: number }> = [
   {},
   { label: \"\", value: undefined }
@@ -566,6 +567,7 @@ var TestProps = React.createClass({
 });
 
 var element = <TestProps x={false} y={false} z={false} />; // 3 errors
+
 (element: $jsx<*>);
 (element: $jsx<TestProps>);
 var FooProps = React.createClass({
@@ -917,6 +919,7 @@ var TestState = React.createClass({
   },
   test: function() {
     var a: number = this.state.x; // error
+
     this.setState({
       x: false // error
     });

--- a/tests/flow/node_tests/crypto/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/crypto/__snapshots__/jsfmt.spec.js.snap
@@ -65,6 +65,7 @@ let tests = [
     hmac.update(\"foo\", \"bogus\"); // 1 error
     hmac.update(buf);
     hmac.update(buf, \"utf8\"); // 1 error: no encoding when passing a buffer
+
     // it\'s also chainable
     (hmac.update(\"some data to hash\").update(buf).digest(): Buffer);
 

--- a/tests/flow/node_tests/fs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/fs/__snapshots__/jsfmt.spec.js.snap
@@ -57,10 +57,13 @@ fs.readFile(\"file.exp\", {}, (_, data) => {
 
 (fs.readFileSync(\"file.exp\"): Buffer);
 (fs.readFileSync(\"file.exp\"): string); // error
+
 (fs.readFileSync(\"file.exp\", \"blah\"): string);
 (fs.readFileSync(\"file.exp\", \"blah\"): Buffer); // error
+
 (fs.readFileSync(\"file.exp\", { encoding: \"blah\" }): string);
 (fs.readFileSync(\"file.exp\", { encoding: \"blah\" }): Buffer); // error
+
 (fs.readFileSync(\"file.exp\", {}): Buffer);
 (fs.readFileSync(\"file.exp\", {}): string); // error
 "

--- a/tests/flow/node_tests/json_file/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/json_file/__snapshots__/jsfmt.spec.js.snap
@@ -29,13 +29,17 @@ let data = require(\"./package/index.json\");
 (data.foo: void); // error, should be object literal
 (data.foo.bar: void); // error, should be boolean
 (data.abc: boolean); // error, should be ?string
+
 let data2 = require(\"./package\");
 (data2.baz: void); // error, should be string
+
 let data3 = require(\"./package2\");
 (data3.foo: void); // error, should be number (not string! index.js wins)
+
 let data4 = require(\"./json_array\");
 (data4: Array<number>);
 (data4: void); // error, should be Array<number>
+
 (require(\"./json_string\"): void); // error, should be string
 (require(\"./json_number\"): void); // error, should be number
 (require(\"./json_true\"): void); // error, should be true

--- a/tests/flow/node_tests/os/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/os/__snapshots__/jsfmt.spec.js.snap
@@ -22,9 +22,11 @@ var os = require(\"os\");
 var u1 = os.userInfo();
 (u1.username: string);
 (u1.username: Buffer); // error
+
 var u2 = os.userInfo({ encoding: \"utf8\" });
 (u2.username: string);
 (u2.username: Buffer); // error
+
 var u3 = os.userInfo({ encoding: \"buffer\" });
 (u3.username: string); // error
 (u3.username: Buffer);

--- a/tests/flow/nullable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/nullable/__snapshots__/jsfmt.spec.js.snap
@@ -48,6 +48,7 @@ function corge(x: number) {}
 var x = bar(); // x: ?string
 if (x != null) qux(x); // x: ?string | null
 if (x != null) corge(x); // x: ?string | null
+
 function grault() {
   x = null;
 }

--- a/tests/flow/object-method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object-method/__snapshots__/jsfmt.spec.js.snap
@@ -128,6 +128,7 @@ function bar(f: () => void) {
 }
 
 bar(foo); // error, since \`this\` is used non-trivially in \`foo\`
+
 function qux(o: { f(): void }) {
   o.f(); // passing o as \`this\`
 }

--- a/tests/flow/object_api/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_api/__snapshots__/jsfmt.spec.js.snap
@@ -65,6 +65,7 @@ var decl_export_: { foo: any, bar: any } = Object.assign({}, export_);
 
 let anyObj: Object = {};
 Object.assign(anyObj, anyObj); // makes sure this terminates
+
 module.exports = export_;
 "
 `;
@@ -176,6 +177,7 @@ class Bar extends Foo {
 var sealed = { one: \"one\", two: \"two\" };
 (Object.keys(sealed): Array<\"one\" | \"two\">);
 (Object.keys(sealed): void); // error, Array<string>
+
 var unsealed = {};
 Object.keys(unsealed).forEach(k => {
   (k: number); // error: number ~> string
@@ -188,12 +190,14 @@ Object.keys(dict).forEach(k => {
 
 var any: Object = {};
 (Object.keys(any): Array<number>); // error, Array<string>
+
 class Foo {
   prop: string;
   foo() {}
 }
 // constructor and foo not enumerable
 (Object.keys(new Foo()): Array<\"error\">); // error: prop ~> error
+
 class Bar extends Foo {
   bar_prop: string;
   bar() {}
@@ -416,6 +420,7 @@ var y = new Foo();
 // call
 takesAString(a.toString());
 d.toString(); // ok, even though dict specifies strings, this is a function
+
 // get
 var aToString: () => string = a.toString;
 var aToString2 = a.toString;
@@ -448,6 +453,7 @@ takesAString(y.toString());
 (123).toString(2);
 (123).toString(\"foo\"); // error
 (123).toString(null); // error
+
 //
 // hasOwnProperty
 //

--- a/tests/flow/object_assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_assign/__snapshots__/jsfmt.spec.js.snap
@@ -88,6 +88,7 @@ var good: number = A.Good.foo();
 
 var f = A.Bad.foo; // Property access is fine
 var bad_: number = f(); // Calling the function is fine
+
 var bad: number = A.Bad.foo(); // Method call is not fine
 /*
 B.js|12 col 1 error|  call of method foo

--- a/tests/flow/object_freeze/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_freeze/__snapshots__/jsfmt.spec.js.snap
@@ -24,7 +24,9 @@ var xx : { x: number } = Object.freeze({ x: \"error\" })
 
 var foo = Object.freeze({ bar: \"12345\" });
 foo.bar = \"23456\"; // error
+
 Object.assign(foo, { bar: \"12345\" }); // error
+
 var baz = { baz: 12345 };
 var bliffl = Object.freeze({ bar: \"12345\", ...baz });
 bliffl.bar = \"23456\"; // error
@@ -32,6 +34,7 @@ bliffl.baz = 3456; // error
 bliffl.corge; // error
 bliffl.constructor = baz; // error
 bliffl.toString = function() {}; // error
+
 baz.baz = 0;
 
 var x: number = Object.freeze(123);

--- a/tests/flow/objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/objects/__snapshots__/jsfmt.spec.js.snap
@@ -29,6 +29,7 @@ var z = Object(123); // error (next line makes this not match any signatures)
 (Object(undefined): {});
 (Object(void 0): {});
 (Object(undefined): Number); // error
+
 var x = Object(null);
 x.foo = \"bar\";
 
@@ -72,9 +73,11 @@ x[\"123\"] = false; // error, boolean !~> string
 x[123] = false; // TODO: use the number\'s value to error here
 x[\"foo\" + \"bar\"] = \"derp\"; // ok since we can\'t tell
 (x[\`foo\`]: string); // error, key doesn\'t exist
+
 var y: { foo: string } = { foo: \"bar\" };
 y[\"foo\"] = 123; // error, number !~> string
 y[\"bar\"] = \"abc\"; // error, property not found
+
 (y[\"hasOwnProperty\"]: string); // error, prototype method is not a string
 "
 `;

--- a/tests/flow/objmap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/objmap/__snapshots__/jsfmt.spec.js.snap
@@ -28,6 +28,7 @@ var o = keyMirror({
 
 (o.FOO: \"FOO\"); // ok
 (o.FOO: \"BAR\"); // error, \'FOO\' incompatible with \'BAR\'
+
 promiseAllByKey({
   foo: Promise.resolve(0),
   bar: \"bar\"

--- a/tests/flow/optional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/optional/__snapshots__/jsfmt.spec.js.snap
@@ -298,6 +298,7 @@ bar(undefined); // ok
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function foo(x?: number) {}
 foo(undefined); // ok
+
 function bar(x = \"bar\"): string {
   return x;
 }
@@ -328,6 +329,7 @@ function foo(x?: number, ...y: Array<string>): [?number, Array<string>] {
 
 foo(); // OK
 foo(123), foo(123, \"hello\"); // OK // OK
+
 foo(true); // ERROR boolean ~> number
 foo(123, true); // ERROR boolean ~> string
 "

--- a/tests/flow/optional_props/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/optional_props/__snapshots__/jsfmt.spec.js.snap
@@ -14,11 +14,13 @@ bar({foo: \"\"});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var x: {} = { foo: 0 };
 var y: { foo?: string } = x; // OK in TypeScript, not OK in Flow
+
 var z: string = y.foo || \"\";
 
 var o = {};
 y = o; // OK; we know that narrowing could not have happened
 o.foo = 0; // future widening is constrained
+
 function bar(config: { foo?: number }) {}
 bar({});
 bar({ foo: \"\" });
@@ -43,11 +45,14 @@ var f: { foo?: ?string } = { foo: null }; // Also fine
 var a: { foo?: string } = {};
 a.foo = undefined; // This is not an error
 a.foo = null; // But this is an error
+
 var b: { foo?: ?string } = {};
 b.foo = undefined; // This is fine
 b.foo = null; // Also fine
+
 var c: { foo?: string } = { foo: undefined }; // This is not an error
 var d: { foo?: string } = { foo: null }; // But this is an error
+
 var e: { foo?: ?string } = { foo: undefined }; // This is fine
 var f: { foo?: ?string } = { foo: null }; // Also fine
 "

--- a/tests/flow/overload/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/overload/__snapshots__/jsfmt.spec.js.snap
@@ -74,9 +74,11 @@ var a = new C();
 a.foo(0); // ok
 a.foo(\"hey\"); // ok
 a.foo(true); // error, function cannot be called on intersection type
+
 a.bar({ a: 0 }); // ok
 a.bar({ a: \"hey\" }); // ok
 a.bar({ a: true }); // error, function cannot be called on intersection type
+
 declare var x: { a: boolean } & { b: string };
 
 a.bar(x); // error with nested intersection info (outer for bar, inner for x)
@@ -164,12 +166,14 @@ declare function f(x: string): void;
 declare function f(x: number): void;
 declare var x_f: string | number;
 f(x_f); // ok
+
 // maybe
 declare function g(x: null): void;
 declare function g(x: void): void;
 declare function g(x: string): void;
 declare var x_g: ?string;
 g(x_g); // ok
+
 // optional
 declare function h(x: void): void;
 declare function h(x: string): void;

--- a/tests/flow/parse_error_haste/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/parse_error_haste/__snapshots__/jsfmt.spec.js.snap
@@ -20,6 +20,7 @@ var C = require(\"./ParseError\"); // Flow file
 // non-flow files should not show parse errors
 var A = require(\"Foo\"); // non-Flow file @providesModule Foo
 var B = require(\"./NoProvides\"); // non-Flow file
+
 var C = require(\"./ParseError\"); // Flow file
 "
 `;

--- a/tests/flow/parse_error_node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/parse_error_node/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,7 @@ var B = require(\"./ParseError\");        // Flow file
 
 // non-flow files should not give parse errors
 var A = require(\"./Imported\"); // non-Flow file @providesModule Foo
+
 var B = require(\"./ParseError\"); // Flow file
 "
 `;

--- a/tests/flow/poly/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/poly/__snapshots__/jsfmt.spec.js.snap
@@ -14,6 +14,7 @@ function bar(): A<*> { // error, * can\'t be {} and {x: string} at the same time
 class A<X> {}
 new A(); // OK, implicitly inferred type args
 class B extends A {} // OK, same as above
+
 function foo(
   b
 ): A<any> { // ok but unsafe, caller may assume any type arg

--- a/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
@@ -54,6 +54,7 @@ Promise.all([
   (a: number); // Error: string ~> number
   (b: boolean); // Error: number ~> boolean
   (c: string); // Error: boolean ~> string
+
   // array element type is (string | number | boolean)
   xs.forEach(x => {
     (x: void); // Errors: string ~> void, number ~> void, boolean ~> void
@@ -62,8 +63,10 @@ Promise.all([
 
 // First argument is required
 Promise.all(); // Error: expected array instead of undefined (too few arguments)
+
 // Mis-typed arg
 Promise.all(0); // Error: expected array instead of number
+
 // Promise.all is a function
 (Promise.all: Function);
 
@@ -692,6 +695,7 @@ exports[`test resolve_void.js 1`] = `
 // @flow
 
 (Promise.resolve(): Promise<number>); // error
+
 (Promise.resolve(undefined): Promise<number>); // error
 "
 `;

--- a/tests/flow/react_functional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react_functional/__snapshots__/jsfmt.spec.js.snap
@@ -19,9 +19,11 @@ function F(props: { foo: string }) {}
 <F />; /* error: missing \`foo\`*/
 <F foo={0} />; /* error: number ~> string*/
 <F foo=\"\" />; // ok
+
 // props subtyping is property-wise covariant
 function G(props: { foo: string | numner }) {}
 <G foo=\"\" />; // ok
+
 var Z = 0;
 <Z />; // error, expected React component
 "

--- a/tests/flow/rec/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/rec/__snapshots__/jsfmt.spec.js.snap
@@ -94,17 +94,21 @@ pstar = (new P: P<P<number>>); // OK
 class P<X> {
   x: X;
 }
+
 // this is like Promise
 
 type Pstar<X> = X | Pstar<P<X>>; // this is like Promise*
+
 var p: P<number> = new P();
 (p.x: string); // error
+
 var pstar: Pstar<number> = 0; // OK
 (pstar: number); // error, but limit potentially unbounded number of errors!
 // e.g., P<number> ~/~ number, P<P<number>> ~/~ number, ...
 
 pstar = p; // OK
 (pstar.x: string); // error
+
 pstar = (new P(): P<P<number>>); // OK
 (pstar.x: string); // error
 "

--- a/tests/flow/record/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/record/__snapshots__/jsfmt.spec.js.snap
@@ -33,11 +33,13 @@ var o1: { [key: Key1]: number } = {
 o1.foo; // OK
 o1.qux; // error: qux not found
 o1.toString(); // ok
+
 type R = { foo: any, bar: any };
 type Key2 = $Keys<R>; // another way to make an enum type, with unknown key set
 var o2: { [key: Key2]: number } = { foo: 0 }; // OK to leave out bar
 o2.bar; // OK to access bar
 o2.qux; // error: qux not found
+
 class C<X> {
   x: $Subtype<{ [key: $Keys<X>]: any }>; // object with larger key set than X\'s
 }

--- a/tests/flow/require/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/require/__snapshots__/jsfmt.spec.js.snap
@@ -156,12 +156,14 @@ require(\"./D\");
 var E = require(\"./E\");
 var e_1: number = E.numberValue;
 E.stringValue; // Error: The E exports obj has no \'stringValue\' property
+
 // We require that the param passed to require() be a string literal to support
 // guaranteed static extraction
 var a = \"./E\";
 require(a); // Error: Param must be string literal
 require(\`./E\`); // template literals are ok...
 require(\`\${\"./E\"}\`); // error: but only if they have no expressions
+
 // require.call is allowed but circumverts Flow\'s static analysis
 require.call(null, \"DoesNotExist\");
 "

--- a/tests/flow/requireLazy/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/requireLazy/__snapshots__/jsfmt.spec.js.snap
@@ -77,6 +77,7 @@ requireLazy([\"A\", \"B\"], function(A, B) {
   var str1: string = A.stringValueA;
   var num2: number = A.stringValueA; // Error: string ~> number
   var str2: string = A.numberValueA; // Error: number ~> string
+
   var num3: number = B.numberValueB;
   var str3: string = B.stringValueB;
   var num4: number = B.stringValueB; // Error: string ~> number

--- a/tests/flow/return_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/return_new/__snapshots__/jsfmt.spec.js.snap
@@ -16,12 +16,15 @@ function Foo() {
   return {};
 }
 var foo: number = new Foo(); // error (returns object literal above)
+
 function Bar() {
   return 0;
 }
 var bar: number = new Bar(); // error (returns new object)
+
 function Qux() {}
 var qux: number = new Qux(); // error (returns new object)
+
 class A {}
 function B() {
   return new A();
@@ -50,7 +53,9 @@ declare class D {
 
 var d = new D();
 d.x = \"\"; // error, string ~/~ number (but property x is found)
+
 (new D(): D); // error, new D is an object, D not in proto chain
+
 module.exports = D;
 "
 `;

--- a/tests/flow/sealed/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/sealed/__snapshots__/jsfmt.spec.js.snap
@@ -59,6 +59,7 @@ Foo.prototype = {
 };
 
 var export_o: { x: any } = o; // awkward type cast
+
 module.exports = export_o;
 "
 `;

--- a/tests/flow/sealed_objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/sealed_objects/__snapshots__/jsfmt.spec.js.snap
@@ -21,16 +21,22 @@ var o7: { x: number; y?: string; } = ({ x: 0, y: 0 }: { x: number; [_:any]:numbe
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var o1 = { x: 0 };
 var s1: string = o1.y; // error
+
 var o2: { x: number, y?: string } = { x: 0 };
 var s2: string = o2.y || \"\"; // ok
+
 var o3: { x: number, y?: string } = ({ x: 0, y: 0 }: { x: number });
 var s3: string = o3.y || \"\"; // error
+
 var o4: { x: number, y?: string } = ({ x: 0 }: { [_: any]: any, x: number });
 var s4: string = o4.y || \"\"; // ok
+
 var o5 = { x: 0, ...{} };
 var s5: string = o5.y; // ok (spreads make object types extensible)
+
 var o6: { [_: any]: any, x: number } = { x: 0 };
 var s6: string = o6.y; // ok  (indexers make object types extensible)
+
 var o7: { x: number, y?: string } = ({ x: 0, y: 0 }: {
   [_: any]: number,
   x: number

--- a/tests/flow/singleton/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/singleton/__snapshots__/jsfmt.spec.js.snap
@@ -45,12 +45,14 @@ function veryOptimistic(isThisAwesome: true): boolean {
 
 var x: boolean = veryOptimistic(true);
 var y: boolean = veryOptimistic(false); // error
+
 function veryPessimistic(isThisAwesome: true): boolean {
   return !isThisAwesome; // test bool conversion
 }
 
 var x: boolean = veryPessimistic(true);
 var y: boolean = veryPessimistic(false); // error
+
 type MyOwnBooleanLOL = true | false;
 
 function bar(x: MyOwnBooleanLOL): false {
@@ -64,6 +66,7 @@ function bar(x: MyOwnBooleanLOL): false {
 bar(true);
 bar(false);
 bar(1); // error
+
 function alwaysFalsy(x: boolean): false {
   if (x) {
     return !x;
@@ -107,6 +110,7 @@ function highlander(howMany: 1): number {
 
 highlander(1);
 highlander(2); // error
+
 type Foo = 1 | 2;
 
 function bar(num: Foo): number {
@@ -116,6 +120,7 @@ function bar(num: Foo): number {
 bar(1);
 bar(2);
 bar(3); // error
+
 type ComparatorResult = -1 | 0 | 1;
 function sort(fn: (x: any, y: any) => ComparatorResult) {}
 sort((x, y) => -1);

--- a/tests/flow/structural_subtyping/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/structural_subtyping/__snapshots__/jsfmt.spec.js.snap
@@ -147,6 +147,7 @@ interface HasOptional {
 var test1: HasOptional = { a: \"hello\" };
 
 var test2: HasOptional = {}; // Error: missing property a
+
 var test3: HasOptional = { a: \"hello\", b: true }; // Error: boolean ~> number
 "
 `;

--- a/tests/flow/suppress/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/suppress/__snapshots__/jsfmt.spec.js.snap
@@ -26,19 +26,24 @@ var test6: string = 123;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // $FlowFixMe
 var test1: string = 123; // This error should be suppressed
+
 // $FlowIssue
 var test2: string = 123; // This error should be suppressed
+
 function getNum() {
   return 123;
 }
 
 // $FlowFixMe This was the second loc in the error
 var test3: string = getNum(); // This error should be suppressed
+
 // $FlowFixMe Error unused suppression
 
 var test4: string = 123; // This error is NOT suppressed
+
 // $FlowFixMe Indentation shouldn\'t matter
 var test5: string = 123; // This error should be suppressed
+
 /*
  * $FlowNewLine
  */

--- a/tests/flow/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/switch/__snapshots__/jsfmt.spec.js.snap
@@ -192,6 +192,7 @@ function foo(x: mixed): string {
   // a is now string | number
   (a: string); // error, string | number ~/> string
   (a: number); // error, string | number ~/> number
+
   // b is now number
   (b: number); // ok
   return b; // error, number ~/> string
@@ -214,9 +215,11 @@ function baz(x: mixed): number {
   // a is now string | number
   (a: string); // error, string | number ~/> string
   (a: number); // error, string | number ~/> number
+
   // b is now string | number
   (b: string); // error, string | number ~/> string
   (b: number); // error, string | number ~/> number
+
   return a + b; // error, string ~/> number
 }
 "

--- a/tests/flow/taint/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/taint/__snapshots__/jsfmt.spec.js.snap
@@ -110,6 +110,7 @@ let tests = [
   function(x: $Tainted<string>) {
     let obj: Object = {};
     obj.foo(x); // error, taint ~> any
+
     let foo = obj.foo;
     foo(x); // error, taint ~> any
   }

--- a/tests/flow/template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/template/__snapshots__/jsfmt.spec.js.snap
@@ -36,8 +36,10 @@ let tests = [
 (\`foo\`: string); // ok
 (\`bar\`: \"bar\"); // ok
 (\`baz\`: number); // error
+
 \`foo \${123} bar\`; // ok, number can be appended to string
 \`foo \${{ bar: 123 }} baz\`; // error, object can\'t be appended
+
 let tests = [
   function(x: string) {
     \`foo \${x}\`; // ok

--- a/tests/flow/this/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this/__snapshots__/jsfmt.spec.js.snap
@@ -74,15 +74,18 @@ function foo(p: string) {}
 var o1 = new F(); // sets o1.x to 0
 o1.x = \"\";
 foo(o1.x); // ok by definite assignment
+
 var o2 = new F();
 o1.y = 0;
 o2.y = \"\";
 foo(o2.y); // setting o1.y to 0 has no effect on o2.y
+
 var o3 = new F();
 o3.m(); // sets o3.y to 0
 o3.y = \"\";
 foo(o3.y); // ok by definite assignment
 foo(o2.y); // setting o3.y to 0 has no effect on o2.y
+
 /*
  * this bindings:
  */
@@ -97,6 +100,7 @@ var f1_2: string = f1.bind({ x: 0 })(); // error, number -> string
 var f1_3 = f1.bind({ x: \"\" })(); // error, string -> number
 // TODO make this error blame the call site, rather than the function body
 var f1_4 = f1(); // error, (global object).x
+
 /* arrow functions bind this at point of definition */
 /* top level arrow functions bind this to global object */
 var a1 = () => {
@@ -104,6 +108,7 @@ var a1 = () => {
 };
 
 var ax = a1(); // error, (this:mixed).x
+
 /* nested arrows bind enclosing this (which may itself rebind) */
 function f2(): number {
   var a2 = () => {
@@ -117,6 +122,7 @@ var f2_2: string = f2.bind({ x: 0 })(); // error, number -> string
 var f2_3 = f2.bind({ x: \"\" })(); // error, string -> number
 // TODO make this error blame the call site, rather than the function body
 var f2_4 = f2(); // error, (global object).x
+
 (this: void);
 
 module.exports = true;
@@ -166,11 +172,13 @@ var c = new C();
 var f = c.foo();
 var i = f(); // OK
 (i: C); // OK
+
 class D extends C {}
 var d = new D();
 var g = d.foo();
 var j = g(); // OK
 (j: D); // error, since return type of bar is C, not the type of \`this\`
+
 class E {
   foo(x: number) {}
 }

--- a/tests/flow/this_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this_type/__snapshots__/jsfmt.spec.js.snap
@@ -87,6 +87,7 @@ class D extends C {}
 var d = new D();
 (d: C).next = new C();
 (d.next: D); // sneaky
+
 class A {
   foo<X: this>(that: X) {} // error: can\'t hide contravariance using a bound
 }
@@ -243,6 +244,7 @@ class B1 extends A1 {
 }
 
 (new B1().bar(): B1); // OK
+
 class B3<X> extends A3<X> {
   foo(): B3<X> {
     return new B3();
@@ -251,6 +253,7 @@ class B3<X> extends A3<X> {
 
 (new B3().bar(): B3<*>); // OK
 (new B3().qux(0): string); // error
+
 (new B3().bar(): A2<*>); // OK
 ((new B3().bar(): B3<string>): A2<number>); // error
 ((new B3(): A2<number>).qux(0): string); // error
@@ -363,6 +366,7 @@ class A {
   }
 }
 class B extends A {} // inherits statics method too, with \`this\` bound to the class
+
 (A.make(): A); // OK
 (B.make(): B); // OK
 (B.make(): A); // OK
@@ -469,6 +473,7 @@ class Override extends Base {
   qux() {
     return this;
   } // OK, too
+
   bar() {
     return new Override();
   } // OK (cf. error below)
@@ -516,6 +521,7 @@ class Override2 extends Base2 {
   qux(): this {
     return this;
   } // OK, too
+
   bar(): Override2 {
     return new Override2();
   } // error (cf. OK above)
@@ -536,6 +542,7 @@ class InheritOverride2 extends Override2 {}
 ((new Override2(): Base2).foo(): Base2);
 
 (new InheritOverride2().bar_caller(): InheritOverride2); // exploits error above
+
 (new Override2(): Base2).corge(new Base2()); // exploits error above
 "
 `;

--- a/tests/flow/tuples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/tuples/__snapshots__/jsfmt.spec.js.snap
@@ -33,6 +33,7 @@ exports[`test optional.js 1`] = `
 
 ([0, undefined]: [number, ?string]); // Ok, correct arity
 ([0]: [number, ?string]); // Error, arity is enforced
+
 ([]: [?number, string]); // error, since second element is not marked optional
 "
 `;

--- a/tests/flow/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
@@ -94,6 +94,7 @@ class MyClass<T> {
 }
 
 var c: MyClass = new MyClass(0); // no error
+
 // no arity error in type annotation using polymorphic class with defaulting
 
 class MyClass2<T, U=string> {
@@ -106,6 +107,7 @@ class MyClass2<T, U=string> {
 }
 
 var c2: MyClass2 = new MyClass2(0, \"\"); // no error
+
 // no arity error in type annotation using polymorphic type alias
 
 type MyObject<T> = {
@@ -113,9 +115,11 @@ type MyObject<T> = {
 };
 
 var o: MyObject = { x: 0 }; // no error
+
 // arity error in type alias rhs
 
 type MySubobject = { y: number } & MyObject; // no error
+
 // arity error in interface extends
 
 interface MyInterface<T> {

--- a/tests/flow/type_args_strict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_args_strict/__snapshots__/jsfmt.spec.js.snap
@@ -92,6 +92,7 @@ class MyClass<T> {
 }
 
 var c: MyClass = new MyClass(0); // error, missing argument list (1)
+
 // arity error in type annotation using polymorphic class with defaulting
 
 class MyClass2<T, U=string> {
@@ -104,6 +105,7 @@ class MyClass2<T, U=string> {
 }
 
 var c2: MyClass2 = new MyClass2(0, \"\"); // error, missing argument list (1-2)
+
 // arity error in type annotation using polymorphic type alias
 
 type MyObject<T> = {
@@ -111,9 +113,11 @@ type MyObject<T> = {
 };
 
 var o: MyObject = { x: 0 }; // error, missing argument list
+
 // arity error in type alias rhs
 
 type MySubobject = { y: number } & MyObject; // error, missing argument list
+
 // arity error in interface extends
 
 interface MyInterface<T> {

--- a/tests/flow/type_param_defaults/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_param_defaults/__snapshots__/jsfmt.spec.js.snap
@@ -86,7 +86,9 @@ var b_star: B<*> = new B(123);
 (b_number.p: boolean); // Error number ~> boolean
 (b_void.p: boolean); // Error void ~> boolean
 (b_default.p: boolean); // Error string ~> boolean
+
 (b_star.p: boolean); // Error number ~> boolean
+
 class C<T: ?string=string> extends A<T> {}
 
 var c_number: C<number> = new C(123); // Error number ~> ?string
@@ -97,6 +99,7 @@ var c_star: C<*> = new C(\"hello\");
 (c_void.p: boolean); // Error void ~> boolean
 (c_default.p: boolean); // Error string ~> boolean
 (c_star.p: boolean); // Error string ~> boolean
+
 class D<S, T=string> extends A<T> {}
 var d_number: D<mixed, number> = new D(123);
 var d_void: D<mixed, void> = new D();
@@ -104,18 +107,23 @@ var d_default: D<mixed> = new D(\"hello\");
 var d_too_few_args: D<> = new D(\"hello\"); // Error too few tparams
 var d_too_many: D<mixed, string, string> = new D(\"hello\"); // Error too many tparams
 var d_star: D<*> = new D(10); // error, number ~> string
+
 (d_number.p: boolean); // Error number ~> boolean
 (d_void.p: boolean); // Error void ~> boolean
 (d_default.p: boolean); // Error string ~> boolean
 (d_star.p: boolean); // Error number ~> boolean
+
 class E<S: string, T: number=S> {} // Error: string ~> number
 class F<S: string, T: S=number> {} // Error: number ~> string
+
 class G<S: string, T=S> extends A<T> {}
 
 var g_default: G<string> = new G(\"hello\");
 
 (g_default.p: boolean); // Error string ~> boolean
+
 class H<S=T, T=string> {} // Error - can\'t refer to T before it\'s defined
+
 class I<T: ?string=*> extends A<T> {}
 
 var i_number: I<number> = new I(123); // Error number ~> ?string

--- a/tests/flow/type_param_scope/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_param_scope/__snapshots__/jsfmt.spec.js.snap
@@ -155,6 +155,7 @@ declare var g: G<number | string>;
 g.m(0); // ok
 g.m(true); // err, bool ~> number|string
 (g.m(\"\"): G<number>); // err, string ~> number
+
 // Shadow bounds incompatible with parent
 
 class H<T> {

--- a/tests/flow/typeof/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/typeof/__snapshots__/jsfmt.spec.js.snap
@@ -147,6 +147,7 @@ var c: typeof MyClass2 = new MyClass2();
 var numValue: number = 42;
 var d: typeof numValue = 100;
 var e: typeof numValue = \"asdf\"; // Error: string ~> number
+
 /////////////////////////////////
 // == typeof <<type-alias>> == //
 /////////////////////////////////
@@ -158,6 +159,7 @@ type numberAlias = number;
 // is suboptimal - just \'cannot resolve name\'. TODO.
 //
 var f: typeof numberAlias = 42; // Error: \'typeof <<type-alias>>\' makes no sense...
+
 /**
  * Use of a non-class/non-function value in type annotation.
  * These provoke a specific error, not just the generic

--- a/tests/flow/unchecked_node_module_vs_lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/unchecked_node_module_vs_lib/__snapshots__/jsfmt.spec.js.snap
@@ -38,15 +38,18 @@ var x3: string = buffer3.INSPECT_MAX_BYTES; // error, module not found
 //
 var buffer = require(\"buffer\");
 var b: boolean = buffer.INSPECT_MAX_BYTES; // error, number ~/> boolean
+
 // node_modules/crypto/index.js is checked,
 // so we should pick up its boolean redefinition of DEFAULT_ENCODING
 //
 var crypto = require(\"crypto\");
 var b: boolean = crypto.DEFAULT_ENCODING; // no error, we\'ve overridden
+
 // names that are explicit paths shouldn\'t fall back to lib defs
 //
 var buffer2 = require(\"./buffer\");
 var x2: string = buffer2.INSPECT_MAX_BYTES; // error, module not found
+
 var buffer3 = require(\"./buffer.js\");
 var x3: string = buffer3.INSPECT_MAX_BYTES; // error, module not found
 "

--- a/tests/flow/undefined/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/undefined/__snapshots__/jsfmt.spec.js.snap
@@ -15,6 +15,7 @@ foo();
 function doSomethingAsync(): Promise<void> {
   return new Promise((resolve, reject) => {
     resolve(); // OK to leave out arg, same as resolve(undefined)
+
     var anotherVoidPromise: Promise<void> = Promise.resolve();
     resolve(anotherVoidPromise);
   });
@@ -93,12 +94,14 @@ let tests = [
     var id;
     var name = id ? \"John\" : undefined;
     (name: boolean); // error, string or void
+
     const bar = [undefined, \"bar\"];
     (bar[x]: boolean); // error, string or void
   },
   function(x: number) {
     var undefined = \"foo\";
     (undefined: string); // ok
+
     var x;
     if (x !== undefined) {
       x[0]; // should error, could be void

--- a/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
@@ -346,6 +346,7 @@ foo(y);
 // TODO: spurious error! (replacing C with number makes the error go away)
 // type Bar = (() => C) | (() => string);
 type Bar = () => C | string; // workaround
+
 function f() {
   return \"\";
 }

--- a/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -508,6 +508,7 @@ function obj(a: A1 | A2) {
 }
 
 const obj_result = obj({ x: \"\" }); // currently an error! (expect it to be OK)
+
 // Type definitions used above are defined below, but in an order that
 // deliberately makes their full resolution as lazy as possible. The call above
 // blocks until A1 is partially resolved. Since the argument partially matches
@@ -1317,6 +1318,7 @@ length({ kind: \"nil\" });
 length({ kind: \"cons\" }); // missing \`next\`
 length({ kind: \"cons\", next: { kind: \"nil\" } });
 length({ kind: \"empty\" }); // \`kind\` not found
+
 type List = Nil | Cons;
 type Nil = { kind: \"nil\" };
 type Cons = { kind: \"cons\", next: List };

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,60 @@
+exports[`test comments.js 1`] = `
+"function a() {
+  const a = 5; // comment
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+
+  return a;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function a() {
+  const a = 5; // comment
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+
+  return a;
+}
+"
+`;

--- a/tests/preserve_line/comments.js
+++ b/tests/preserve_line/comments.js
@@ -1,0 +1,28 @@
+function a() {
+  const a = 5; // comment
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+
+  return a;
+}

--- a/tests/preserve_line/jsfmt.spec.js
+++ b/tests/preserve_line/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -66,6 +66,7 @@ exports[`test strings.js 1`] = `
   \"🐶\",
   \'\\uD801\\uDC28\'
 ]; // Normalization of \\x and \\u escapes: // Basic case.
+
 \"a\\xaaAb\\ub1cdE\";
 \`a\\xaaAb\\ub1cdE\`; // ES2015 unicode escapes.
 \"\\u{1fa3}\";


### PR DESCRIPTION
It turns that our `hasNextLine` logic needs to be tuned to skip all the trailing comments. The code is not pretty but it does the job. It looks like it fixes a bunch of things in the test cases :)

I made sure that nested inline comments are NOT valid JavaScript

```js
/* /* a */ */
Uncaught SyntaxError: Unexpected token *
```

so it is okay to do a dumb search for */ when you are in a comment

Fixes #526