### PR TITLE
Whitelist UnaryExpression for parentless objects

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2664,7 +2664,8 @@ function shouldPrintSameLine(node) {
     type === "ObjectPattern" ||
     type === "StringLiteral" ||
     type === "ThisExpression" ||
-    type === "TypeCastExpression";
+    type === "TypeCastExpression" ||
+    type === "UnaryExpression";
 }
 
 function printAstToDoc(ast, options) {

--- a/tests/unary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/unary/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,16 @@
+exports[`test object.js 1`] = `
+"state = {
+  // students
+  hoverColumn: -1
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+state = {
+  // students
+  hoverColumn: -1
+};
+"
+`;
+
 exports[`test series.js 1`] = `
 "1 + ++x;
 1 + x++;

--- a/tests/unary/object.js
+++ b/tests/unary/object.js
@@ -1,0 +1,4 @@
+state = {
+  // students
+  hoverColumn: -1
+};


### PR DESCRIPTION
It seems like unary are unlikely to need parenthesis

Fixes #542