### PR TITLE
Update Vim documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prettier 
+# Prettier
 
 [![Gitter](https://badges.gitter.im/gitterHQ/gitter.svg)](https://gitter.im/jlongster/prettier)
 [![Build Status](https://travis-ci.org/jlongster/prettier.svg?branch=master)](https://travis-ci.org/jlongster/prettier)
@@ -174,10 +174,11 @@ autocmd FileType javascript set formatprg=prettier\ --stdin
 
 This makes Prettier power the [`gq` command](http://vimdoc.sourceforge.net/htmldoc/change.html#gq)
 for automatic formatting without any plugins. You can also add the following to your
-`.vimrc` to run prettier when `.js` files are saved:
+`.vimrc` to run prettier when `.js` files are saved (`<C-o>`s in the end
+will ensure that cursor position is restored after the autocommand):
 
 ```
-autocmd BufWritePre *.js :normal gggqG
+autocmd BufWritePre *.js exe "normal! gggqG\<C-o>\<C-o>"
 ```
 
 ### Visual Studio Code
@@ -190,7 +191,7 @@ Can also be installed using `ext install prettier-vscode`
 
 ### Sublime Text
 
-Sublime Text support is available through Package Control and 
+Sublime Text support is available through Package Control and
 the [JsPrettier](https://packagecontrol.io/packages/JsPrettier) plug-in.
 
 ### JetBrains


### PR DESCRIPTION
Modify `autocmd` configuration to restore original cursor position
before automatic movement and formatting commands were invoked.