### PR TITLE
Do not normalize escapes in tagged templates

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1231,6 +1231,11 @@ function genericPrintNoParens(path, options, print) {
     case "ClassExpression":
       return concat(printClass(path, options, print));
     case "TemplateElement":
+      if (path.getParentNode(1).type === "TaggedTemplateExpression") {
+        // Raw values of escapes are visible in tagged template expressions;
+        // they cannot be normalized.
+        return join(literalline, n.value.raw.split("\n"));
+      }
       return join(
         literalline,
         n.value.raw.split("\n").map(line => normalizeEscapes(line))

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -77,6 +77,6 @@ exports[`test strings.js 1`] = `
 \`\\B\\S\`; // Handles escaped backslashes.
 \"\\\\xAB\\\\\\xab\\\\\\\\xAB\\B\\\\\\B\\u1234\";
 \`\\\\xAB\\\\\\xab\\\\\\\\xAB\\B\\\\\\B\\u1234\`; // Mix of everything.
-\"\\xf0\"\`a\\uabcd\${\"\\xfdE\"}\\\\\\u{00abcde}\`;
+\"\\xf0\"\`a\\uaBcD\${\"\\xfdE\"}\\\\\\u{00AbCdE}\`;
 "
 `;


### PR DESCRIPTION
The raw value of escape sequences in template literals is observable in tagged templates, so normalizing them changes program semantics. #522 introduced a bug by normalizing them.

As an example,
```js
console.log(String.raw`\u{AA}`);
```
prints `\u{AA}` to the console; after running it through prettier (without this commit) the above program becomes
```js
console.log(String.raw`\u{aa}`);
```
which prints `\u{aa}` to the console.