### PR TITLE
Ensure that all comments are printed

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,13 +46,26 @@ function attachComments(text, ast, opts) {
   }
   ast.tokens = [];
   opts.originalText = text.trimRight();
+  return astComments;
+}
+
+function ensureAllCommentsPrinted(astComments) {
+  astComments.forEach(comment => {
+    if (!comment.printed) {
+      throw new Error(
+        'Comment "' + comment.value.trim() + '" was not printed. Please report this error!'
+      );
+    }
+    delete comment.printed;
+  });
 }
 
 function format(text, opts) {
   const ast = parse(text, opts);
-  attachComments(text, ast, opts);
+  const astComments = attachComments(text, ast, opts);
   const doc = printAstToDoc(ast, opts);
   const str = printDocToString(doc, opts.printWidth, guessLineEnding(text));
+  ensureAllCommentsPrinted(astComments);
   return str;
 }
 

--- a/src/comments.js
+++ b/src/comments.js
@@ -255,6 +255,7 @@ function breakTies(tiesToBreak, text) {
 function addCommentHelper(node, comment) {
   var comments = node.comments || (node.comments = []);
   comments.push(comment);
+  comment.printed = false;
 }
 
 function addLeadingComment(node, comment) {
@@ -369,6 +370,7 @@ function handleMemberExpressionComment(enclosingNode, followingNode, comment) {
 
 function printComment(commentPath) {
   const comment = commentPath.getValue();
+  comment.printed = true;
 
   switch (comment.type) {
     case "CommentBlock":


### PR DESCRIPTION
This currently fails for 20 tests. I'm putting this up as a pull request so we can merge it once all the comments are properly printed :)