### PR TITLE
Fix ternary indent bug 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 npm-debug.log
-test.js

--- a/src/printer.js
+++ b/src/printer.js
@@ -774,10 +774,10 @@ function genericPrintNoParens(path, options, print) {
             concat([
               line,
               "? ",
-              indent(options.tabWidth, path.call(print, "consequent")),
+              indent(2, path.call(print, "consequent")),
               line,
               ": ",
-              indent(options.tabWidth, path.call(print, "alternate"))
+              indent(2, path.call(print, "alternate"))
             ])
           )
         ])

--- a/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -49,3 +49,55 @@ const obj5 = conditionIsTruthy
     };
 "
 `;
+
+exports[`test test.js 2`] = `
+"const obj0 = conditionIsTruthy ? shortThing : otherShortThing
+
+const obj1 = conditionIsTruthy ? { some: \'long\', object: \'with\', lots: \'of\', stuff } : shortThing
+
+const obj2 = conditionIsTruthy ? shortThing : { some: \'long\', object: \'with\', lots: \'of\', stuff }
+
+const obj3 = conditionIsTruthy ? { some: \'eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger\', object: \'with\', lots: \'of\', stuff } : shortThing
+
+const obj4 = conditionIsTruthy ? shortThing : { some: \'eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger\', object: \'with\', lots: \'of\', stuff }
+
+const obj5 = conditionIsTruthy ? { some: \'long\', object: \'with\', lots: \'of\', stuff } : { some: \'eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger\', object: \'with\', lots: \'of\', stuff }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const obj0 = conditionIsTruthy ? shortThing : otherShortThing;
+
+const obj1 = conditionIsTruthy
+    ? { some: \"long\", object: \"with\", lots: \"of\", stuff }
+    : shortThing;
+
+const obj2 = conditionIsTruthy
+    ? shortThing
+    : { some: \"long\", object: \"with\", lots: \"of\", stuff };
+
+const obj3 = conditionIsTruthy
+    ? {
+          some: \"eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger\",
+          object: \"with\",
+          lots: \"of\",
+          stuff
+      }
+    : shortThing;
+
+const obj4 = conditionIsTruthy
+    ? shortThing
+    : {
+          some: \"eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger\",
+          object: \"with\",
+          lots: \"of\",
+          stuff
+      };
+
+const obj5 = conditionIsTruthy
+    ? { some: \"long\", object: \"with\", lots: \"of\", stuff }
+    : {
+          some: \"eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger\",
+          object: \"with\",
+          lots: \"of\",
+          stuff
+      };
+"
+`;

--- a/tests/ternaries/jsfmt.spec.js
+++ b/tests/ternaries/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname);
+run_spec(__dirname, { tabWidth: 4 });


### PR DESCRIPTION
addresses #564

Also adds `test.js` back to source control