### PR TITLE
Preserve empty line before last comment

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -421,7 +421,13 @@ function printTrailingComment(commentPath, print, options, parentNode) {
     // trailing comment for `2`. We can simulate the above by checking
     // if this a comment on its own line; normal trailing comments are
     // always at the end of another expression.
-    return concat([hardline, contents]);
+
+    const isLineBeforeEmpty = util.isPreviousLineEmpty(
+      options.originalText,
+      comment
+    );
+
+    return concat([hardline, isLineBeforeEmpty ? hardline : "", contents]);
   } else if (isBlock) {
     // Trailing block comments never need a newline
     return concat([" ", contents]);

--- a/src/util.js
+++ b/src/util.js
@@ -195,6 +195,14 @@ function hasNewlineInRange(text, start, end) {
   return false;
 }
 
+// Note: this function doesn't ignore leading comments unlike isNextLineEmpty
+function isPreviousLineEmpty(text, node) {
+  let idx = locStart(node) - 1;
+  idx = skipSpaces(text, idx, {backwards: true});
+  idx = skipNewline(text, idx, {backwards: true});
+  return hasNewline(text, idx, {backwards: true});
+}
+
 function isNextLineEmpty(text, node) {
   let oldIdx = null;
   let idx = locEnd(node);
@@ -299,6 +307,7 @@ module.exports = {
   skipSpaces,
   skipNewline,
   isNextLineEmpty,
+  isPreviousLineEmpty,
   hasNewline,
   hasNewlineInRange,
   hasSpaces,

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -794,6 +794,54 @@ exports[`test jsx.js 2`] = `
 "
 `;
 
+exports[`test preserve-new-line-last.js 1`] = `
+"function name() {
+  // comment1
+  func1()
+
+  // comment2
+  func2()
+
+  // comment3 why func3 commented
+  // func3()
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function name() {
+  // comment1
+  func1();
+
+  // comment2
+  func2();
+  // comment3 why func3 commented
+  // func3()
+}
+"
+`;
+
+exports[`test preserve-new-line-last.js 2`] = `
+"function name() {
+  // comment1
+  func1()
+
+  // comment2
+  func2()
+
+  // comment3 why func3 commented
+  // func3()
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function name() {
+  // comment1
+  func1();
+
+  // comment2
+  func2();
+  // comment3 why func3 commented
+  // func3()
+}
+"
+`;
+
 exports[`test try.js 1`] = `
 "// comment 1
 try {

--- a/tests/comments/preserve-new-line-last.js
+++ b/tests/comments/preserve-new-line-last.js
@@ -1,0 +1,10 @@
+function name() {
+  // comment1
+  func1()
+
+  // comment2
+  func2()
+
+  // comment3 why func3 commented
+  // func3()
+}

--- a/tests/flow/more_generics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_generics/__snapshots__/jsfmt.spec.js.snap
@@ -69,6 +69,7 @@ function foo8<U>(x: U, y): U {
   y();
   return x;
 }
+
 /*
  foo8(0,void 0);
 */

--- a/tests/flow/while/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/while/__snapshots__/jsfmt.spec.js.snap
@@ -30,6 +30,7 @@ function foo(x: boolean) {
     }
     return;
   }
+
   //console.log(\'this is still reachable\');
 }
 
@@ -38,6 +39,7 @@ function bar(x: boolean) {
   while (ii > 0) {
     return;
   }
+
   //console.log(\'this is still reachable\');
 }
 "


### PR DESCRIPTION
We want to preserve an empty line before the last comment. It is added as a trailing comment of the node and adding the same logic to detect if the next line is empty is working.

Fixes #566