### PR TITLE
test on current release of node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 4
   - 6
+  - stable
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
Add the "stable" alias to the list of node.js versions to test against. This will hit 7.x today, and 8.x pretty soon.