### PR TITLE
Remove first line special case

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -135,11 +135,9 @@ function attach(comments, ast, text) {
     const precedingNode = comment.precedingNode;
     const enclosingNode = comment.enclosingNode;
     const followingNode = comment.followingNode;
-    const isStartOfFile = comment.loc.start.line === 1;
 
     if (
-      util.hasNewline(text, locStart(comment), { backwards: true }) ||
-        isStartOfFile
+      util.hasNewline(text, locStart(comment), { backwards: true })
     ) {
       // If a comment exists on its own line, prefer a leading comment.
       // We also need to check if it's the first line of the file.

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -70,6 +70,24 @@ declare class Foo extends Qux<string> {/* dangling */}
 "
 `;
 
+exports[`test first-line.js 1`] = `
+"a // comment
+b
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a; // comment
+b;
+"
+`;
+
+exports[`test first-line.js 2`] = `
+"a // comment
+b
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a; // comment
+b;
+"
+`;
+
 exports[`test if.js 1`] = `
 "if (1)
 // comment

--- a/tests/comments/first-line.js
+++ b/tests/comments/first-line.js
@@ -1,0 +1,2 @@
+a // comment
+b

--- a/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
@@ -148,9 +148,7 @@ function foo() {
   class MyClass { } // looked up above
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-let myClassInstance: MyClass = null;
-
-// forward ref ok, null ~> class error
+let myClassInstance: MyClass = null; // forward ref ok, null ~> class error
 
 function bar(): MyClass {
   return null; // forward ref ok, null ~> class error

--- a/tests/flow/get-def2/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/get-def2/lib/__snapshots__/jsfmt.spec.js.snap
@@ -7,8 +7,7 @@ type $JSXIntrinsics = {
   span: $JSXIntrinsic<{id: string, class: string}>,
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-declare var $React: $Exports<\"react\">;
-// fake import
+declare var $React: $Exports<\"react\">; // fake import
 type $JSXIntrinsic<T> = Class<$React.Component<void, T, mixed>>;
 
 type $JSXIntrinsics = {

--- a/tests/flow/jsx_intrinsics.custom/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/jsx_intrinsics.custom/lib/__snapshots__/jsfmt.spec.js.snap
@@ -7,8 +7,7 @@ type $JSXIntrinsics = {
   span: $JSXIntrinsic<{id: string, class: string}>,
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-declare var $React: $Exports<\"react\">;
-// fake import
+declare var $React: $Exports<\"react\">; // fake import
 type $JSXIntrinsic<T> = Class<$React.Component<void, T, mixed>>;
 
 type $JSXIntrinsics = {

--- a/tests/flow/new_react/fakelib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/fakelib/__snapshots__/jsfmt.spec.js.snap
@@ -6,8 +6,7 @@ exports[`test type_aliases.js 1`] = `
 type _ReactElement<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: $React.Component<DefaultProps, Props, any>> = $React.Element<Config>;
 type $jsx<C> = _ReactElement<*, *, *, C>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-declare var $React: $Exports<\"react\">;
-// fake import
+declare var $React: $Exports<\"react\">; // fake import
 // Strawman: revised definition of $jsx (alternatively, React.Element).
 // Using bounded poly to specify a constraint on a type parameter, and
 // existentials to elide type arguments.

--- a/tests/flow/node_tests/basic_file/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/basic_file/__snapshots__/jsfmt.spec.js.snap
@@ -9,8 +9,7 @@ exports[`test foo.js 1`] = `
 "var x = require(\'./bar\'); // bar.js does not work
 console.log(x);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var x = require(\"./bar\");
-// bar.js does not work
+var x = require(\"./bar\"); // bar.js does not work
 console.log(x);
 "
 `;

--- a/tests/flow/node_tests/basic_package/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/basic_package/__snapshots__/jsfmt.spec.js.snap
@@ -2,8 +2,7 @@ exports[`test foo.js 1`] = `
 "var x = require(\'./bar_lib\'); // \'bar_lib\' does not work!
 console.log(x);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var x = require(\"./bar_lib\");
-// \'bar_lib\' does not work!
+var x = require(\"./bar_lib\"); // \'bar_lib\' does not work!
 console.log(x);
 "
 `;

--- a/tests/flow/node_tests/package_file/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/package_file/__snapshots__/jsfmt.spec.js.snap
@@ -9,8 +9,7 @@ exports[`test foo.js 1`] = `
 "var x: string = require(\'./bar_lib\'); // \'bar_lib\' does not work!
 console.log(x);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var x: string = require(\"./bar_lib\");
-// \'bar_lib\' does not work!
+var x: string = require(\"./bar_lib\"); // \'bar_lib\' does not work!
 console.log(x);
 "
 `;

--- a/tests/flow/node_tests/package_file_node_modules/foo/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/node_tests/package_file_node_modules/foo/__snapshots__/jsfmt.spec.js.snap
@@ -2,8 +2,7 @@ exports[`test foo.js 1`] = `
 "var x: string = require(\'bar_lib\'); // \'bar_lib\' does not work!
 console.log(x);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var x: string = require(\"bar_lib\");
-// \'bar_lib\' does not work!
+var x: string = require(\"bar_lib\"); // \'bar_lib\' does not work!
 console.log(x);
 "
 `;

--- a/tests/flow/rec/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/rec/__snapshots__/jsfmt.spec.js.snap
@@ -93,9 +93,7 @@ pstar = (new P: P<P<number>>); // OK
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class P<X> {
   x: X;
-}
-
-// this is like Promise
+} // this is like Promise
 
 type Pstar<X> = X | Pstar<P<X>>; // this is like Promise*
 
@@ -146,8 +144,7 @@ class B<X> extends D<X> { }
 class C<X> extends B<X> { }
 ((new C: C<number>): D<string>) // error: number ~/~ string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var a = [];
-// Array<X> ~> a
+var a = []; // Array<X> ~> a
 function bar() {
   a = a.concat([]); // terminate despite expanding types:
   // a ~> .concat(Array<Y>)

--- a/tests/flow/record/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/record/__snapshots__/jsfmt.spec.js.snap
@@ -24,8 +24,7 @@ class D extends C<{foo: number, bar: string}> {
 type AnyKey = $Keys<Object>;
 var o3: {[key: AnyKey]: number} = { foo: 0 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-type Key1 = \"foo\" | \"bar\";
-// make an enum type with known key set
+type Key1 = \"foo\" | \"bar\"; // make an enum type with known key set
 var o1: { [key: Key1]: number } = {
   foo: 0,
   bar: \"\" // error: string ~/~ number

--- a/tests/flow/type-destructors/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type-destructors/__snapshots__/jsfmt.spec.js.snap
@@ -62,8 +62,7 @@ var x1: $NonMaybeType<number|string> = true; // err, boolean ~> number|string
 var x2: $PropertyType<{p:number}|{p:string},\'p\'> = 0; // ok, number ~> number|string
 var x3: $PropertyType<{p:number}|{p:string},\'p\'> = true; // err, boolean ~> number|string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var x0: $NonMaybeType<number | string> = 0;
-// ok, number ~> number|string
+var x0: $NonMaybeType<number | string> = 0; // ok, number ~> number|string
 var x1: $NonMaybeType<number | string> = true; // err, boolean ~> number|string
 var x2: $PropertyType<{ p: number } | { p: string }, \"p\"> = 0; // ok, number ~> number|string
 var x3: $PropertyType<{ p: number } | { p: string }, \"p\"> = true; // err, boolean ~> number|string


### PR DESCRIPTION
If you removed it before #561, it would trigger an exception in the globalPreceding branch. But now that we don't have this hack anymore, it works fine.

Fixes #523 