### PR TITLE
Do not attach comments to EmptyStatement

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -28,7 +28,7 @@ function getSortedChildNodes(node, text, resultArray) {
   util.fixFaultyLocations(node, text);
 
   if (resultArray) {
-    if (n.Node.check(node)) {
+    if (n.Node.check(node) && node.type !== "EmptyStatement") {
       // This reverse insertion sort almost always takes constant
       // time because we almost always (maybe always?) append the
       // nodes in order anyway.

--- a/tests/flow/binding/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/binding/__snapshots__/jsfmt.spec.js.snap
@@ -416,13 +416,13 @@ function var_var() {
 
 function function_toplevel() {
   function a() {}
-  function a() {}
+  function a() {} // OK
 }
 
 function function_block() {
   {
     function a() {}
-    function a() {}
+    function a() {} // error: name already bound
   }
 }
 


### PR DESCRIPTION
Since we don't print EmptyStatement, we don't want to attach comments to them. I've tried actually printing the EmptyStatement but it messes up a ton of other things.