### PR TITLE
[RFC] Better indentation for binary expressions

### DIFF
--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -337,11 +337,11 @@ export type AsyncExecuteOptions =
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(
   \"^\\\\s*\" + // beginning of the line
-    \"name\\\\s*=\\\\s*\" + // name =
-    \"[\'\\\"]\" + // opening quotation mark
-    escapeStringRegExp(target.name) + // target name
-    \"[\'\\\"]\" + // closing quotation mark
-    \",?$\" // optional trailing comma
+  \"name\\\\s*=\\\\s*\" + // name =
+  \"[\'\\\"]\" + // opening quotation mark
+  escapeStringRegExp(target.name) + // target name
+  \"[\'\\\"]\" + // closing quotation mark
+  \",?$\" // optional trailing comma
 );
 
 // The comment is moved and doesn\'t trigger the eslint rule anymore
@@ -566,11 +566,11 @@ export type AsyncExecuteOptions =
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(
   \"^\\\\s*\" + // beginning of the line
-    \"name\\\\s*=\\\\s*\" + // name =
-    \"[\'\\\"]\" + // opening quotation mark
-    escapeStringRegExp(target.name) + // target name
-    \"[\'\\\"]\" + // closing quotation mark
-    \",?$\" // optional trailing comma
+  \"name\\\\s*=\\\\s*\" + // name =
+  \"[\'\\\"]\" + // opening quotation mark
+  escapeStringRegExp(target.name) + // target name
+  \"[\'\\\"]\" + // closing quotation mark
+  \",?$\" // optional trailing comma
 );
 
 // The comment is moved and doesn\'t trigger the eslint rule anymore

--- a/tests/trailing_whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/trailing_whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -19,7 +19,7 @@ export type Result<T, V> =
    
    
 \` +
-  \`
+\`
     
     
 \`;

--- a/tests/while/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/while/__snapshots__/jsfmt.spec.js.snap
@@ -4,16 +4,16 @@ while (someVeryLongStringA && someVeryLongStringB && someVeryLongStringC && some
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 if (
   someVeryLongStringA &&
-    someVeryLongStringB &&
-    someVeryLongStringC &&
-    someVeryLongStringD
+  someVeryLongStringB &&
+  someVeryLongStringC &&
+  someVeryLongStringD
 ) {
 }
 while (
   someVeryLongStringA &&
-    someVeryLongStringB &&
-    someVeryLongStringC &&
-    someVeryLongStringD
+  someVeryLongStringB &&
+  someVeryLongStringC &&
+  someVeryLongStringD
 ) {
 }
 "


### PR DESCRIPTION
Right now we always indent any binary expression group (a sequence of binary expressions of the same predecence) which leads to weird looking code, especially in if statements.

This new logic tries to make it better. There are now three cases where we need to indent things:

1) If we are in a comparison operator that is unlikely to be chained (eg ===)
2) If the parent expects a level of indentation (eg, var a = ...)
3) If the parent is a binary expression with a different precedence level (eg, && inside of ||)

The biggest observable change is the fact that it no longer indents the second and on conditions inside of an if statement.

Before:

```js
if (
  this.state.open &&
    this.props.value &&
    this.props.value[consts.inspected] === false
) {
  this.inspect();
}
```

After:

```js
if (
  this.state.open &&
  this.props.value &&
  this.props.value[consts.inspected] === false
) {
  this.inspect();
}
```

You can see how this runs on the Nuclide codebase: https://gist.github.com/vjeux/510742148b0a011d0375f23f260bf859

Fix #567