### PR TITLE
Do not indent binary expressions inside of if

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -168,6 +168,15 @@ function genericPrintNoParens(path, options, print) {
     case "LogicalExpression": {
       const parts = [];
       printBinaryishExpressions(path, parts, print, options);
+      const parent = path.getParentNode();
+
+      const shouldNotIndent =
+        (parent.type === "IfStatement" ||
+        parent.type === "WhileStatement" ||
+        parent.type === "DoStatement" ||
+        parent.type === "ForStatement") && n !== parent.body;
+
+      const rest = concat(parts.slice(1));
 
       return group(
         concat([
@@ -175,7 +184,7 @@ function genericPrintNoParens(path, options, print) {
           // level. The first item is guaranteed to be the first
           // left-most expression.
           parts.length > 0 ? parts[0] : "",
-          indent(options.tabWidth, concat(parts.slice(1)))
+          shouldNotIndent ? rest : indent(options.tabWidth, rest)
         ])
       );
     }

--- a/src/printer.js
+++ b/src/printer.js
@@ -170,11 +170,15 @@ function genericPrintNoParens(path, options, print) {
       printBinaryishExpressions(path, parts, print, options);
       const parent = path.getParentNode();
 
-      const shouldNotIndent =
+      // Avoid indenting sub-expressions in if/etc statements.
+      if(
         (parent.type === "IfStatement" ||
-        parent.type === "WhileStatement" ||
-        parent.type === "DoStatement" ||
-        parent.type === "ForStatement") && n !== parent.body;
+         parent.type === "WhileStatement" ||
+         parent.type === "DoStatement" ||
+         parent.type === "ForStatement") && n !== parent.body
+      ) {
+        return group(concat(parts));
+      }
 
       const rest = concat(parts.slice(1));
 
@@ -184,7 +188,7 @@ function genericPrintNoParens(path, options, print) {
           // level. The first item is guaranteed to be the first
           // left-most expression.
           parts.length > 0 ? parts[0] : "",
-          shouldNotIndent ? rest : indent(options.tabWidth, rest)
+          indent(options.tabWidth, rest)
         ])
       );
     }
@@ -2516,7 +2520,7 @@ function printBinaryishExpressions(path, parts, print, options, isNested) {
     // print them normally.
     if (
       util.getPrecedence(node.left.operator) ===
-        util.getPrecedence(node.operator)
+      util.getPrecedence(node.operator)
     ) {
       // Flatten them out by recursively calling this function. The
       // printed values will all be appended to `parts`.

--- a/tests/while/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/while/__snapshots__/jsfmt.spec.js.snap
@@ -4,16 +4,16 @@ while (someVeryLongStringA && someVeryLongStringB && someVeryLongStringC && some
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 if (
   someVeryLongStringA &&
-    someVeryLongStringB &&
-    someVeryLongStringC &&
-    someVeryLongStringD
+  someVeryLongStringB &&
+  someVeryLongStringC &&
+  someVeryLongStringD
 ) {
 }
 while (
   someVeryLongStringA &&
-    someVeryLongStringB &&
-    someVeryLongStringC &&
-    someVeryLongStringD
+  someVeryLongStringB &&
+  someVeryLongStringC &&
+  someVeryLongStringD
 ) {
 }
 "


### PR DESCRIPTION
The reason why the indent has been added is to support the

```js
var x = a ||
  b;
```

use case where we need a level of indentation. But inside of a `if` it just looks strange

```js
if (
  a ||
    b
) {
```

because the parent already indented the first line.

Fixes #567