### PR TITLE
Fix trailing commas with a trailing comment

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -427,7 +427,7 @@ function printTrailingComment(commentPath, print, options, parentNode) {
       comment
     );
 
-    return concat([hardline, isLineBeforeEmpty ? hardline : "", contents]);
+    return lineSuffix(concat([hardline, isLineBeforeEmpty ? hardline : "", contents]));
   } else if (isBlock) {
     // Trailing block comments never need a newline
     return concat([" ", contents]);

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -63,11 +63,7 @@ function ifBreak(breakContents, flatContents) {
 }
 
 function lineSuffix(contents) {
-  if (typeof contents !== "string") {
-    throw new Error(
-      "lineSuffix only takes a string, but given: " + JSON.stringify(contents)
-    );
-  }
+  assertDoc(contents);
   return { type: "line-suffix", contents };
 }
 

--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -87,7 +87,7 @@ function printDocToString(doc, width, newLine) {
   let cmds = [[0, MODE_BREAK, doc]];
   let out = [];
   let shouldRemeasure = false;
-  let lineSuffix = "";
+  let lineSuffix = [];
 
   while (cmds.length !== 0) {
     const x = cmds.pop();
@@ -190,7 +190,7 @@ function printDocToString(doc, width, newLine) {
 
           break;
         case "line-suffix":
-          lineSuffix += doc.contents;
+          lineSuffix.push([ind, mode, doc.contents]);
           break;
         case "line":
           switch (mode) {
@@ -215,8 +215,15 @@ function printDocToString(doc, width, newLine) {
               }
 
             case MODE_BREAK:
+              if (lineSuffix.length) {
+                cmds.push([ind, mode, doc]);
+                [].push.apply(cmds, lineSuffix.reverse());
+                lineSuffix = [];
+                break;
+              }
+
               if (doc.literal) {
-                out.push(lineSuffix + newLine);
+                out.push(newLine);
                 pos = 0;
               } else {
                 if (out.length > 0) {
@@ -227,11 +234,9 @@ function printDocToString(doc, width, newLine) {
                   );
                 }
 
-                out.push(lineSuffix + newLine + " ".repeat(ind));
+                out.push(newLine + " ".repeat(ind));
                 pos = ind;
               }
-
-              lineSuffix = "";
               break;
           }
           break;

--- a/tests/trailing_comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/trailing_comma/__snapshots__/jsfmt.spec.js.snap
@@ -153,3 +153,153 @@ const aLong = {
 };
 "
 `;
+
+exports[`test trailing_whitespace.js 1`] = `
+"let example = [
+  \'FOO\',
+  \'BAR\',
+  // Comment
+];
+
+foo({},
+  // Comment
+);
+
+o = {
+  state,
+  // Comment
+};
+
+o = {
+  state,
+
+  // Comment
+};
+
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB
+  // Comment
+) {
+  a
+}
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB,
+  // Comment
+) {
+  a
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+let example = [
+  \"FOO\",
+  \"BAR\"
+  // Comment
+];
+
+foo(
+  {}
+  // Comment
+);
+
+o = {
+  state
+  // Comment
+};
+
+o = {
+  state
+  // Comment
+};
+
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB
+) // Comment
+{
+  a;
+}
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB
+) // Comment
+{
+  a;
+}
+"
+`;
+
+exports[`test trailing_whitespace.js 2`] = `
+"let example = [
+  \'FOO\',
+  \'BAR\',
+  // Comment
+];
+
+foo({},
+  // Comment
+);
+
+o = {
+  state,
+  // Comment
+};
+
+o = {
+  state,
+
+  // Comment
+};
+
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB
+  // Comment
+) {
+  a
+}
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB,
+  // Comment
+) {
+  a
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+let example = [
+  \"FOO\",
+  \"BAR\",
+  // Comment
+];
+
+foo(
+  {},
+  // Comment
+);
+
+o = {
+  state,
+  // Comment
+};
+
+o = {
+  state,
+  // Comment
+};
+
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB,
+) // Comment
+{
+  a;
+}
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB,
+) // Comment
+{
+  a;
+}
+"
+`;

--- a/tests/trailing_comma/trailing_whitespace.js
+++ b/tests/trailing_comma/trailing_whitespace.js
@@ -1,0 +1,35 @@
+let example = [
+  'FOO',
+  'BAR',
+  // Comment
+];
+
+foo({},
+  // Comment
+);
+
+o = {
+  state,
+  // Comment
+};
+
+o = {
+  state,
+
+  // Comment
+};
+
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB
+  // Comment
+) {
+  a
+}
+function supersupersupersuperLongF(
+  supersupersupersuperLongA,
+  supersupersupersuperLongB,
+  // Comment
+) {
+  a
+}


### PR DESCRIPTION
The reason why trailing comments on a line work with commas is because of a special `lineSuffix` document that delays printing the content until a \n is printed. But `lineSuffix` only worked for pure string. By making it work with arbitrary documents we can fix trailing commas with trailing comments.

Fixes #538