### PR TITLE
[RFC] Preserve new lines next to a + where either side is a string

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -125,6 +125,7 @@ function skip(chars) {
 const skipWhitespace = skip(/\s/);
 const skipSpaces = skip(" \t");
 const skipToLineEnd = skip(",; \t");
+const skipPlus = skip("+ \t");
 const skipEverythingButNewLine = skip(/[^\r\n]/);
 
 function skipInlineComment(text, index) {
@@ -306,6 +307,7 @@ module.exports = {
   skipWhitespace,
   skipSpaces,
   skipNewline,
+  skipPlus,
   isNextLineEmpty,
   isPreviousLineEmpty,
   hasNewline,

--- a/tests/string_concat/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/string_concat/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,58 @@
+exports[`test string_concat.js 1`] = `
+"var fnString =
+  \'\"\' + this.USE + \' \' + this.STRICT + \'\";\\n\' +
+  this.filterPrefix() +
+  \'var fn=\' + this.generateFunction(\'fn\', \'s,l,a,i\') +
+  extra +
+  this.watchFns() +
+  \'return fn;\';
+
+console.error(
+  \'In order to use \' + prompt + \', you need to configure a \' +
+  \'few environment variables to be able to commit to the \' +
+  \'repository. Follow those steps to get you setup:\\n\' +
+  \'\\n\' +
+  \'Go to https://github.com/settings/tokens/new\\n\' +
+  \' - Fill \"Token description\" with \"\' + prompt + \' for \' +
+    repoSlug + \'\"\\n\' +
+  \' - Check \"public_repo\"\\n\' +
+  \' - Press \"Generate Token\"\\n\' +
+  \'\\n\' +
+  \'In a different tab, go to https://travis-ci.org/\' +
+    repoSlug + \'/settings\\n\' +
+  \' - Make sure \"Build only if .travis.yml is present\" is ON\\n\' +
+  \' - Fill \"Name\" with \"GITHUB_USER\" and \"Value\" with the name of the \' +
+    \'account you generated the token with. Press \"Add\"\\n\' +
+  \'\\n\' +
+  \'Once this is done, commit anything to the repository to restart \' +
+    \'Travis and it should work :)\'
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var fnString = \'\"\' + this.USE + \" \" + this.STRICT + \'\";\\n\' +
+  this.filterPrefix() +
+  \"var fn=\" + this.generateFunction(\"fn\", \"s,l,a,i\") +
+  extra + this.watchFns() +
+  \"return fn;\";
+
+console.error(
+  \"In order to use \" + prompt + \", you need to configure a \" +
+    \"few environment variables to be able to commit to the \" +
+    \"repository. Follow those steps to get you setup:\\n\" +
+    \"\\n\" +
+    \"Go to https://github.com/settings/tokens/new\\n\" +
+    \' - Fill \"Token description\" with \"\' + prompt + \" for \" +
+    repoSlug + \'\"\\n\' +
+    \' - Check \"public_repo\"\\n\' +
+    \' - Press \"Generate Token\"\\n\' +
+    \"\\n\" +
+    \"In a different tab, go to https://travis-ci.org/\" +
+    repoSlug + \"/settings\\n\" +
+    \' - Make sure \"Build only if .travis.yml is present\" is ON\\n\' +
+    \' - Fill \"Name\" with \"GITHUB_USER\" and \"Value\" with the name of the \' +
+    \'account you generated the token with. Press \"Add\"\\n\' +
+    \"\\n\" +
+    \"Once this is done, commit anything to the repository to restart \" +
+    \"Travis and it should work :)\"
+);
+"
+`;

--- a/tests/string_concat/jsfmt.spec.js
+++ b/tests/string_concat/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/string_concat/string_concat.js
+++ b/tests/string_concat/string_concat.js
@@ -1,0 +1,28 @@
+var fnString =
+  '"' + this.USE + ' ' + this.STRICT + '";\n' +
+  this.filterPrefix() +
+  'var fn=' + this.generateFunction('fn', 's,l,a,i') +
+  extra +
+  this.watchFns() +
+  'return fn;';
+
+console.error(
+  'In order to use ' + prompt + ', you need to configure a ' +
+  'few environment variables to be able to commit to the ' +
+  'repository. Follow those steps to get you setup:\n' +
+  '\n' +
+  'Go to https://github.com/settings/tokens/new\n' +
+  ' - Fill "Token description" with "' + prompt + ' for ' +
+    repoSlug + '"\n' +
+  ' - Check "public_repo"\n' +
+  ' - Press "Generate Token"\n' +
+  '\n' +
+  'In a different tab, go to https://travis-ci.org/' +
+    repoSlug + '/settings\n' +
+  ' - Make sure "Build only if .travis.yml is present" is ON\n' +
+  ' - Fill "Name" with "GITHUB_USER" and "Value" with the name of the ' +
+    'account you generated the token with. Press "Add"\n' +
+  '\n' +
+  'Once this is done, commit anything to the repository to restart ' +
+    'Travis and it should work :)'
+);


### PR DESCRIPTION
Many people still use string concatenation in order to build a bigger one and new lines are usually significant. This is an attempt at solving this use case, right now we split on every single `+` which is making the string lose meaning compared to the original one.

Fixes #489