### PR TITLE
Avoid unneeded parenthesis for colon with comments

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -684,13 +684,13 @@ function genericPrintNoParens(path, options, print) {
           parts.push(concat([": ", printedValue]));
         } else {
           parts.push(
-            concat([
+            group(concat([
               ":",
               ifBreak(" (", " "),
               indent(options.tabWidth, concat([softline, printedValue])),
               softline,
               ifBreak(")")
-            ])
+            ]))
           );
         }
       }

--- a/tests/object-prop-break-in/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object-prop-break-in/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,20 @@
+exports[`test comment.js 1`] = `
+"function foo() {
+  return {
+    // this comment causes the problem
+    bar: baz() + 1
+  };
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function foo() {
+  return {
+    // this comment causes the problem
+    bar: baz() + 1
+  };
+}
+"
+`;
+
 exports[`test test.js 1`] = `
 "const a = classnames({
   \"some-prop\": this.state.longLongLongLongLongLongLongLongLongTooLongProp

--- a/tests/object-prop-break-in/comment.js
+++ b/tests/object-prop-break-in/comment.js
@@ -1,0 +1,6 @@
+function foo() {
+  return {
+    // this comment causes the problem
+    bar: baz() + 1
+  };
+}


### PR DESCRIPTION
Because the group was too high up, the comment would be taken into consideration to determine the size and it would break and add parenthesis. Adding a group where we actually want the ifBreak seems to be passing all the existing tests and fixes this edge case.

Fixes #655