### PR TITLE
Always put a hardline before dangling comment

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -10,6 +10,7 @@ var hardline = docBuilders.hardline;
 var breakParent = docBuilders.breakParent;
 var indent = docBuilders.indent;
 var lineSuffix = docBuilders.lineSuffix;
+var join = docBuilders.join;
 var util = require("./util");
 var comparePos = util.comparePos;
 var childNodesCacheKey = Symbol("child-nodes");
@@ -450,7 +451,7 @@ function printTrailingComment(commentPath, print, options, parentNode) {
   return concat([lineSuffix(" " + contents), !isBlock ? breakParent : ""]);
 }
 
-function printDanglingComments(path, options, noIndent) {
+function printDanglingComments(path, options, sameIndent) {
   const text = options.originalText;
   const parts = [];
   const node = path.getValue();
@@ -463,19 +464,20 @@ function printDanglingComments(path, options, noIndent) {
     commentPath => {
       const comment = commentPath.getValue();
       if (!comment.leading && !comment.trailing) {
-        if (util.hasNewline(text, locStart(comment), { backwards: true })) {
-          parts.push(hardline);
-        }
         parts.push(printComment(commentPath));
       }
     },
     "comments"
   );
 
-  if (!noIndent) {
-    return indent(options.tabWidth, concat(parts));
+  if (parts.length === 0) {
+    return "";
   }
-  return concat(parts);
+
+  if (sameIndent) {
+    return join(hardline, parts);
+  }
+  return indent(options.tabWidth, concat([hardline, join(hardline, parts)]));
 }
 
 function printComments(path, print, options) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -141,7 +141,7 @@ function genericPrintNoParens(path, options, print) {
       );
 
       parts.push(
-        comments.printDanglingComments(path, options, /* noIdent */ true)
+        comments.printDanglingComments(path, options, /* sameIndent */ true)
       );
 
       // Only force a trailing newline if there were any contents.
@@ -1230,7 +1230,7 @@ function genericPrintNoParens(path, options, print) {
     case "JSXText":
       throw new Error("JSXTest should be handled by JSXElement");
     case "JSXEmptyExpression":
-      return concat([comments.printDanglingComments(path, options), softline]);
+      return concat([comments.printDanglingComments(path, options, /* sameIndent */ true), softline]);
     case "TypeAnnotatedIdentifier":
       return concat([
         path.call(print, "annotation"),

--- a/tests/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/classes/__snapshots__/jsfmt.spec.js.snap
@@ -46,7 +46,8 @@ class A {
   // comment
 }
 
-class A {// comment
+class A {
+  // comment
 }
 
 class A {}

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -39,15 +39,21 @@ function x() {
 }
 declare class Foo extends Qux<string> {/* dangling */}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var x = {/* dangling */};
+var x = {
+  /* dangling */
+};
 var x = {
   // dangling
 };
-var x = [/* dangling */];
+var x = [
+  /* dangling */
+];
 function x() {
   /* dangling */
 }
-declare class Foo extends Qux<string> {/* dangling */}
+declare class Foo extends Qux<string> {
+  /* dangling */
+}
 "
 `;
 
@@ -62,15 +68,21 @@ function x() {
 }
 declare class Foo extends Qux<string> {/* dangling */}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var x = {/* dangling */};
+var x = {
+  /* dangling */
+};
 var x = {
   // dangling
 };
-var x = [/* dangling */];
+var x = [
+  /* dangling */
+];
 function x() {
   /* dangling */
 }
-declare class Foo extends Qux<string> {/* dangling */}
+declare class Foo extends Qux<string> {
+  /* dangling */
+}
 "
 `;
 
@@ -701,9 +713,7 @@ exports[`test jsx.js 1`] = `
 </div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div>
-  {
-    /* comment */
-  }
+  {/* comment */}
 </div>;
 
 <div>
@@ -779,9 +789,7 @@ exports[`test jsx.js 2`] = `
 </div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div>
-  {
-    /* comment */
-  }
+  {/* comment */}
 </div>;
 
 <div>

--- a/tests/flow/more_path/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_path/__snapshots__/jsfmt.spec.js.snap
@@ -101,7 +101,8 @@ function goofy() {
   var x = g();
   if (typeof x == \"function\") {
     x();
-  } else {// if (typeof x == \'number\') {
+  } else {
+    // if (typeof x == \'number\') {
     //f(x);
   }
 }

--- a/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
@@ -179,10 +179,12 @@ type T1 = {};
 type T2 = { x: number };
 type T3 = { x: number, y: number };
 
-class C1 extends React.Component<T1, T2, any> {// error
+class C1 extends React.Component<T1, T2, any> {
+  // error
 }
 
-class C2 extends React.Component<void, T2, any> {// OK
+class C2 extends React.Component<void, T2, any> {
+  // OK
 }
 
 // no need to add type arguments to React.Component
@@ -198,7 +200,8 @@ class C4 extends React.Component {
   props: T2;
 }
 
-class C5 extends React.Component<T2, T3, any> {// error
+class C5 extends React.Component<T2, T3, any> {
+  // error
 }
 
 class C6 extends React.Component {

--- a/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
@@ -1394,11 +1394,13 @@ let tests = [
     }
   },
   function(num: number, obj: { foo: number }) {
-    if (num === obj.bar) {// ok, typos allowed in conditionals
+    if (num === obj.bar) {
+      // ok, typos allowed in conditionals
     }
   },
   function(num: number, obj: { [key: string]: number }) {
-    if (num === obj.bar) {// ok
+    if (num === obj.bar) {
+      // ok
     }
   },
   function(n: number): Mode {
@@ -1974,11 +1976,13 @@ let tests = [
     }
   },
   function(str: string, obj: { foo: string }) {
-    if (str === obj.bar) {// ok, typos allowed in conditionals
+    if (str === obj.bar) {
+      // ok, typos allowed in conditionals
     }
   },
   function(str: string, obj: { [key: string]: string }) {
-    if (str === obj.bar) {// ok
+    if (str === obj.bar) {
+      // ok
     }
   },
   function(str: string): Mode {

--- a/tests/flow/try/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/try/__snapshots__/jsfmt.spec.js.snap
@@ -554,7 +554,8 @@ function bar(response) {
     throw new Error(\"...\");
   }
   // here via [try] only.
-  if (payload.error) {// ok
+  if (payload.error) {
+    // ok
     // ...
   }
 }


### PR DESCRIPTION
In #563 it looked odd that there was no space before `//`, it turns out that we don't automatically go to the new line for dangling comments. I think that we just should no matter what, so this is what this diff does.

Fixes #563