### PR TITLE
Print line-suffix in --debug-print-doc

### DIFF
--- a/src/doc-debug.js
+++ b/src/doc-debug.js
@@ -92,6 +92,12 @@ function printDoc(doc) {
       printDoc(doc.contents) +
       ")";
   }
+
+  if (doc.type === "line-suffix") {
+    return "lineSuffix(" + printDoc(doc.contents) + ")";
+  }
+
+  throw new Error('Unknown doc type ' + doc.type);
 }
 
 module.exports = {


### PR DESCRIPTION
I was trying to debug #620 and got confused that it didn't show `//comment1`. Turns out we just fail silently if we can't print a node type. I added support for `line-suffix` and throw if we encounter a node type that we can't print.