### PR TITLE
Fix comments in return statement argument

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -561,7 +561,18 @@ function genericPrintNoParens(path, options, print) {
     case "ReturnStatement":
       parts.push("return");
 
-      if (n.argument) {
+      if (n.argument &&
+          n.argument.comments &&
+          n.argument.comments.some(comment => comment.leading)) {
+        parts.push(
+          concat([
+            ' (',
+            indent(options.tabWidth, concat([softline, path.call(print, "argument")])),
+            line,
+            ')'
+          ])
+        );
+      } else if (n.argument) {
         parts.push(" ", path.call(print, "argument"));
       }
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -864,6 +864,84 @@ function name() {
 "
 `;
 
+exports[`test return-statement.js 1`] = `
+"function a() {
+  return (
+    // Comment
+    <div />
+  );
+}
+
+function b() {
+  return (
+    // Comment
+    !!x
+  );
+}
+
+function c() {
+  return 1337; // Comment
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function a() {
+  return (
+    /* Comment*/
+    <div />
+  );
+}
+
+function b() {
+  return (
+    // Comment
+    !!x
+  );
+}
+
+function c() {
+  return 1337; // Comment
+}
+"
+`;
+
+exports[`test return-statement.js 2`] = `
+"function a() {
+  return (
+    // Comment
+    <div />
+  );
+}
+
+function b() {
+  return (
+    // Comment
+    !!x
+  );
+}
+
+function c() {
+  return 1337; // Comment
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function a() {
+  return (
+    // Comment
+    <div />
+  );
+}
+
+function b() {
+  return (
+    // Comment
+    !!x
+  );
+}
+
+function c() {
+  return 1337; // Comment
+}
+"
+`;
+
 exports[`test try.js 1`] = `
 "// comment 1
 try {

--- a/tests/comments/return-statement.js
+++ b/tests/comments/return-statement.js
@@ -1,0 +1,17 @@
+function a() {
+  return (
+    // Comment
+    <div />
+  );
+}
+
+function b() {
+  return (
+    // Comment
+    !!x
+  );
+}
+
+function c() {
+  return 1337; // Comment
+}

--- a/tests/flow/generics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/generics/__snapshots__/jsfmt.spec.js.snap
@@ -72,7 +72,9 @@ class E<X> extends C<X> {
   //x:X;
   set(x: X): X {
     /*return x;*/ this.x = x;
-    return /*this.x; */ this.get();
+    return (
+      /*this.x; */ this.get()
+    );
   }
 }
 


### PR DESCRIPTION
I couldn't figure out how to add a commit to #657 so creating another pull request for it. I think that we can just check if there's a leading comment and if that's the case then put parenthesis. This should work better than checking the source location.

Fixes #611 
