### PR TITLE
[RFC] Remove parenthesis object special case

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -703,21 +703,7 @@ function genericPrintNoParens(path, options, print) {
         } else {
           parts.push(printPropertyKey(path, options, print));
         }
-
-        let printedValue = path.call(print, "value");
-        if (shouldPrintSameLine(n.value)) {
-          parts.push(concat([": ", printedValue]));
-        } else {
-          parts.push(
-            group(concat([
-              ":",
-              ifBreak(" (", " "),
-              indent(options.tabWidth, concat([softline, printedValue])),
-              softline,
-              ifBreak(")")
-            ]))
-          );
-        }
+        parts.push(concat([": ", path.call(print, "value")]));
       }
 
       return concat(parts); // Babel 6
@@ -2780,28 +2766,6 @@ function isObjectTypePropertyAFunction(node) {
     node.value.type === "FunctionTypeAnnotation" &&
     !node.static &&
     util.locStart(node.key) !== util.locStart(node.value);
-}
-
-function shouldPrintSameLine(node) {
-  const type = node.type;
-  return namedTypes.Literal.check(node) ||
-    type === "ArrayExpression" ||
-    type === "ArrayPattern" ||
-    type === "ArrowFunctionExpression" ||
-    type === "AssignmentPattern" ||
-    type === "CallExpression" ||
-    type === "FunctionExpression" ||
-    type === "Identifier" ||
-    type === "JSXElement" ||
-    type === "Literal" ||
-    type === "MemberExpression" ||
-    type === "NewExpression" ||
-    type === "ObjectExpression" ||
-    type === "ObjectPattern" ||
-    type === "StringLiteral" ||
-    type === "ThisExpression" ||
-    type === "TypeCastExpression" ||
-    type === "UnaryExpression";
 }
 
 function isFlowNodeStartingWithDeclare(node, options) {

--- a/tests/object-prop-break-in/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object-prop-break-in/__snapshots__/jsfmt.spec.js.snap
@@ -49,9 +49,8 @@ const a = classnames({
 });
 
 const b = classnames({
-  \"some-prop\": (
-    this.state.longLongLongLongLongLongLongLongLongTooLongProp === true
-  )
+  \"some-prop\": this.state.longLongLongLongLongLongLongLongLongTooLongProp ===
+    true
 });
 
 const c = classnames({
@@ -71,9 +70,8 @@ const f = classnames({
 });
 
 const g = classnames({
-  \"some-prop\": (
-    longLongLongLongLongLongLongLongLongLongLongLongLongTooLongVar || 1337
-  )
+  \"some-prop\": longLongLongLongLongLongLongLongLongLongLongLongLongTooLongVar ||
+    1337
 });
 "
 `;

--- a/tests/object_colon_bug/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object_colon_bug/__snapshots__/jsfmt.spec.js.snap
@@ -5,9 +5,9 @@ exports[`test bug.js 1`] = `
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const foo = {
-  bar: (
-    props.bar ? props.bar : noop
-  ),
+  bar: props.bar
+    ? props.bar
+    : noop,
   baz: props.baz
 };
 "


### PR DESCRIPTION
I've started the discussion around it but I think that it was a mistake. It feels weird to add parenthesis on object values sometimes but not others. I think that it's best to let prettier do its work on staying under 80 columns based on the rules we added.