### PR TITLE
[JSX] Don't add newline following newline

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2381,7 +2381,9 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
             }
           });
 
-          children.push(softline);
+          if (!isLineNext(util.getLast(children))) {
+            children.push(softline);
+          }
         } else if (/\n/.test(value)) {
           children.push(hardline);
 

--- a/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
@@ -81,6 +81,18 @@ regression_extra_newline = (
     New Messages
   </div>
 );
+
+
+regression_extra_newline_2 = (
+  <div>
+    (
+    <FormattedMessage
+      id=\"some-id\"
+      defaultMessage=\"some loooooooooooooooooooooooooooong default\"
+    />
+    )
+  </div>
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 keep = (
   <p>
@@ -158,6 +170,17 @@ regression_extra_newline = (
   <div>
     <span className=\"nuclide-console-new-messages-notification-icon icon icon-nuclicon-arrow-down\" />
     New Messages
+  </div>
+);
+
+regression_extra_newline_2 = (
+  <div>
+    (
+    <FormattedMessage
+      id=\"some-id\"
+      defaultMessage=\"some loooooooooooooooooooooooooooong default\"
+    />
+    )
   </div>
 );
 "

--- a/tests/jsx-newlines/test.js
+++ b/tests/jsx-newlines/test.js
@@ -80,3 +80,15 @@ regression_extra_newline = (
     New Messages
   </div>
 );
+
+
+regression_extra_newline_2 = (
+  <div>
+    (
+    <FormattedMessage
+      id="some-id"
+      defaultMessage="some loooooooooooooooooooooooooooong default"
+    />
+    )
+  </div>
+);


### PR DESCRIPTION
Fixes https://github.com/jlongster/prettier/issues/686

Was adding a `softline` for this case: `some text<span />` but shouldn't have been in this case: `some text\n<span />`. Now only adds the softline when necessary. 