### PR TITLE
Do not inline new as last argument

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1828,8 +1828,7 @@ function printArgumentsList(path, options, print) {
           lastArg.body.type === "ObjectExpression" ||
           lastArg.body.type === "ArrayExpression" ||
           lastArg.body.type === "CallExpression" ||
-          lastArg.body.type === "JSXElement") ||
-      lastArg.type === "NewExpression");
+          lastArg.body.type === "JSXElement"));
 
   if (groupLastArg) {
     const shouldBreak = printed.slice(0, -1).some(willBreak);

--- a/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
@@ -376,9 +376,11 @@ new Promise((resolve, reject) => resolve(0)).then(function(num) {
 
 // Promise constructor resolve(Promise<T>) -> then(T)
 new Promise(function(resolve, reject) {
-  resolve(new Promise(function(resolve, reject) {
-    resolve(0);
-  }));
+  resolve(
+    new Promise(function(resolve, reject) {
+      resolve(0);
+    })
+  );
 }).then(function(num) {
   var a: number = num;
   var b: string = num; // Error: number ~> string
@@ -386,11 +388,15 @@ new Promise(function(resolve, reject) {
 
 // Promise constructor resolve(Promise<Promise<T>>) -> then(T)
 new Promise(function(resolve, reject) {
-  resolve(new Promise(function(resolve, reject) {
-    resolve(new Promise(function(resolve, reject) {
-      resolve(0);
-    }));
-  }));
+  resolve(
+    new Promise(function(resolve, reject) {
+      resolve(
+        new Promise(function(resolve, reject) {
+          resolve(0);
+        })
+      );
+    })
+  );
 }).then(function(num) {
   var a: number = num;
   var b: string = num; // Error: number ~> string
@@ -428,9 +434,11 @@ new Promise(function(resolve, reject) {
 
 // TODO: Promise constructor reject(Promise<T>) ~> catch(Promise<T>)
 new Promise(function(resolve, reject) {
-  reject(new Promise(function(resolve, reject) {
-    reject(0);
-  }));
+  reject(
+    new Promise(function(resolve, reject) {
+      reject(0);
+    })
+  );
 }).catch(function(num) {
   var a: Promise<number> = num;
 


### PR DESCRIPTION
We inline function definitions but we shouldn't inline new expressions,

https://github.com/jlongster/prettier/commit/835befebf53da9f4a8a1e447cb33f1087e862ea3 introduced both call expressions and new expressions. Call expressions have been removed but looks like new haven't.