### PR TITLE
docs: Add pre-commit hook with 🚫💩 lint-staged section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,34 @@ prettier --write 'src/**/*.js' 'bin/*.js'
 
 In the future we will have better support for formatting whole projects.
 
+#### Pre-commit hook for changed files
+
+[🚫💩 lint-staged](https://github.com/okonet/lint-staged) can re-format your files that are marked as "staged" via `git add`  before you commit.
+
+Install it along with [pre-commit](https://github.com/observing/pre-commit) (or [husky](https://github.com/typicode/husky)):
+
+```bash
+npm install --save-dev lint-staged pre-commit
+```
+
+and add this config to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint:staged": "lint-staged"
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "pre-commit": "lint:staged"
+}
+```
+
+
 ### API
 
 The API is a single function exported as `format`. The options
@@ -202,7 +230,7 @@ Can also be installed using `ext install prettier-vscode`
 
 ### Sublime Text
 
-Sublime Text support is available through Package Control and 
+Sublime Text support is available through Package Control and
 the [JsPrettier](https://packagecontrol.io/packages/JsPrettier) plug-in.
 
 ### JetBrains


### PR DESCRIPTION
As discussed on twitter: https://twitter.com/dan_abramov/status/831616492068290561