### PR TITLE
[RFC] Do not format template literals

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1317,32 +1317,15 @@ function genericPrintNoParens(path, options, print) {
     case "ClassExpression":
       return concat(printClass(path, options, print));
     case "TemplateElement":
-      return join(literalline, n.value.raw.split("\n"));
     case "TemplateLiteral":
-      var expressions = path.map(print, "expressions");
-
-      parts.push("`");
-
-      path.each(
-        function(childPath) {
-          var i = childPath.getName();
-
-          parts.push(print(childPath));
-
-          if (i < expressions.length) {
-            parts.push("${", expressions[i], "}");
-          }
-        },
-        "quasis"
+      return options.originalText.slice(
+        util.locStart(n),
+        util.locEnd(n)
       );
-
-      parts.push("`");
-
-      return concat(parts);
-    // These types are unprintable because they serve as abstract
-    // supertypes for other (printable) types.
     case "TaggedTemplateExpression":
       return concat([path.call(print, "tag"), path.call(print, "quasi")]);
+    // These types are unprintable because they serve as abstract
+    // supertypes for other (printable) types.
     case "Node":
     case "Printable":
     case "SourceLocation":

--- a/tests/flow/require/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/require/__snapshots__/jsfmt.spec.js.snap
@@ -165,7 +165,7 @@ E.stringValue; // Error: The E exports obj has no \'stringValue\' property
 var a = \"./E\";
 require(a); // Error: Param must be string literal
 require(\`./E\`); // template literals are ok...
-require(\`\${\"./E\"}\`); // error: but only if they have no expressions
+require(\`\${\'./E\'}\`); // error: but only if they have no expressions
 
 // require.call is allowed but circumverts Flow\'s static analysis
 require.call(null, \"DoesNotExist\");

--- a/tests/flow/template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/template/__snapshots__/jsfmt.spec.js.snap
@@ -38,28 +38,28 @@ let tests = [
 (\`baz\`: number); // error
 
 \`foo \${123} bar\`; // ok, number can be appended to string
-\`foo \${{ bar: 123 }} baz\`; // error, object can\'t be appended
+\`foo \${{bar: 123}} baz\`; // error, object can\'t be appended
 
 let tests = [
   function(x: string) {
     \`foo \${x}\`; // ok
     \`\${x} bar\`; // ok
-    \`foo \${\"bar\"} \${x}\`; // ok
+    \`foo \${\'bar\'} \${x}\`; // ok
   },
   function(x: number) {
     \`foo \${x}\`; // ok
     \`\${x} bar\`; // ok
-    \`foo \${\"bar\"} \${x}\`; // ok
+    \`foo \${\'bar\'} \${x}\`; // ok
   },
   function(x: boolean) {
     \`foo \${x}\`; // error
     \`\${x} bar\`; // error
-    \`foo \${\"bar\"} \${x}\`; // error
+    \`foo \${\'bar\'} \${x}\`; // error
   },
   function(x: mixed) {
     \`foo \${x}\`; // error
     \`\${x} bar\`; // error
-    \`foo \${\"bar\"} \${x}\`; // error
+    \`foo \${\'bar\'} \${x}\`; // error
   }
 ];
 "

--- a/tests/trailing_whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/trailing_whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -18,8 +18,7 @@ export type Result<T, V> =
 \`
    
    
-\` +
-  \`
+\` + \`
     
     
 \`;


### PR DESCRIPTION
We have a lot of issues with template literals that are improperly indented with prettier and shouldn't be. Maybe the best solution for this is to actually just give up and reprint it exactly the way the user entered it. I'm not super happy about this but well, it's worth a shot.