### PR TITLE
Remove extra parenthesis around await inside of unary expression

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -354,12 +354,14 @@ FPp.needsParens = function(assumeExpressionContext) {
       }
 
     case "YieldExpression":
+      if (parent.type === "UnaryExpression") {
+        return true;
+      }
     case "AwaitExpression":
       switch (parent.type) {
         case "TaggedTemplateExpression":
         case "BinaryExpression":
         case "LogicalExpression":
-        case "UnaryExpression":
         case "SpreadElement":
         case "SpreadProperty":
         case "NewExpression":

--- a/tests/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/async/__snapshots__/jsfmt.spec.js.snap
@@ -4,12 +4,25 @@ async function g() {
   invariant(
     (await driver.navigator.getUrl()).substr(-7)
   );
-}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+function *f(){
+  !(yield a);
+}
+async function f() {
+  a = !(await f());
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 async function f() {
   (await f()).length;
 }
 async function g() {
   invariant((await driver.navigator.getUrl()).substr(-7));
+}
+function* f() {
+  !(yield a);
+}
+async function f() {
+  a = !await f();
 }
 "
 `;

--- a/tests/async/await_parse.js
+++ b/tests/async/await_parse.js
@@ -4,3 +4,9 @@ async function g() {
     (await driver.navigator.getUrl()).substr(-7)
   );
 }
+function *f(){
+  !(yield a);
+}
+async function f() {
+  a = !(await f());
+}


### PR DESCRIPTION
Big props to @bakkot for mentioning that yield shouldn't be applied the same treatment.

Fixes #728